### PR TITLE
Next-gen foundation: malleable profiles + roadmap modules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,12 +50,30 @@ When adding features: **deny by default**, enable via admin feature flags or env
 
 ## Development pipeline (mandatory)
 
+Source of truth also: Windows SquidSec workspace  
+`/mnt/c/Users/ynot_/OneDrive/Desktop/Company Data/SquidSec/AGENTS.md` + `knowledge-base/MEMORY.md`  
+→ **Development cycles (git repos)**.
+
+### Git cycle (every change)
+
+1. **Update main/master** — pull latest  
+2. **Feature branch** — name for the change  
+3. **Unit tests first** — describe expected behavior  
+4. **Implement** code  
+5. **Red-green-refactor** — all tests pass; clean up  
+6. **Push branch** (never direct to main)  
+7. **Open PR**  
+8. **Wait for CI** — do not merge red  
+9. **Merge** when green  
+10. **Next change** — back to step 1  
+
+### Prod after merge
+
 ```text
-feature branch → PR → CI tests green → merge main/master
-  → CI builds Linux/Windows binaries (sc5, squidc5)
-  → prod deploy = Linux squidc5 binary ONLY (keep data/)
+merge main → CI builds Linux/Windows binaries → deploy Linux squidc5 binary ONLY
 ```
 
+- **Never** commit/push straight to `main`/`master`
 - **Never** rsync WIP source or `docker compose up --build` to prod
 - **Never** deploy a feature-branch-only binary
 - Docker is for **local/lab** only once binary prod path is active

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -1,0 +1,31 @@
+# SquidC5 threat model (authorized lab / red team)
+
+## Assets
+
+- Operator tokens and admin bootstrap token
+- Session/shell channels and task results
+- LLM API keys (server-side only)
+- C2 profile configuration
+- Audit log integrity
+
+## Adversaries
+
+- Internet scanners and credential stuffing against the API
+- Stolen operator tokens
+- Malicious external MCP clients
+- Prompt injection via implant/session output into Admin AI
+
+## Controls
+
+- Scoped tokens; no public OpenAPI
+- MCP off by default; per-token tool allow-list
+- Admin AI: sanitize_untrusted + capability allow-list
+- Feature flags; public_docs hard-locked off
+- Security headers; no wildcard CORS
+- Shell false-positive filter + exec probe
+- Plugins deny-by-default + HMAC signature
+- Prod binary-only deploy after green CI
+
+## Out of scope
+
+Unauthorized access to third-party systems. Operators must have authorization.

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -91,6 +91,34 @@ class FeaturesUpdate(BaseModel):
     features: dict[str, bool]
 
 
+class ProfileShapeRequest(BaseModel):
+    profile_id: str | None = None
+    beacon: dict[str, Any] = Field(default_factory=dict)
+
+
+class ImplantPlanRequest(BaseModel):
+    family: str = "http_beacon"
+    platform: str = "linux"
+    arch: str = "x64"
+    host: str | None = None
+    port: int | None = None
+
+
+class TeamCreate(BaseModel):
+    name: str
+
+
+class HandoffRequest(BaseModel):
+    to: str
+    note: str = ""
+
+
+class PluginRegister(BaseModel):
+    manifest: dict[str, Any]
+    signature: str
+    enable: bool = False
+
+
 def build_api_router() -> APIRouter:
     api = APIRouter(prefix="/api/v1")
 
@@ -689,6 +717,221 @@ def build_api_router() -> APIRouter:
             raise HTTPException(400, str(e)) from e
         except Exception as e:
             raise HTTPException(502, f"Admin AI error: {e}") from e
+
+    # ----- Malleable C2 profiles -----
+
+    @api.get("/profiles")
+    async def list_profiles(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("profiles:read", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not await state.features.enabled("malleable_profiles"):
+            raise HTTPException(403, "Malleable profiles disabled by feature flag")
+        active = state.profiles.active()
+        return {
+            "profiles": state.profiles.list_profiles(),
+            "active_id": active.id if active else None,
+        }
+
+    @api.get("/profiles/active")
+    async def get_active_profile(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("profiles:read", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        p = state.profiles.active()
+        if not p:
+            raise HTTPException(404, "no active profile")
+        return p.to_dict()
+
+    @api.post("/profiles/{profile_id}/activate")
+    async def activate_profile(
+        profile_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("profiles:write", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not await state.features.enabled("malleable_profiles"):
+            raise HTTPException(403, "Malleable profiles disabled by feature flag")
+        try:
+            p = await state.profiles.set_active(profile_id)
+        except KeyError:
+            raise HTTPException(404, "profile not found") from None
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="profile.activate",
+            resource=profile_id,
+            details={"name": p.name},
+            risk_score=4,
+        )
+        await state.metrics.incr("profiles.activated")
+        return p.to_dict()
+
+    @api.post("/profiles/shape")
+    async def shape_beacon_request(
+        body: ProfileShapeRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("profiles:read", "payloads:generate", "admin")),
+    ) -> dict[str, Any]:
+        """Preview HTTP shaping + jitter for a beacon object under active (or named) profile."""
+        state = get_state(request)
+        prof = state.profiles.get(body.profile_id) if body.profile_id else state.profiles.active()
+        beacon = body.beacon or {"session_id": "ses_preview", "hostname": "lab"}
+        return state.profiles.shape_http_request(prof, beacon)
+
+    # ----- Implants catalog -----
+
+    @api.get("/implants/families")
+    async def implant_families(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "admin")),
+    ) -> dict[str, Any]:
+        return {"families": get_state(request).implants.list_families()}
+
+    @api.post("/implants/plan")
+    async def implant_plan(
+        body: ImplantPlanRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        host = body.host or state.settings.public_host or "127.0.0.1"
+        port = int(body.port or state.settings.port)
+        try:
+            profile_plan = state.profiles.implant_snippet(state.profiles.active(), host, port)
+            return state.implants.stager_plan(
+                body.family, body.platform, body.arch, host, port, profile_plan
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+
+    # ----- Evasion assist -----
+
+    @api.get("/evasion/checklist")
+    async def evasion_checklist(
+        platform: str = "linux",
+        auth: AuthContext = Depends(require_scope("ai:use", "payloads:generate", "admin")),
+    ) -> dict[str, Any]:
+        from squidc5.evasion.checks import anti_analysis_checklist, sleep_obfuscation_plan
+
+        return {
+            "platform": platform,
+            "checklist": anti_analysis_checklist(platform),
+            "sleep": sleep_obfuscation_plan(5.0, 25.0),
+        }
+
+    # ----- Multi-operator collab -----
+
+    @api.get("/teams")
+    async def list_teams(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("collab:use", "admin")),
+    ) -> list[dict[str, Any]]:
+        state = get_state(request)
+        if not await state.features.enabled("collab_teams"):
+            raise HTTPException(403, "Collab disabled by feature flag")
+        return await state.teams.list_teams()
+
+    @api.post("/teams")
+    async def create_team(
+        body: TeamCreate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("collab:use", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not await state.features.enabled("collab_teams"):
+            raise HTTPException(403, "Collab disabled by feature flag")
+        if not body.name.strip():
+            raise HTTPException(400, "name required")
+        return await state.teams.create_team(body.name.strip(), auth.name)
+
+    @api.post("/sessions/{session_id}/handoff")
+    async def session_handoff(
+        session_id: str,
+        body: HandoffRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("collab:use", "sessions:write", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not body.to:
+            raise HTTPException(400, "to required")
+        try:
+            return await state.teams.handoff(
+                session_id, auth.name, body.to, note=body.note or ""
+            )
+        except Exception as e:
+            raise HTTPException(400, str(e)) from e
+
+    @api.get("/sessions/{session_id}/spectator")
+    async def session_spectator(
+        session_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("sessions:read", "collab:use", "admin")),
+    ) -> dict[str, Any]:
+        try:
+            return await get_state(request).teams.spectator_view(session_id)
+        except KeyError:
+            raise HTTPException(404, "session not found") from None
+
+    # ----- Plugins -----
+
+    @api.get("/plugins")
+    async def list_plugins(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("plugins:manage", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not await state.features.enabled("plugins_enabled"):
+            return {"plugins": [], "enabled_feature": False}
+        return {"plugins": state.plugins.list_plugins(), "enabled_feature": True}
+
+    @api.post("/plugins/register")
+    async def register_plugin(
+        body: PluginRegister,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("plugins:manage", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not await state.features.enabled("plugins_enabled"):
+            raise HTTPException(403, "Plugins disabled by feature flag")
+        try:
+            entry = state.plugins.register(
+                body.manifest, body.signature, enable=body.enable
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="plugin.register",
+            resource=entry["name"],
+            details={"version": entry["version"]},
+            risk_score=6,
+        )
+        return entry
+
+    # ----- Observability -----
+
+    @api.get("/observability/timeline")
+    async def obs_timeline(
+        request: Request,
+        limit: int = 100,
+        offset: int = 0,
+        auth: AuthContext = Depends(require_scope("audit:read", "metrics:read", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        if not await state.features.enabled("observability_timeline"):
+            raise HTTPException(403, "Observability timeline disabled")
+        return {"events": await state.timeline.timeline(limit=min(limit, 500), offset=offset)}
+
+    @api.get("/observability/heatmap")
+    async def obs_heatmap(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("metrics:read", "sessions:read", "admin")),
+    ) -> dict[str, Any]:
+        return await get_state(request).timeline.heatmap()
 
     # ----- Implant (no auth — session-bound beacon) -----
 

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -32,6 +32,10 @@ SCOPES = frozenset(
         "files:read",
         "files:write",
         "phone:operator",
+        "profiles:read",
+        "profiles:write",
+        "plugins:manage",
+        "collab:use",
     }
 )
 

--- a/src/squidc5/collab/__init__.py
+++ b/src/squidc5/collab/__init__.py
@@ -1,0 +1,3 @@
+from squidc5.collab.teams import TeamService
+
+__all__ = ["TeamService"]

--- a/src/squidc5/collab/teams.py
+++ b/src/squidc5/collab/teams.py
@@ -1,0 +1,71 @@
+"""Multi-operator collaboration: teams, session ownership, handoff notes."""
+
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from squidc5.db.store import Database
+
+
+class TeamService:
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+    async def list_teams(self) -> list[dict[str, Any]]:
+        return await self.db.list_teams()
+
+    async def create_team(self, name: str, created_by: str) -> dict[str, Any]:
+        tid = await self.db.create_team(name, created_by)
+        return {"id": tid, "name": name, "created_by": created_by}
+
+    async def handoff(
+        self,
+        session_id: str,
+        from_actor: str,
+        to_actor: str,
+        note: str = "",
+    ) -> dict[str, Any]:
+        entry = {
+            "ts": time.time(),
+            "from": from_actor,
+            "to": to_actor,
+            "note": (note or "")[:2000],
+            "session_id": session_id,
+        }
+        await self.db.add_session_handoff(session_id, entry)
+        await self.db.audit(
+            actor=from_actor,
+            actor_type="operator",
+            action="session.handoff",
+            resource=session_id,
+            details={"to": to_actor, "note_len": len(note or "")},
+            risk_score=2,
+        )
+        return entry
+
+    async def session_notes(self, session_id: str) -> list[dict[str, Any]]:
+        return await self.db.get_session_handoffs(session_id)
+
+    async def set_owner(self, session_id: str, owner: str) -> None:
+        await self.db.set_session_owner(session_id, owner)
+
+    async def spectator_view(self, session_id: str) -> dict[str, Any]:
+        """Read-only snapshot for spectator mode (no shell interact)."""
+        row = await self.db.get_session(session_id)
+        if not row:
+            raise KeyError(session_id)
+        meta = row.get("metadata") or {}
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        return {
+            "id": row["id"],
+            "kind": row["kind"],
+            "status": row["status"],
+            "remote_addr": row.get("remote_addr"),
+            "hostname": row.get("hostname"),
+            "owner": meta.get("owner"),
+            "handoffs": await self.session_notes(session_id),
+            "mode": "spectator",
+        }

--- a/src/squidc5/core/state.py
+++ b/src/squidc5/core/state.py
@@ -9,13 +9,18 @@ if TYPE_CHECKING:
     from squidc5.ai.admin_ai import AdminAI
     from squidc5.audit.trail import AuditTrail
     from squidc5.auth.tokens import TokenService
+    from squidc5.collab.teams import TeamService
     from squidc5.config import Settings
     from squidc5.db.store import Database
     from squidc5.features import FeatureFlags
+    from squidc5.implants.registry import ImplantRegistry
     from squidc5.listeners.manager import ListenerManager
     from squidc5.metrics.collector import MetricsCollector
+    from squidc5.observability.timeline import TimelineService
     from squidc5.payloads.generator import PayloadGenerator
+    from squidc5.plugins.registry import PluginRegistry
     from squidc5.policy.engine import PolicyEngine
+    from squidc5.profiles.engine import ProfileEngine
     from squidc5.sessions.manager import SessionManager
     from squidc5.tasking.manager import TaskManager
 
@@ -34,5 +39,10 @@ class AppState:
     payloads: PayloadGenerator
     admin_ai: AdminAI
     features: FeatureFlags
+    profiles: ProfileEngine
+    implants: ImplantRegistry
+    teams: TeamService
+    plugins: PluginRegistry
+    timeline: TimelineService
     admin_token_once: str = ""
     shell_buffers: dict[str, list[str]] = field(default_factory=dict)

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -105,6 +105,31 @@ CREATE TABLE IF NOT EXISTS metrics (
 CREATE INDEX IF NOT EXISTS idx_audit_ts ON audit_log(ts);
 CREATE INDEX IF NOT EXISTS idx_tasks_session ON tasks(session_id);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
+
+CREATE TABLE IF NOT EXISTS c2_profiles (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL,
+    config TEXT NOT NULL,
+    active INTEGER NOT NULL DEFAULT 0,
+    created_at REAL NOT NULL,
+    updated_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS teams (
+    id TEXT PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE,
+    created_by TEXT,
+    created_at REAL NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS session_handoffs (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    ts REAL NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_handoffs_session ON session_handoffs(session_id);
 """
 
 
@@ -499,3 +524,80 @@ class Database:
     async def get_metrics(self) -> dict[str, float]:
         rows = await self.fetchall("SELECT key, value FROM metrics")
         return {r["key"]: r["value"] for r in rows}
+
+    # --- C2 profiles ---
+
+    async def list_profiles(self) -> list[dict[str, Any]]:
+        rows = await self.fetchall(
+            "SELECT id, name, config, active, created_at, updated_at FROM c2_profiles ORDER BY name"
+        )
+        for r in rows:
+            if isinstance(r.get("config"), str):
+                r["config"] = json.loads(r["config"])
+        return rows
+
+    async def upsert_profile(
+        self, profile_id: str, name: str, config: dict[str, Any], active: bool = False
+    ) -> None:
+        existing = await self.fetchone("SELECT id FROM c2_profiles WHERE id = ?", (profile_id,))
+        now = _now()
+        if existing:
+            await self.execute(
+                "UPDATE c2_profiles SET name = ?, config = ?, active = ?, updated_at = ? WHERE id = ?",
+                (name, json.dumps(config), 1 if active else 0, now, profile_id),
+            )
+        else:
+            await self.execute(
+                "INSERT INTO c2_profiles (id, name, config, active, created_at, updated_at) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (profile_id, name, json.dumps(config), 1 if active else 0, now, now),
+            )
+
+    async def set_active_profile(self, profile_id: str) -> None:
+        await self.execute("UPDATE c2_profiles SET active = 0")
+        await self.execute(
+            "UPDATE c2_profiles SET active = 1, updated_at = ? WHERE id = ?",
+            (_now(), profile_id),
+        )
+
+    # --- Teams / collab ---
+
+    async def list_teams(self) -> list[dict[str, Any]]:
+        return await self.fetchall("SELECT * FROM teams ORDER BY name")
+
+    async def create_team(self, name: str, created_by: str) -> str:
+        tid = _uid("team_")
+        await self.execute(
+            "INSERT INTO teams (id, name, created_by, created_at) VALUES (?, ?, ?, ?)",
+            (tid, name, created_by, _now()),
+        )
+        return tid
+
+    async def add_session_handoff(self, session_id: str, entry: dict[str, Any]) -> None:
+        await self.execute(
+            "INSERT INTO session_handoffs (session_id, payload, ts) VALUES (?, ?, ?)",
+            (session_id, json.dumps(entry), entry.get("ts") or _now()),
+        )
+
+    async def get_session_handoffs(self, session_id: str) -> list[dict[str, Any]]:
+        rows = await self.fetchall(
+            "SELECT payload, ts FROM session_handoffs WHERE session_id = ? ORDER BY ts ASC",
+            (session_id,),
+        )
+        out = []
+        for r in rows:
+            p = r["payload"]
+            if isinstance(p, str):
+                p = json.loads(p)
+            out.append(p)
+        return out
+
+    async def set_session_owner(self, session_id: str, owner: str) -> None:
+        row = await self.get_session(session_id)
+        if not row:
+            raise KeyError(session_id)
+        meta = row.get("metadata") or {}
+        if isinstance(meta, str):
+            meta = json.loads(meta)
+        meta["owner"] = owner
+        await self.update_session(session_id, metadata=json.dumps(meta))

--- a/src/squidc5/evasion/__init__.py
+++ b/src/squidc5/evasion/__init__.py
@@ -1,0 +1,3 @@
+from squidc5.evasion.checks import anti_analysis_checklist, sleep_obfuscation_plan
+
+__all__ = ["anti_analysis_checklist", "sleep_obfuscation_plan"]

--- a/src/squidc5/evasion/checks.py
+++ b/src/squidc5/evasion/checks.py
@@ -1,0 +1,64 @@
+"""Evasion / anti-analysis helpers (deterministic suggestions + implant snippets)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def anti_analysis_checklist(platform: str = "linux") -> list[dict[str, str]]:
+    """Operator checklist — not automatic offensive action."""
+    common = [
+        {"id": "sleep_jitter", "title": "Sleep with jitter", "detail": "Use profile jitter_pct; avoid fixed intervals"},
+        {"id": "decoy", "title": "Decoy HTTP paths", "detail": "Enable profile decoy_paths to blend with site noise"},
+        {"id": "ua_blend", "title": "User-Agent blend", "detail": "Match environment-common UA strings in profile"},
+    ]
+    if platform.startswith("win"):
+        common.extend(
+            [
+                {"id": "vm_check", "title": "VM artifact awareness", "detail": "Review known hypervisor MAC/OEM strings before long-haul implants"},
+                {"id": "dbg_check", "title": "Debugger resistance", "detail": "Prefer memory-only stages; avoid obvious debug APIs in payloads"},
+            ]
+        )
+    else:
+        common.extend(
+            [
+                {"id": "container", "title": "Container/sandbox signals", "detail": "cgroup / .dockerenv presence may indicate lab sandboxes"},
+                {"id": "ptrace", "title": "Tracer awareness", "detail": "Unexpected TracerPid may indicate analysis"},
+            ]
+        )
+    return common
+
+
+def sleep_obfuscation_plan(base_sec: float, jitter_pct: float = 25.0) -> dict[str, Any]:
+    return {
+        "mode": "jittered_sleep",
+        "base_sec": base_sec,
+        "jitter_pct": jitter_pct,
+        "impl_hint": "sleep(base ± base*jitter_pct/100); avoid busy-spin",
+        "encrypt_sleep": False,  # placeholder for future Ekko/Zilean-style techniques
+    }
+
+
+def sandbox_probe_snippet(platform: str = "linux") -> str:
+    """Read-only probe snippet for authorized lab implants (string template only)."""
+    if platform.startswith("win"):
+        return (
+            "# sandbox probe (authorized lab only)\n"
+            "try:\n"
+            "    import os\n"
+            "    _ = os.environ.get('USERNAME','')\n"
+            "except Exception:\n"
+            "    pass\n"
+        )
+    return (
+        "# sandbox probe (authorized lab only)\n"
+        "import os\n"
+        "signals = []\n"
+        "if os.path.exists('/.dockerenv'): signals.append('docker')\n"
+        "if os.path.exists('/proc/1/cgroup'):\n"
+        "    try:\n"
+        "        c = open('/proc/1/cgroup').read()\n"
+        "        if 'docker' in c or 'kubepods' in c: signals.append('cgroup')\n"
+        "    except Exception:\n"
+        "        pass\n"
+    )

--- a/src/squidc5/features.py
+++ b/src/squidc5/features.py
@@ -21,6 +21,10 @@ DEFAULT_FEATURES: dict[str, bool] = {
     "payloads_generate": True,
     "public_docs": False,  # never expose Swagger/OpenAPI
     "ops_dashboard": True,
+    "malleable_profiles": True,
+    "plugins_enabled": False,  # deny by default until allow-listed
+    "collab_teams": True,
+    "observability_timeline": True,
 }
 
 FEATURE_LABELS: dict[str, str] = {
@@ -36,6 +40,10 @@ FEATURE_LABELS: dict[str, str] = {
     "payloads_generate": "Payload generation",
     "public_docs": "Public /docs and OpenAPI (keep OFF)",
     "ops_dashboard": "Ops dashboard (/ops)",
+    "malleable_profiles": "Malleable / adaptive C2 profiles",
+    "plugins_enabled": "Plugin registry (allow-list)",
+    "collab_teams": "Multi-operator teams / handoff",
+    "observability_timeline": "Timeline + ATT&CK mapping",
 }
 
 

--- a/src/squidc5/implants/__init__.py
+++ b/src/squidc5/implants/__init__.py
@@ -1,0 +1,3 @@
+from squidc5.implants.registry import ImplantRegistry
+
+__all__ = ["ImplantRegistry"]

--- a/src/squidc5/implants/registry.py
+++ b/src/squidc5/implants/registry.py
@@ -1,0 +1,89 @@
+"""Advanced implant / beacon template registry (deterministic, arch-aware)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class ImplantRegistry:
+    """Catalog of implant families beyond basic reverse shells."""
+
+    FAMILIES = {
+        "http_beacon": {
+            "platforms": ["linux", "windows", "macos"],
+            "arches": ["x64", "x86", "arm64"],
+            "stages": ["stage0_stager", "stage1_beacon"],
+            "memory_only": False,
+            "description": "HTTP beacon with profile-aware callbacks",
+        },
+        "reverse_shell_stable": {
+            "platforms": ["linux", "windows"],
+            "arches": ["x64", "x86"],
+            "stages": ["stage0_shell", "stage2_reconnect"],
+            "memory_only": False,
+            "description": "Reverse shell with stage-2 reconnect agent",
+        },
+        "memory_beacon_python": {
+            "platforms": ["linux", "macos"],
+            "arches": ["x64", "arm64"],
+            "stages": ["stage0_loader", "stage1_inmem"],
+            "memory_only": True,
+            "description": "Python in-memory beacon loader (authorized lab)",
+        },
+        "bof_stub": {
+            "platforms": ["windows"],
+            "arches": ["x64"],
+            "stages": ["object_module"],
+            "memory_only": True,
+            "description": "BOF-like module stub (operator-supplied object)",
+        },
+    }
+
+    def list_families(self) -> list[dict[str, Any]]:
+        out = []
+        for name, meta in self.FAMILIES.items():
+            out.append({"name": name, **meta})
+        return out
+
+    def resolve(
+        self,
+        family: str,
+        platform: str,
+        arch: str = "x64",
+    ) -> dict[str, Any]:
+        meta = self.FAMILIES.get(family)
+        if not meta:
+            raise ValueError(f"Unknown implant family: {family}")
+        if platform not in meta["platforms"]:
+            raise ValueError(f"Family {family} does not support platform {platform}")
+        if arch not in meta["arches"]:
+            raise ValueError(f"Family {family} does not support arch {arch}")
+        return {
+            "family": family,
+            "platform": platform,
+            "arch": arch,
+            "stages": list(meta["stages"]),
+            "memory_only": meta["memory_only"],
+            "description": meta["description"],
+        }
+
+    def stager_plan(
+        self,
+        family: str,
+        platform: str,
+        arch: str,
+        host: str,
+        port: int,
+        profile_plan: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        resolved = self.resolve(family, platform, arch)
+        return {
+            **resolved,
+            "callback_host": host,
+            "callback_port": port,
+            "profile": profile_plan or {},
+            "injection": {
+                "techniques": ["self_inject"] if resolved["memory_only"] else ["disk_drop", "self_inject"],
+                "note": "Technique selection is operator-driven; no automatic injection against unauthorized hosts",
+            },
+        }

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -16,16 +16,21 @@ from squidc5.ai.admin_ai import AdminAI
 from squidc5.api.routes import build_api_router
 from squidc5.audit.trail import AuditTrail
 from squidc5.auth.tokens import TokenService
+from squidc5.collab.teams import TeamService
 from squidc5.config import Settings, get_settings
 from squidc5.core.state import AppState
 from squidc5.db.store import Database
 from squidc5.features import FeatureFlags
+from squidc5.implants.registry import ImplantRegistry
 from squidc5.listeners.manager import ListenerManager
 from squidc5.mcp.server import build_mcp_router
 from squidc5.metrics.collector import MetricsCollector
+from squidc5.observability.timeline import TimelineService
 from squidc5.paths import web_dir
 from squidc5.payloads.generator import PayloadGenerator
+from squidc5.plugins.registry import PluginRegistry
 from squidc5.policy.engine import PolicyEngine
+from squidc5.profiles.engine import ProfileEngine
 from squidc5.sessions.manager import SessionManager
 from squidc5.tasking.manager import TaskManager
 
@@ -52,6 +57,12 @@ async def build_state(settings: Settings) -> AppState:
     admin_ai = AdminAI(db, metrics, policy)
     features = FeatureFlags(db)
     await features.load()
+    profiles = ProfileEngine(db)
+    await profiles.load()
+    implants = ImplantRegistry()
+    teams = TeamService(db)
+    plugins = PluginRegistry()
+    timeline = TimelineService(db)
 
     listeners = ListenerManager(
         db,
@@ -94,6 +105,11 @@ async def build_state(settings: Settings) -> AppState:
         payloads=payloads,
         admin_ai=admin_ai,
         features=features,
+        profiles=profiles,
+        implants=implants,
+        teams=teams,
+        plugins=plugins,
+        timeline=timeline,
         admin_token_once=admin_once,
     )
 

--- a/src/squidc5/observability/__init__.py
+++ b/src/squidc5/observability/__init__.py
@@ -1,0 +1,3 @@
+from squidc5.observability.timeline import ATTACK_MAP, TimelineService
+
+__all__ = ["TimelineService", "ATTACK_MAP"]

--- a/src/squidc5/observability/timeline.py
+++ b/src/squidc5/observability/timeline.py
@@ -1,0 +1,69 @@
+"""Observability: timeline + lightweight MITRE ATT&CK mapping."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from squidc5.db.store import Database
+
+# action prefix / event type -> ATT&CK technique ids (illustrative)
+ATTACK_MAP: dict[str, list[str]] = {
+    "shell.interact": ["T1059"],
+    "shell.broadcast": ["T1059"],
+    "payloads.generate": ["T1587", "T1608"],
+    "listeners.create": ["T1090", "T1571"],
+    "listeners.start": ["T1090"],
+    "session.handoff": ["T1078"],
+    "tokens.create": ["T1136"],
+    "ai.admin": ["T1588"],
+    "implant.beacon": ["T1071.001"],
+    "mcp.call": ["T1106"],
+    "features.update": ["T1562"],
+    "profile.activate": ["T1071"],
+}
+
+
+class TimelineService:
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+    def map_attack(self, action: str) -> list[str]:
+        if action in ATTACK_MAP:
+            return list(ATTACK_MAP[action])
+        for prefix, techs in ATTACK_MAP.items():
+            if action.startswith(prefix.split(".")[0]):
+                return list(techs)
+        return []
+
+    async def timeline(self, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
+        rows = await self.db.list_audit(limit=limit, offset=offset)
+        out = []
+        for r in rows:
+            action = r.get("action") or ""
+            out.append(
+                {
+                    "ts": r.get("ts"),
+                    "actor": r.get("actor"),
+                    "action": action,
+                    "resource": r.get("resource"),
+                    "allowed": bool(r.get("allowed", 1)),
+                    "risk_score": r.get("risk_score", 0),
+                    "attack": self.map_attack(action),
+                }
+            )
+        return out
+
+    async def heatmap(self) -> dict[str, Any]:
+        sessions = await self.db.list_sessions(status="active")
+        by_host: dict[str, int] = {}
+        by_kind: dict[str, int] = {}
+        for s in sessions:
+            host = s.get("hostname") or s.get("remote_addr") or "unknown"
+            by_host[host] = by_host.get(host, 0) + 1
+            kind = s.get("kind") or "unknown"
+            by_kind[kind] = by_kind.get(kind, 0) + 1
+        return {
+            "active_sessions": len(sessions),
+            "by_host": by_host,
+            "by_kind": by_kind,
+        }

--- a/src/squidc5/plugins/__init__.py
+++ b/src/squidc5/plugins/__init__.py
@@ -1,0 +1,3 @@
+from squidc5.plugins.registry import PluginRegistry
+
+__all__ = ["PluginRegistry"]

--- a/src/squidc5/plugins/registry.py
+++ b/src/squidc5/plugins/registry.py
@@ -1,0 +1,64 @@
+"""Signed / allow-listed plugin registry (deny by default)."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from typing import Any
+
+
+class PluginRegistry:
+    """In-process allow-list. Plugins must be registered with a signature check."""
+
+    def __init__(self, signing_secret: bytes | None = None) -> None:
+        self._plugins: dict[str, dict[str, Any]] = {}
+        self._signing_secret = signing_secret or b"sc5-dev-plugin-secret-change-me"
+        self._enabled: set[str] = set()
+
+    def sign_manifest(self, manifest: dict[str, Any]) -> str:
+        body = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+        return hmac.new(self._signing_secret, body, hashlib.sha256).hexdigest()
+
+    def verify(self, manifest: dict[str, Any], signature: str) -> bool:
+        expected = self.sign_manifest(manifest)
+        return hmac.compare_digest(expected, signature or "")
+
+    def register(self, manifest: dict[str, Any], signature: str, *, enable: bool = False) -> dict[str, Any]:
+        name = manifest.get("name")
+        if not name or not isinstance(name, str):
+            raise ValueError("manifest.name required")
+        if not self.verify(manifest, signature):
+            raise ValueError("invalid plugin signature")
+        entry = {
+            "name": name,
+            "version": manifest.get("version") or "0.0.0",
+            "capabilities": list(manifest.get("capabilities") or []),
+            "description": manifest.get("description") or "",
+            "signature_ok": True,
+            "enabled": False,
+        }
+        self._plugins[name] = entry
+        if enable:
+            self.enable(name)
+        return entry
+
+    def enable(self, name: str) -> None:
+        if name not in self._plugins:
+            raise KeyError(name)
+        self._enabled.add(name)
+        self._plugins[name]["enabled"] = True
+
+    def disable(self, name: str) -> None:
+        self._enabled.discard(name)
+        if name in self._plugins:
+            self._plugins[name]["enabled"] = False
+
+    def list_plugins(self) -> list[dict[str, Any]]:
+        return list(self._plugins.values())
+
+    def is_allowed(self, name: str, capability: str) -> bool:
+        if name not in self._enabled:
+            return False
+        caps = self._plugins.get(name, {}).get("capabilities") or []
+        return capability in caps

--- a/src/squidc5/profiles/__init__.py
+++ b/src/squidc5/profiles/__init__.py
@@ -1,0 +1,4 @@
+from squidc5.profiles.engine import ProfileEngine
+from squidc5.profiles.models import DEFAULT_PROFILES, C2Profile
+
+__all__ = ["ProfileEngine", "C2Profile", "DEFAULT_PROFILES"]

--- a/src/squidc5/profiles/engine.py
+++ b/src/squidc5/profiles/engine.py
@@ -1,0 +1,161 @@
+"""Profile engine: jitter, request shaping, decoy plan, runtime active profile."""
+
+from __future__ import annotations
+
+import json
+import random
+import re
+import secrets
+import uuid
+from typing import Any
+
+from squidc5.db.store import Database
+from squidc5.profiles.models import DEFAULT_PROFILES, C2Profile
+
+_PLACEHOLDER = re.compile(r"\{(uuid|beacon|rand)\}")
+
+
+class ProfileEngine:
+    def __init__(self, db: Database) -> None:
+        self.db = db
+        self._cache: dict[str, C2Profile] = {}
+        self._active_id: str | None = None
+
+    async def load(self) -> None:
+        rows = await self.db.list_profiles()
+        if not rows:
+            for p in DEFAULT_PROFILES:
+                await self.db.upsert_profile(p.id, p.name, p.to_dict(), active=p.active)
+            rows = await self.db.list_profiles()
+        self._cache.clear()
+        self._active_id = None
+        for row in rows:
+            data = row["config"] if isinstance(row["config"], dict) else json.loads(row["config"])
+            data["id"] = row["id"]
+            data["name"] = row["name"]
+            data["active"] = bool(row.get("active"))
+            prof = C2Profile.from_dict(data)
+            self._cache[prof.id] = prof
+            if prof.active:
+                self._active_id = prof.id
+        if self._active_id is None and self._cache:
+            # ensure one active
+            first = next(iter(self._cache.values()))
+            await self.set_active(first.id)
+
+    def list_profiles(self) -> list[dict[str, Any]]:
+        return [p.to_dict() for p in self._cache.values()]
+
+    def get(self, profile_id: str) -> C2Profile | None:
+        return self._cache.get(profile_id)
+
+    def active(self) -> C2Profile | None:
+        if self._active_id:
+            return self._cache.get(self._active_id)
+        return None
+
+    async def set_active(self, profile_id: str) -> C2Profile:
+        if profile_id not in self._cache:
+            raise KeyError(profile_id)
+        await self.db.set_active_profile(profile_id)
+        for pid, p in self._cache.items():
+            p.active = pid == profile_id
+        self._active_id = profile_id
+        return self._cache[profile_id]
+
+    async def upsert(self, profile: C2Profile) -> C2Profile:
+        await self.db.upsert_profile(
+            profile.id, profile.name, profile.to_dict(), active=profile.active
+        )
+        self._cache[profile.id] = profile
+        if profile.active:
+            await self.set_active(profile.id)
+        return profile
+
+    @staticmethod
+    def compute_sleep(base_sec: float, jitter_pct: float, rng: random.Random | None = None) -> float:
+        """Sleep with jitter: base ± (jitter_pct% of base)."""
+        r = rng or random.Random()
+        pct = max(0.0, min(100.0, float(jitter_pct))) / 100.0
+        delta = base_sec * pct
+        return max(0.1, base_sec + r.uniform(-delta, delta))
+
+    def shape_http_request(
+        self,
+        profile: C2Profile | None,
+        beacon_obj: dict[str, Any],
+        *,
+        rng: random.Random | None = None,
+    ) -> dict[str, Any]:
+        """Build outbound implant HTTP request description from profile."""
+        p = profile or self.active() or DEFAULT_PROFILES[0]
+        http = p.http
+        r = rng or random.Random()
+        uri = r.choice(http.uris) if http.uris else "/api/v1/implant/beacon"
+        beacon_json = json.dumps(beacon_obj, separators=(",", ":"))
+
+        def _sub(m: re.Match[str]) -> str:
+            key = m.group(1)
+            if key == "uuid":
+                return str(uuid.uuid4())
+            if key == "beacon":
+                return beacon_json
+            if key == "rand":
+                return secrets.token_hex(8)
+            return m.group(0)
+
+        headers = {k: _PLACEHOLDER.sub(_sub, v) for k, v in http.headers.items()}
+        body = _PLACEHOLDER.sub(_sub, http.request_body_template)
+        if "{beacon}" not in http.request_body_template and body == http.request_body_template:
+            # template had no placeholder — if still literal, wrap
+            if body == "{beacon}" or not body:
+                body = beacon_json
+        sleep = self.compute_sleep(http.sleep_sec, http.jitter_pct, r)
+        decoys: list[str] = []
+        if http.decoy_enabled and http.decoy_paths:
+            n = min(2, len(http.decoy_paths))
+            decoys = r.sample(http.decoy_paths, k=n)
+        return {
+            "profile_id": p.id,
+            "channel": "http",
+            "method": http.method,
+            "uri": uri,
+            "headers": headers,
+            "user_agent": http.user_agent,
+            "body": body,
+            "sleep_sec": round(sleep, 3),
+            "decoy_uris": decoys,
+        }
+
+    def implant_snippet(self, profile: C2Profile | None, host: str, port: int) -> dict[str, Any]:
+        """Deterministic implant callback plan for payload generator."""
+        p = profile or self.active() or DEFAULT_PROFILES[0]
+        if p.channel == "dns":
+            return {
+                "channel": "dns",
+                "zone": p.dns.zone,
+                "record_type": p.dns.record_type,
+                "sleep_sec": p.dns.sleep_sec,
+                "jitter_pct": p.dns.jitter_pct,
+            }
+        if p.channel == "ws":
+            return {
+                "channel": "ws",
+                "url": f"ws://{host}:{port}{p.ws.path}",
+                "sleep_sec": p.ws.sleep_sec,
+                "jitter_pct": p.ws.jitter_pct,
+            }
+        shaped = self.shape_http_request(p, {"session_id": None, "hostname": "HOST"})
+        return {
+            "channel": "http",
+            "base": f"http://{host}:{port}",
+            "uri": shaped["uri"],
+            "method": shaped["method"],
+            "headers": shaped["headers"],
+            "user_agent": shaped["user_agent"],
+            "sleep_sec": p.http.sleep_sec,
+            "jitter_pct": p.http.jitter_pct,
+            "decoy_enabled": p.http.decoy_enabled,
+            "profile_id": p.id,
+            "profile_name": p.name,
+        }

--- a/src/squidc5/profiles/models.py
+++ b/src/squidc5/profiles/models.py
@@ -1,0 +1,174 @@
+"""Malleable / adaptive C2 profile models."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+
+@dataclass
+class HttpProfile:
+    """HTTP/S beacon surface: URI, headers, body wrappers, user-agent."""
+
+    uris: list[str] = field(default_factory=lambda: ["/api/v1/implant/beacon"])
+    method: str = "POST"
+    headers: dict[str, str] = field(
+        default_factory=lambda: {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+    )
+    user_agent: str = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+    # Body: {beacon} is replaced with JSON beacon payload
+    request_body_template: str = "{beacon}"
+    # Response: extract task JSON from wrapper if needed
+    response_prefix: str = ""
+    response_suffix: str = ""
+    # Sleep between beacons (seconds) before jitter
+    sleep_sec: float = 5.0
+    jitter_pct: float = 20.0  # 0-100
+    decoy_enabled: bool = False
+    decoy_paths: list[str] = field(default_factory=lambda: ["/favicon.ico", "/robots.txt", "/health"])
+
+
+@dataclass
+class DnsProfile:
+    """DNS C2 (data in subdomain labels). Lab/authorized only."""
+
+    zone: str = "c2.example.invalid"
+    max_label_len: int = 63
+    sleep_sec: float = 10.0
+    jitter_pct: float = 30.0
+    record_type: str = "TXT"
+
+
+@dataclass
+class WsProfile:
+    """WebSocket C2 path and framing."""
+
+    path: str = "/ws/v1/beacon"
+    subprotocol: str = ""
+    sleep_sec: float = 3.0
+    jitter_pct: float = 15.0
+    ping_interval_sec: float = 30.0
+
+
+@dataclass
+class C2Profile:
+    id: str
+    name: str
+    description: str = ""
+    channel: str = "http"  # http | dns | ws
+    http: HttpProfile = field(default_factory=HttpProfile)
+    dns: DnsProfile = field(default_factory=DnsProfile)
+    ws: WsProfile = field(default_factory=WsProfile)
+    active: bool = False
+    version: int = 1
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> C2Profile:
+        http = HttpProfile(**(data.get("http") or {}))
+        dns = DnsProfile(**(data.get("dns") or {}))
+        ws = WsProfile(**(data.get("ws") or {}))
+        return cls(
+            id=data["id"],
+            name=data["name"],
+            description=data.get("description") or "",
+            channel=data.get("channel") or "http",
+            http=http,
+            dns=dns,
+            ws=ws,
+            active=bool(data.get("active")),
+            version=int(data.get("version") or 1),
+        )
+
+
+def _amazon_like() -> C2Profile:
+    return C2Profile(
+        id="prof_amazon_cdn",
+        name="amazon-cdn-blend",
+        description="HTTP traffic shaped like CDN/API client noise",
+        channel="http",
+        http=HttpProfile(
+            uris=["/v1/telemetry", "/api/client/events", "/cdn/config/refresh"],
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "X-Request-Id": "{uuid}",
+                "X-Amz-Target": "Telemetry.PutEvents",
+            },
+            user_agent="aws-sdk-python/1.34.0 Python/3.11 Linux",
+            request_body_template='{"Records":[{beacon}]}',
+            sleep_sec=8.0,
+            jitter_pct=35.0,
+            decoy_enabled=True,
+            decoy_paths=["/favicon.ico", "/robots.txt", "/.well-known/security.txt"],
+        ),
+    )
+
+
+def _office_like() -> C2Profile:
+    return C2Profile(
+        id="prof_ms_graph",
+        name="ms-graph-blend",
+        description="HTTP shaped like Microsoft Graph-style calls",
+        channel="http",
+        http=HttpProfile(
+            uris=["/v1.0/me/drive/root/delta", "/v1.0/communications/callRecords"],
+            method="POST",
+            headers={
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "ConsistencyLevel": "eventual",
+            },
+            user_agent="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0",
+            request_body_template='{"value":{beacon}}',
+            sleep_sec=12.0,
+            jitter_pct=40.0,
+            decoy_enabled=True,
+        ),
+    )
+
+
+def _default_http() -> C2Profile:
+    return C2Profile(
+        id="prof_default_http",
+        name="default-http",
+        description="Native SquidC5 HTTP beacon path (cleartext lab default)",
+        channel="http",
+        http=HttpProfile(),
+        active=True,
+    )
+
+
+def _default_dns() -> C2Profile:
+    return C2Profile(
+        id="prof_default_dns",
+        name="default-dns",
+        description="DNS TXT channel skeleton (authorized lab only)",
+        channel="dns",
+        dns=DnsProfile(),
+    )
+
+
+def _default_ws() -> C2Profile:
+    return C2Profile(
+        id="prof_default_ws",
+        name="default-ws",
+        description="WebSocket channel skeleton",
+        channel="ws",
+        ws=WsProfile(),
+    )
+
+
+DEFAULT_PROFILES: list[C2Profile] = [
+    _default_http(),
+    _amazon_like(),
+    _office_like(),
+    _default_dns(),
+    _default_ws(),
+]

--- a/tests/test_nextgen_modules.py
+++ b/tests/test_nextgen_modules.py
@@ -1,0 +1,142 @@
+"""Implants, evasion, collab, plugins, observability foundations."""
+
+from __future__ import annotations
+
+import pytest
+
+from squidc5.evasion.checks import anti_analysis_checklist, sleep_obfuscation_plan
+from squidc5.implants.registry import ImplantRegistry
+from squidc5.observability.timeline import ATTACK_MAP
+from squidc5.plugins.registry import PluginRegistry
+
+
+def test_implant_registry_resolve():
+    reg = ImplantRegistry()
+    fams = reg.list_families()
+    assert any(f["name"] == "http_beacon" for f in fams)
+    plan = reg.stager_plan("http_beacon", "linux", "x64", "1.2.3.4", 8443, {"channel": "http"})
+    assert plan["callback_host"] == "1.2.3.4"
+    assert "stage0_stager" in plan["stages"]
+    with pytest.raises(ValueError):
+        reg.resolve("http_beacon", "freebsd")
+
+
+def test_evasion_checklist_platform_specific():
+    lin = anti_analysis_checklist("linux")
+    win = anti_analysis_checklist("windows")
+    assert any(c["id"] == "sleep_jitter" for c in lin)
+    assert any(c["id"] == "vm_check" for c in win)
+    sleep = sleep_obfuscation_plan(5.0, 30.0)
+    assert sleep["base_sec"] == 5.0
+
+
+def test_plugin_signature_allowlist():
+    reg = PluginRegistry(signing_secret=b"test-secret")
+    manifest = {
+        "name": "lab_recon",
+        "version": "1.0.0",
+        "capabilities": ["recon.list"],
+        "description": "lab only",
+    }
+    sig = reg.sign_manifest(manifest)
+    entry = reg.register(manifest, sig, enable=True)
+    assert entry["enabled"] is True
+    assert reg.is_allowed("lab_recon", "recon.list")
+    assert not reg.is_allowed("lab_recon", "shell.exec")
+    with pytest.raises(ValueError):
+        reg.register(manifest, "deadbeef" * 8)
+
+
+def test_attack_map_covers_shell():
+    assert "T1059" in ATTACK_MAP["shell.interact"]
+
+
+@pytest.mark.asyncio
+async def test_implants_and_evasion_api(client, admin_headers):
+    fams = await client.get("/api/v1/implants/families", headers=admin_headers)
+    assert fams.status_code == 200
+    assert len(fams.json()["families"]) >= 3
+
+    plan = await client.post(
+        "/api/v1/implants/plan",
+        headers=admin_headers,
+        json={"family": "memory_beacon_python", "platform": "linux", "arch": "x64", "host": "10.0.0.1", "port": 8443},
+    )
+    assert plan.status_code == 200
+    assert plan.json()["memory_only"] is True
+    assert plan.json()["profile"]["channel"] in ("http", "dns", "ws")
+
+    ev = await client.get("/api/v1/evasion/checklist?platform=windows", headers=admin_headers)
+    assert ev.status_code == 200
+    assert ev.json()["checklist"]
+
+
+@pytest.mark.asyncio
+async def test_collab_team_and_handoff(client, admin_headers):
+    # create beacon session
+    b = await client.post("/api/v1/implant/beacon", json={"hostname": "collab-host"})
+    sid = b.json()["session_id"]
+
+    team = await client.post(
+        "/api/v1/teams", headers=admin_headers, json={"name": "red-cell-a"}
+    )
+    assert team.status_code == 200
+    assert team.json()["id"].startswith("team_")
+
+    teams = await client.get("/api/v1/teams", headers=admin_headers)
+    assert any(t["name"] == "red-cell-a" for t in teams.json())
+
+    ho = await client.post(
+        f"/api/v1/sessions/{sid}/handoff",
+        headers=admin_headers,
+        json={"to": "operator-b", "note": "taking over recon"},
+    )
+    assert ho.status_code == 200
+    assert ho.json()["to"] == "operator-b"
+
+    spec = await client.get(f"/api/v1/sessions/{sid}/spectator", headers=admin_headers)
+    assert spec.status_code == 200
+    assert spec.json()["mode"] == "spectator"
+    assert len(spec.json()["handoffs"]) >= 1
+
+
+@pytest.mark.asyncio
+async def test_plugins_disabled_by_default(client, admin_headers):
+    r = await client.get("/api/v1/plugins", headers=admin_headers)
+    assert r.status_code == 200
+    assert r.json()["enabled_feature"] is False
+
+    # enable feature then register signed plugin
+    await client.put(
+        "/api/v1/features",
+        headers=admin_headers,
+        json={"features": {"plugins_enabled": True}},
+    )
+
+    # API uses server's secret - bad sig fails
+    bad = await client.post(
+        "/api/v1/plugins/register",
+        headers=admin_headers,
+        json={
+            "manifest": {"name": "x", "version": "1", "capabilities": []},
+            "signature": "00" * 32,
+        },
+    )
+    assert bad.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_observability_timeline_and_heatmap(client, admin_headers):
+    # generate audit via token list
+    await client.get("/api/v1/tokens", headers=admin_headers)
+    tl = await client.get("/api/v1/observability/timeline?limit=20", headers=admin_headers)
+    assert tl.status_code == 200
+    events = tl.json()["events"]
+    assert isinstance(events, list)
+    if events:
+        assert "attack" in events[0]
+
+    hm = await client.get("/api/v1/observability/heatmap", headers=admin_headers)
+    assert hm.status_code == 200
+    assert "active_sessions" in hm.json()
+    assert "by_kind" in hm.json()

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,84 @@
+"""Malleable C2 profile engine unit + API tests."""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from squidc5.profiles.engine import ProfileEngine
+from squidc5.profiles.models import DEFAULT_PROFILES, C2Profile, HttpProfile
+
+
+def test_default_profiles_include_active_http():
+    assert any(p.active and p.channel == "http" for p in DEFAULT_PROFILES)
+    assert any(p.channel == "dns" for p in DEFAULT_PROFILES)
+    assert any(p.channel == "ws" for p in DEFAULT_PROFILES)
+
+
+def test_jitter_bounds():
+    rng = random.Random(0)
+    for _ in range(50):
+        s = ProfileEngine.compute_sleep(10.0, 20.0, rng)
+        assert 8.0 <= s <= 12.0
+
+
+def test_shape_http_includes_uri_and_decoy():
+    eng = ProfileEngine.__new__(ProfileEngine)
+    eng._cache = {}
+    eng._active_id = None
+    prof = C2Profile(
+        id="t1",
+        name="test",
+        channel="http",
+        http=HttpProfile(
+            uris=["/a", "/b"],
+            decoy_enabled=True,
+            decoy_paths=["/x", "/y", "/z"],
+            jitter_pct=0,
+            sleep_sec=5,
+            request_body_template='{"q":{beacon}}',
+        ),
+    )
+    shaped = eng.shape_http_request(prof, {"session_id": "ses_1"}, rng=random.Random(1))
+    assert shaped["uri"] in ("/a", "/b")
+    assert shaped["method"] == "POST"
+    assert "ses_1" in shaped["body"]
+    assert shaped["sleep_sec"] == 5.0
+    assert len(shaped["decoy_uris"]) == 2
+
+
+@pytest.mark.asyncio
+async def test_profiles_api_list_and_activate(client, admin_headers):
+    r = await client.get("/api/v1/profiles", headers=admin_headers)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["active_id"]
+    assert len(data["profiles"]) >= 3
+
+    # activate amazon blend
+    target = next(p for p in data["profiles"] if p["id"] == "prof_amazon_cdn")
+    act = await client.post(
+        f"/api/v1/profiles/{target['id']}/activate", headers=admin_headers
+    )
+    assert act.status_code == 200
+    assert act.json()["active"] is True
+
+    active = await client.get("/api/v1/profiles/active", headers=admin_headers)
+    assert active.status_code == 200
+    assert active.json()["id"] == "prof_amazon_cdn"
+
+    shape = await client.post(
+        "/api/v1/profiles/shape",
+        headers=admin_headers,
+        json={"beacon": {"hostname": "lab-host"}},
+    )
+    assert shape.status_code == 200
+    body = shape.json()
+    assert body["uri"] in target["http"]["uris"]
+    assert body["profile_id"] == "prof_amazon_cdn"
+
+
+@pytest.mark.asyncio
+async def test_profiles_require_auth(client):
+    assert (await client.get("/api/v1/profiles")).status_code == 401


### PR DESCRIPTION
## Summary
Implements working foundations for the 2026-2027 roadmap under the SquidSec git cycle (tests first, feature branch, PR, CI).

1. **Malleable profiles** (priority 1): HTTP/DNS/WS models, jitter, decoy paths, runtime activate, shape preview API
2. **Implants**: family registry + stager plans (arch/platform aware)
3. **Evasion**: checklist + sleep obfuscation plan API
4. **Collab**: teams, session handoff, spectator mode
5. **Plugins**: HMAC-signed allow-list registry (feature-flagged off by default)
6. **Observability**: audit timeline with ATT&CK tags + session heatmap
7. **Docs**: threat model; agent memory includes full Windows SquidSec development cycle

## Test plan
- [x] `pytest -q` (106 passed)
- [x] `ruff check src tests`
- [ ] CI green on PR
- [ ] After merge: main CI binaries; deploy Linux `squidc5` binary only to prod