### PR TITLE
Expand ops panels by default and fix desktop layout

### DIFF
--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -12,9 +12,9 @@
   const root = document.getElementById("adminMount");
   if (!root) return;
 
-  function panel(id, title, body, _open) {
-    // All collapsible panels start collapsed; open arg ignored by design
-    return `<details class="panel" id="${id}">
+  function panel(id, title, body, open) {
+    const isOpen = open !== false;
+    return `<details class="panel" id="${id}"${isOpen ? " open" : ""}>
       <summary>${title}</summary>
       ${body}
     </details>`;
@@ -65,7 +65,7 @@
         <button type="button" id="listAllSesBtn">List all</button>
       </div>
       <div id="sesExtra" class="outbox empty-out" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Tasks (beacons) -----
@@ -82,7 +82,7 @@
         </div>
       ` : `<div class="row"><button type="button" id="listTasksBtn">List tasks</button></div>`}
       <div class="outbox empty-out" id="taskOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Listeners -----
@@ -114,7 +114,7 @@
           <button type="button" class="primary" id="createLisBtn">Create + start</button>
         </div>
       ` : ""}
-    `, false));
+    `, true));
   }
 
   // ----- Payloads -----
@@ -165,7 +165,7 @@
         <button type="button" id="genImpBtn">Generate implant</button>
       </div>
       <div class="outbox empty-out" id="payOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Plugins -----
@@ -181,7 +181,7 @@
         <button type="button" class="primary" id="plugInstallBtn">Install + enable</button>
       </div>
       <div class="outbox empty-out" id="plugOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Deploy helpers -----
@@ -194,7 +194,7 @@
         <button type="button" id="certPlanBtn">Cert plan</button>
       </div>
       <div class="outbox empty-out" id="deployOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Metrics / Audit -----
@@ -205,7 +205,7 @@
         ${can("audit:read") ? '<button type="button" id="auditBtn">Audit log</button>' : ""}
       </div>
       <div class="outbox" id="adminOut" style="margin-top:8px"></div>
-    `, false));
+    `, true));
   }
 
   // ----- Admin AI -----
@@ -261,7 +261,7 @@
         <button type="button" id="llmListBtn">List</button>
       </div>
       <div class="outbox empty-out" id="llmOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Tokens -----
@@ -290,7 +290,7 @@
       <div class="outbox empty-out" id="tokMintOut" style="margin-top:10px;border-color:rgba(0,255,157,0.35);color:var(--ok)">Minted token appears here once</div>
       <h2 style="margin-top:12px">Active tokens</h2>
       <div id="tokList" class="empty">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Observability extras -----
@@ -302,7 +302,7 @@
         <button type="button" id="timelineBtn">Timeline</button>
       </div>
       <div class="outbox empty-out" id="obsExtraOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Collab chat -----
@@ -315,7 +315,7 @@
         <button type="button" id="chatReloadBtn">Reload</button>
       </div>
       <div class="outbox empty-out" id="chatOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- C2 Profiles -----
@@ -328,7 +328,7 @@
         ${can("payloads:generate") || can("admin") ? '<button type="button" class="primary" id="profGenBtn">Generate beacon (active)</button>' : ""}
       </div>
       <div class="outbox empty-out" id="profOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- Feature toggles (admin) -----
@@ -340,7 +340,7 @@
         <button type="button" class="primary" id="saveFeaturesBtn">Save features</button>
         <button type="button" id="reloadFeaturesBtn">Reload</button>
       </div>
-    `, false));
+    `, true));
   }
 
   // ----- Policy -----
@@ -355,7 +355,7 @@
         <button type="button" class="primary" id="policySetBtn">Save policy</button>
       </div>
       <div class="outbox empty-out" id="policyOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   // ----- MCP -----
@@ -372,7 +372,7 @@
         <button type="button" class="primary" id="mcpCallBtn">Call</button>
       </div>
       <div class="outbox empty-out" id="mcpOut" style="margin-top:8px">—</div>
-    `, false));
+    `, true));
   }
 
   root.innerHTML = parts.join("\n") || '<div class="card muted">No scoped actions for this token.</div>';

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -189,27 +189,48 @@
 
     /* Desktop */
     @media (min-width: 1100px) {
-      .wrap { max-width: 1360px; }
+      .wrap { max-width: 1440px; }
       .overview {
-        grid-template-columns: 1.3fr 1fr 1fr;
+        display: grid;
+        grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr) minmax(0, 1fr);
         gap: 14px 18px;
+        align-items: stretch;
       }
-      .overview .shells-card { grid-column: 1; grid-row: 1 / span 2; }
+      .overview .shells-card {
+        grid-column: 1;
+        grid-row: 1 / span 2;
+        min-height: 100%;
+      }
       .overview .listeners-card { grid-column: 2; grid-row: 1; }
       .overview .signal-card { grid-column: 3; grid-row: 1; }
-      .overview .events-panel { grid-column: 2 / -1; grid-row: 2; }
+      .overview .events-panel {
+        grid-column: 2 / -1;
+        grid-row: 2;
+        min-height: 0;
+      }
       #adminMount {
+        display: grid;
         grid-template-columns: repeat(3, minmax(0, 1fr));
         gap: 14px 18px;
+        align-items: start;
       }
+      /* Full-width work surfaces */
       #adminMount > #quickRunCard,
       #adminMount > #aiCard {
         grid-column: 1 / -1;
+      }
+      /* Identity spans full width above shell when present */
+      #adminMount > #identityCard {
+        grid-column: 1 / -1;
+      }
+      #adminMount > details.panel {
+        min-width: 0;
       }
       .brand h1 { font-size: 1.45rem; }
       .hero { padding: 16px 18px; margin-bottom: 16px; }
       .card, details.panel { padding: 14px 16px; }
       table { font-size: 0.85rem; }
+      .outbox { max-height: 420px; }
     }
   </style>
 </head>
@@ -276,7 +297,7 @@
         <p class="muted" id="healthLine" style="margin:8px 0 0">—</p>
       </div>
 
-      <details class="panel events-panel" id="eventsPanel">
+      <details class="panel events-panel" id="eventsPanel" open>
         <summary>Recent events</summary>
         <div id="eventsBox" class="empty">—</div>
       </details>
@@ -418,10 +439,9 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
       $("url").value = url || "";
       $("token").value = localStorage.getItem(KEYS.token) || "";
       $("refresh").value = localStorage.getItem(KEYS.refresh) || "10";
-      // Collapsed by default; only open connection panel if no token yet
-      $("settingsPanel").open = false;
-      if (!$("token").value) $("settingsPanel").open = true;
-      if (imported) $("settingsPanel").open = false;
+      // Start expanded; keep connection open after QR import so user can verify
+      $("settingsPanel").open = true;
+      $("eventsPanel").open = true;
       return imported;
     }
     function fmtUptime(sec) {
@@ -675,7 +695,6 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
       $("adminMount").innerHTML = "";
       schedule();
       refresh();
-      $("settingsPanel").open = false;
     };
     $("refreshBtn").onclick = () => refresh();
     $("shareBtn").onclick = () => showQr();


### PR DESCRIPTION
## Summary
- Start all ops collapsible panels expanded (connection, events, admin modules)
- Desktop CSS: wider wrap, stretch overview grid, identity full-width, safer minmax columns

## Test plan
- [ ] Open /ops on desktop — panels open, overview 3-col layout stable
- [ ] Collapse/expand still works via summary click
- [ ] Mobile single-column unchanged