### PR TITLE
Docs: 2026–2027 roadmap + agent pipeline memory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,38 @@ Ops UI: `/ops` (admin UI loaded only after server-side admin token check)
 
 When adding features: **deny by default**, enable via admin feature flags or env after review.
 
+## Development pipeline (mandatory)
+
+```text
+feature branch → PR → CI tests green → merge main/master
+  → CI builds Linux/Windows binaries (sc5, squidc5)
+  → prod deploy = Linux squidc5 binary ONLY (keep data/)
+```
+
+- **Never** rsync WIP source or `docker compose up --build` to prod
+- **Never** deploy a feature-branch-only binary
+- Docker is for **local/lab** only once binary prod path is active
+- Full policy: see **Production deploy policy** under Deployment Knowledge
+
+## Roadmap 2026–2027 (next work — prioritized)
+
+Full detail: `docs/roadmap-2026-2027.md`. Agents plan work against this list; stay OPSEC-first, agents-on-rails.
+
+| # | Focus | Notes |
+|---|--------|--------|
+| **1** | **Malleable / adaptive C2 profiles** | **TOP PRIORITY** — HTTP/S, DNS, WS; jitter; decoy; runtime switch |
+| 2 | Advanced implant / beacon framework | Stagers, injection, memory-only, BOF-like; Win/Linux/macOS |
+| 3 | Evasion & anti-analysis | Sandbox/VM/debugger resistance; fronting/CDN; QUIC/WebTransport candidates |
+| 4 | Multi-operator collaboration | Teams, chat, handoff, spectator; per-operator audit |
+| 5 | Deeper AI (railed) | Policy-limited chaining; local LLM; beacon anomaly suggestions |
+| 6 | Plugin / extension system | Signed plugins; allow-list; ops discovery |
+| 7 | Observability / forensics dashboard | Timeline, ATT&CK map, reports, heatmap |
+| 8 | Deploy & OpSec hardening | Nix/microVM/K8s; redirectors; cert/domain rotation |
+| 9 | Testing & validation suite | Lab victims; evasion benchmarks; playbook scenarios |
+| 10 | Community & docs | Runbook, threat model, disclosure, OPSEC changelogs |
+
+**When implementing any roadmap item:** small PRs, tests required, secure defaults, no weakening of MCP/Admin AI/public_docs locks, prod only via main CI binary.
+
 ## Architecture Map
 
 ```
@@ -305,8 +337,9 @@ docker exec squidc5 cat /data/admin_token.txt
 | `AGENTS.md` | **This file** — primary agent operating memory |
 | `CLAUDE.md` | Pointer to AGENTS + docs |
 | `docs/squidc5-vision.md` | Full product vision / security architecture |
+| `docs/roadmap-2026-2027.md` | Prioritized next-gen roadmap (10 focus areas) |
 | `docs/operator-runbook.md` | Operator procedures |
-| `docs/deployment.md` | Docker / droplet deployment |
+| `docs/deployment.md` | Binary prod deploy + lab Docker |
 | `README.md` | Public-facing quickstart |
 | `SECURITY.md` | Disclosure policy |
 | `.gitignore` | Blocks secrets, data, local config |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ Follow **AGENTS.md** as the primary agent memory for this repository.
 Also read:
 
 - `docs/squidc5-vision.md` — product/security architecture
+- `docs/roadmap-2026-2027.md` — 2026–2027 prioritized roadmap (start with malleable C2 profiles)
 - `docs/operator-runbook.md` — operator CLI & reverse-shell procedures
 - `docs/deployment.md` — Docker / droplet deployment
 

--- a/docs/roadmap-2026-2027.md
+++ b/docs/roadmap-2026-2027.md
@@ -1,0 +1,90 @@
+# SquidC5 Roadmap — 2026–2027
+
+**Goal:** Best open-source military-grade, next-gen C2 for **authorized** red team operations.
+
+**Philosophy (non-negotiable):** secure by default · agents on rails · audit everything · OPSEC first · operator ergonomics · AI leverage without open-ended autonomy.
+
+**Delivery pipeline (prod):**
+
+```text
+PR → CI tests green → merge main → CI builds binaries → deploy Linux squidc5 binary only
+```
+
+Never deploy WIP source or Docker rebuilds to production.
+
+---
+
+## Priority focus areas
+
+### 1. Malleable / Adaptive C2 Profiles — **TOP PRIORITY**
+
+- Full malleable HTTP/S, DNS, and WebSocket profiles (CS-inspired; AI-generated variations allowed only via allow-listed generators)
+- Runtime profile switching, jitter, decoy traffic
+- **Impact:** traffic blends with legitimate apps; major detection resistance
+
+### 2. Advanced Implant / Beacon Framework
+
+- Beyond reverse shells: staged loaders, process injection (syscalls, APC, …), memory-only execution, BOF-like modules
+- Cross-platform (Windows / Linux / macOS), architecture-aware payloads
+- Admin AI assist: mutate implant templates from target fingerprinting (templates + sanitize; no free-form agent loops for external MCP)
+
+### 3. Evasion & Anti-Analysis Layer
+
+- Sandbox / VM / debugger resistance, sleep obfuscation in implants
+- Domain fronting, CDN proxying, encrypted channels (QUIC / WebTransport candidates)
+- Admin AI: real-time evasion **suggestions** (operator-approved; audited)
+
+### 4. Multi-Operator & Collaboration
+
+- Role-based teams, shared sessions, real-time operator chat, per-operator audit
+- Session handoff + spectator mode
+- **Impact:** true team red-team tool without weakening scopes or audit
+
+### 5. Deeper AI Integration (next-gen edge)
+
+- Admin AI task chaining under **policy rails** (HITL thresholds, max steps, capability allow-list)
+- Local LLM (Ollama / GGUF) for air-gapped ops
+- Anomaly detection on beacon behavior + remediation **suggestions**
+
+### 6. Modular Plugin / Extension System
+
+- Official plugin API (cred dump, lateral movement, exfil modules — authorized use only)
+- Signed plugins + allow-list enforcement
+- Ops-console discovery (marketplace-style, still deny-by-default)
+
+### 7. Observability & Forensics Dashboard
+
+- Timeline, behavioral graphs, MITRE ATT&CK mapping
+- Exportable operator reports (Grok-powered summaries when LLM configured)
+- Real-time heatmap of compromised assets
+
+### 8. Deployment & OpSec Hardening
+
+- One-click Nix / microVM / Kubernetes with network isolation
+- Built-in redirector / proxy tier
+- Certificate + domain rotation helpers
+- Prod remains **binary-only** from main CI
+
+### 9. Testing & Validation Suite
+
+- Auto test victims, evasion benchmarks (lab-safe)
+- CI with controlled EDR/AV bypass checks (isolated; never against unauthorized targets)
+- Public “SquidC5 Red Team Playbook” scenarios (authorized only)
+
+### 10. Community & Documentation
+
+- Operator runbook, threat model, security audit results
+- Discord / Matrix + responsible disclosure / bug bounty
+- Regular releases; changelog highlights OPSEC improvements
+
+---
+
+## Implementation rules for agents
+
+1. One focus area (or thin vertical slice) per PR when possible.
+2. Every feature ships with **tests** (auth, policy, privacy, feature flags as applicable).
+3. New surface area is **deny-by-default** (feature flags / scopes).
+4. AI stays sandboxed: `sanitize_untrusted`, capability allow-lists, no raw session dump into prompts.
+5. External MCP never gains open-ended autonomous loops.
+6. Prod deploy only after merge + main CI binary artifact.
+7. Prefer determinism (profiles, templates, fixed chains) over free-form agent planning.

--- a/docs/squidc5-vision.md
+++ b/docs/squidc5-vision.md
@@ -2,8 +2,8 @@
 
 **Version:** 0.1.0  
 **Status:** Active development — **military-grade, security-first C2**  
-**Purpose:** Authorized penetration testing, red team, and defensive security operations only
-
+**Purpose:** Authorized penetration testing, red team, and defensive security operations only  
+**Roadmap:** See `docs/roadmap-2026-2027.md` (malleable profiles → implants → evasion → multi-op → AI → plugins → observability → deploy → testing → community)
 ## Overview
 
 SquidC5 is a professional, lightweight, **military-grade**, security-first, AI-native Command & Control framework under active development. It is designed open-source-ready from the first commit, with strong emphasis on **secure defaults**, AI restriction, determinism, auditability, and low resource usage.


### PR DESCRIPTION
## Summary
- Adds `docs/roadmap-2026-2027.md` with the 10 high-impact focus areas (OPSEC / ergonomics / AI-on-rails)
- Wires roadmap + mandatory PR→binary prod pipeline into `AGENTS.md` / `CLAUDE.md` / vision

## Test plan
- [x] Docs only — no runtime change
- [ ] CI green