### PR TITLE
Fix desktop ops layout

### DIFF
--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -26,8 +26,9 @@
     .wrap { max-width: 520px; margin: 0 auto; width: 100%; }
     .brand { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
     .toolbar { margin-bottom: 10px; }
-    .dash-main, .dash-side { min-width: 0; }
-    #adminMount { display: flex; flex-direction: column; gap: 0; }
+    .overview { display: flex; flex-direction: column; }
+    .overview > * { min-width: 0; }
+    #adminMount { display: flex; flex-direction: column; }
     #adminMount > * { margin-bottom: 10px; }
     #adminMount > *:last-child { margin-bottom: 0; }
 
@@ -144,66 +145,69 @@
     .qr-box { background: #fff; border-radius: 12px; padding: 12px; width: fit-content; margin: 0 auto 12px; }
     .qr-box img { width: 220px; height: 220px; display: block; }
     .share-url { font: 0.65rem var(--mono); color: var(--pink); word-break: break-all; margin-bottom: 10px; }
-    footer { text-align: center; color: var(--muted); font-size: 0.72rem; margin-top: 14px; grid-column: 1 / -1; }
+    footer { text-align: center; color: var(--muted); font-size: 0.72rem; margin-top: 14px; }
     .hidden { display: none !important; }
 
-    /* Tablet / small desktop */
+    /* Tablet */
     @media (min-width: 768px) {
       body {
-        padding: max(16px, env(safe-area-inset-top)) 20px calc(24px + env(safe-area-inset-bottom));
+        padding: max(16px, env(safe-area-inset-top)) 24px calc(24px + env(safe-area-inset-bottom));
       }
-      .wrap {
-        max-width: 980px;
+      .wrap { max-width: 1000px; }
+      .overview {
         display: grid;
-        grid-template-columns: 1fr 1fr;
+        grid-template-columns: 1.2fr 1fr;
         gap: 12px 16px;
         align-items: start;
+        margin-bottom: 4px;
       }
-      .brand, #error, #okmsg, #settingsPanel, .toolbar, .hero, footer {
-        grid-column: 1 / -1;
+      .overview > .card,
+      .overview > details.panel {
+        margin-bottom: 0;
       }
-      .dash-main { grid-column: 1; display: flex; flex-direction: column; gap: 0; }
-      .dash-side { grid-column: 2; display: flex; flex-direction: column; gap: 0; }
-      .dash-main .card, .dash-side .card, .dash-main details.panel, .dash-side details.panel {
-        margin-bottom: 12px;
-      }
+      .overview .shells-card { grid-column: 1; grid-row: 1 / span 2; }
+      .overview .listeners-card { grid-column: 2; grid-row: 1; }
+      .overview .signal-card { grid-column: 2; grid-row: 2; }
+      .overview .events-panel { grid-column: 1 / -1; grid-row: 3; }
       #adminMount {
-        grid-column: 1 / -1;
         display: grid;
         grid-template-columns: 1fr 1fr;
         gap: 12px 16px;
         align-items: start;
+        margin-top: 12px;
       }
-      #adminMount > * { margin-bottom: 0; }
+      #adminMount > * { margin-bottom: 0 !important; }
+      /* shell runner is primary work surface */
       #adminMount > #quickRunCard { grid-column: 1 / -1; }
       #adminMount > #aiCard { grid-column: 1 / -1; }
-
-      .outbox { max-height: 360px; }
+      .outbox { max-height: 380px; }
       button { min-width: 120px; flex: 0 1 auto; }
       .stats { gap: 12px; }
       .stat .n { font-size: 1.5rem; }
       .modal { width: min(100%, 420px); }
     }
 
-    /* Wide desktop */
-    @media (min-width: 1200px) {
-      .wrap {
-        max-width: 1320px;
-        grid-template-columns: 1.25fr 1fr 1fr;
+    /* Desktop */
+    @media (min-width: 1100px) {
+      .wrap { max-width: 1360px; }
+      .overview {
+        grid-template-columns: 1.3fr 1fr 1fr;
         gap: 14px 18px;
       }
-      .dash-main { grid-column: 1; }
-      .dash-side { grid-column: 2 / -1; display: grid; grid-template-columns: 1fr 1fr; gap: 12px 16px; align-items: start; }
-      .dash-side > * { margin-bottom: 0; }
+      .overview .shells-card { grid-column: 1; grid-row: 1 / span 2; }
+      .overview .listeners-card { grid-column: 2; grid-row: 1; }
+      .overview .signal-card { grid-column: 3; grid-row: 1; }
+      .overview .events-panel { grid-column: 2 / -1; grid-row: 2; }
       #adminMount {
-        grid-column: 1 / -1;
-        grid-template-columns: repeat(3, 1fr);
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 14px 18px;
       }
-      #adminMount > #quickRunCard { grid-column: 1 / 3; }
-      #adminMount > #identityCard { grid-column: 3; }
-      #adminMount > #aiCard { grid-column: 1 / -1; }
+      #adminMount > #quickRunCard,
+      #adminMount > #aiCard {
+        grid-column: 1 / -1;
+      }
       .brand h1 { font-size: 1.45rem; }
-      .hero { padding: 16px 18px; }
+      .hero { padding: 16px 18px; margin-bottom: 16px; }
       .card, details.panel { padding: 14px 16px; }
       table { font-size: 0.85rem; }
     }
@@ -255,32 +259,30 @@
       </div>
     </div>
 
-    <div class="dash-main">
-      <div class="card">
+    <div class="overview">
+      <div class="card shells-card">
         <h2>Verified reverse shells</h2>
         <div id="shellsBox" class="empty">No verified shells</div>
       </div>
-    </div>
 
-    <div class="dash-side">
-      <div class="card">
+      <div class="card listeners-card">
         <h2>Listeners</h2>
         <div id="listenersBox" class="empty">—</div>
       </div>
 
-      <div class="card">
+      <div class="card signal-card">
         <h2>Signal</h2>
         <div class="chips" id="chips"><span class="chip">—</span></div>
         <p class="muted" id="healthLine" style="margin:8px 0 0">—</p>
       </div>
 
-      <details class="panel" id="eventsPanel">
+      <details class="panel events-panel" id="eventsPanel">
         <summary>Recent events</summary>
         <div id="eventsBox" class="empty">—</div>
       </details>
     </div>
 
-    <!-- Admin UI injected after server-side scope check (full width on desktop) -->
+    <!-- Admin UI injected after server-side scope check -->
     <div id="adminMount"></div>
 
     <footer>


### PR DESCRIPTION
## Summary
Fixes broken large-screen layout:
- Overview row: shells | listeners | signal, events below
- Admin tools in even 2/3-column grid
- Shell + AI full width; no floating identity column

## Test plan
- [ ] CI green
- [ ] Hard-refresh /ops on desktop after deploy