### PR TITLE
Deeper docs + Grokpedia links; calmer ops theme

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,5 +20,10 @@ The `/ops` console links into the user guide anchors, for example:
 - https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#listeners  
 - https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#c2-profiles  
 - https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#admin-ai  
+- https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#payloads-and-implants  
 
 Full index of sections is the heading list in [user-guide.md](user-guide.md).
+
+## External concept primers (Grokpedia)
+
+The user guide links to [Grokpedia](https://grok.com/pedia) for industry definitions (C2, payload, implant, reverse shell, beacon, etc.). Those pages are **not** hosted by SquidC5 and are not required to operate the product.

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,17 +13,41 @@ This guide lives in the GitHub repository. It is **not** served by the C2 proces
 | [Threat model](threat-model.md) | Trust boundaries |
 | [Roadmap](roadmap-2026-2027.md) | Planned work |
 
+### Concepts primer (Grokpedia)
+
+Background reading for operators who want the *security-industry* meaning of a term, not just SquidC5 UI steps. These open **[Grokpedia](https://grok.com/pedia)** concept pages (external). SquidC5 still only runs under **authorized** ROE.
+
+| Concept | Why it matters here | Grokpedia |
+|---------|---------------------|-----------|
+| Command and control (C2) | Overall role of SquidC5 as a team server | [command-and-control](https://grok.com/pedia/command-and-control) · [c2](https://grok.com/pedia/c2) |
+| Red team | Authorized adversarial simulation | [red-team](https://grok.com/pedia/red-team) |
+| Penetration testing | Scoped offensive assessment | [penetration-testing](https://grok.com/pedia/penetration-testing) |
+| Payload | Delivered code/stage that runs on a target | [payload](https://grok.com/pedia/payload) |
+| Implant | Persistent or resident agent on a target | [implant](https://grok.com/pedia/implant) |
+| Beacon | Periodic check-in style implant | [beacon](https://grok.com/pedia/beacon) |
+| Reverse shell | Target connects *out* to operator listener | [reverse-shell](https://grok.com/pedia/reverse-shell) |
+| DNS tunneling | Covert channel over DNS | [dns-tunneling](https://grok.com/pedia/dns-tunneling) |
+| WebSocket | Bidirectional web channel (WS beacons) | [websocket](https://grok.com/pedia/websocket) |
+| Phishing | Credential/payload delivery vector (authorized only) | [phishing](https://grok.com/pedia/phishing) |
+| Model Context Protocol | External tool bridge pattern (MCP panel) | [model-context-protocol](https://grok.com/pedia/model-context-protocol) |
+
+If a Grokpedia slug 404s or is empty (SPA), search from [grok.com/pedia](https://grok.com/pedia) for the term. Industry references also: [MITRE ATT&CK — Command and Control](https://attack.mitre.org/tactics/TA0011/).
+
 ---
 
 ## Overview
 
 ### What SquidC5 is
 
-SquidC5 is a **security-first, AI-native command-and-control (C2)** platform for **authorized** engagements. Operators use:
+SquidC5 is a **security-first, AI-native command-and-control (C2)** platform for **authorized** engagements. In industry language, a C2 *team server* is the hub operators use to task implants, receive output, and manage listeners during a red-team or pen-test. SquidC5 implements that hub with strong defaults (scoped tokens, audit, AI rails).
+
+Operators use:
 
 - **REST API** (scoped tokens)
 - **Ops UI** at `/ops` (browser console)
 - **CLI** `sc5` / `squidc5-cli`
+
+**Learn more:** [Grokpedia: command-and-control](https://grok.com/pedia/command-and-control) · [red-team](https://grok.com/pedia/red-team)
 
 ### Why it is designed this way
 
@@ -31,6 +55,7 @@ SquidC5 is a **security-first, AI-native command-and-control (C2)** platform for
 - **Deterministic implants** — templates and fixed generators over free-form agent loops
 - **Auditability** — operator, AI, MCP, and feature changes go through policy/audit
 - **Port flexibility** — no hard requirement for 80/443
+- **Dual AI** — external models stay on allow-listed MCP tools; Admin AI stays capability-gated and sanitizes untrusted input
 
 ### High-level architecture
 
@@ -42,6 +67,16 @@ Operator (CLI /ops)
         → SQLite data/ (local, never commit)
 Implants / reverse shells → Listeners → Sessions
 ```
+
+### Engagement lifecycle (mental model)
+
+1. **Stand up** team server + admin token  
+2. **Open listeners** for the channels you will use  
+3. **Generate payloads/implants** pointed at those listeners (and active C2 profile if HTTP)  
+4. **Execute only on authorized targets** per ROE  
+5. **Operate** via Shell (interactive) or Tasks (beacon queue)  
+6. **Observe** metrics/audit/events; hand off via chat/report  
+7. **Tear down** listeners, revoke tokens, preserve audit as required  
 
 ---
 
@@ -196,9 +231,19 @@ sc5 whoami
 
 Interactive command runner for **verified reverse shells** only.
 
+A **reverse shell** is a pattern where the *target* initiates a connection *outbound* to your listener, then presents a remote command line. That is the opposite of a bind shell (target listens). Outbound connections often pass egress firewalls more easily during authorized tests.
+
+**Learn more:** [Grokpedia: reverse-shell](https://grok.com/pedia/reverse-shell)
+
 ### Why
 
-Unverified or echo-only sockets are dangerous noise (scanners, TLS handshakes). Exec probe + false-shell filter ensure only real shells get operator commands.
+Unverified or echo-only sockets are dangerous noise (Internet scanners, TLS ClientHellos, HTTP probes on common ports). SquidC5:
+
+1. **Classifies** inbound bytes (drops obvious non-shells)
+2. **Exec-probes** the channel (must run a real command)
+3. Marks sessions **verified** only if the probe succeeds  
+
+Only then does the Shell panel accept operator commands.
 
 ### How
 
@@ -206,6 +251,8 @@ Unverified or echo-only sockets are dangerous noise (scanners, TLS handshakes). 
 2. Select session → enter command → **Run**.
 3. **All verified** broadcasts to every verified shell.
 4. **Buffer** reads captured session output (`GET /api/v1/sessions/{id}/output`).
+
+Not a full interactive PTY multiplexer: commands are sent, output is collected with wait/idle windows. Prefer short commands; long interactive programs may not behave like a local terminal.
 
 ### Example
 
@@ -220,7 +267,7 @@ sc5 shell all "id"
 
 ### Why stage-2 stabilize
 
-Raw reverse shells die on network blips. Auto-stabilize injects a reconnecting agent (Linux Python / Windows PowerShell) that re-checks in and supports reliable command execution.
+Raw reverse shells die on network blips and often lack a clean line protocol. Auto-stabilize injects a reconnecting agent (Linux Python / Windows PowerShell) that re-checks in to `SQUIDC5_PUBLIC_HOST:<port>` and supports reliable command execution. Stage-2 reconnects skip re-staging (banner skip).
 
 ---
 
@@ -228,11 +275,17 @@ Raw reverse shells die on network blips. Auto-stabilize injects a reconnecting a
 
 ### What
 
-All tracked implant/shell connections (beacons, reverse shells, closed).
+All tracked implant/shell connections (beacons, reverse shells, closed). A **session** is SquidC5’s first-class object for “something on a target that can be tasked or shelled.”
 
 ### Why
 
-Sessions are the unit of tasking and shell interaction. Reaping drops zombies so operators are not fooled by “live but mute” entries.
+Sessions unify:
+
+- Interactive reverse shells  
+- Beacon implants (HTTP/DNS/WS)  
+- Lifecycle (active / closed / rejected)  
+
+Reaping drops zombies so operators are not fooled by “live but mute” entries.
 
 ### How
 
@@ -251,6 +304,13 @@ sc5 sessions reap
 sc5 sessions close <id>
 ```
 
+### Session kinds (operator view)
+
+| Kind | Interaction model |
+|------|-------------------|
+| `reverse_shell` / `tcp` | Prefer **Shell** panel after `verified: true` |
+| `beacon` (HTTP/DNS/WS) | Prefer **Tasks** queue; poll for results |
+
 ---
 
 ## Tasks
@@ -259,15 +319,21 @@ sc5 sessions close <id>
 
 Async command queue for **beacon** implants (not interactive reverse shells).
 
+A **beacon** is an implant that periodically *checks in* to C2, asks for work, and returns results—classic low-and-slow C2 rather than a permanent interactive shell.
+
+**Learn more:** [Grokpedia: beacon](https://grok.com/pedia/beacon) · [implant](https://grok.com/pedia/implant)
+
 ### Why
 
-Beacons check in on a schedule. Tasks wait until the next poll, then return results — suitable for intermittent/low-and-slow C2.
+Beacons sleep between check-ins (interval + optional jitter via profiles). Tasks wait until the next poll, then return results—suitable for intermittent connectivity and reduced network chatter during authorized ops.
 
 ### How
 
 1. Get beacon `session_id` from sessions list.
 2. Create task with command.
-3. Poll task status until complete.
+3. Poll task status until complete (`pending` → `running`/`complete`).
+
+Do **not** use Shell for pure beacons; use Tasks.
 
 ### Example
 
@@ -277,31 +343,42 @@ sc5 tasks get <task_id>
 sc5 tasks list --session <beacon_session_id>
 ```
 
+### Lifecycle detail
+
+```text
+Operator creates task → stored in DB
+Beacon check-in → claims task → runs command on target
+Beacon posts result → task complete → operator reads output
+```
+
 ---
 
 ## Listeners
 
 ### What
 
-Server-side acceptors for implant traffic.
+Server-side acceptors for implant traffic—the sockets (or protocol handlers) bound on the team server (or host network) that wait for targets to connect or query.
 
 ### Why
 
-Different channels need different sockets: raw TCP shells vs HTTP beacons vs DNS.
+Different channels need different handlers:
+
+| Kind | Use | Industry context |
+|------|-----|------------------|
+| `reverse_shell` | bash `/dev/tcp`, python reverse shells | Classic reverse shell |
+| `http` | HTTP beacon check-ins | Web-looking C2 |
+| `tcp` | Generic TCP channel | Raw framing |
+| `dns` | DNS TXT C2 (set zone) | Covert DNS channel |
+
+**Learn more:** [Grokpedia: reverse-shell](https://grok.com/pedia/reverse-shell) · [dns-tunneling](https://grok.com/pedia/dns-tunneling) · [websocket](https://grok.com/pedia/websocket)
 
 ### How to set up
 
-1. **Create** name + port + kind.
+1. **Create** name + port + kind (+ DNS zone if `dns`).
 2. **Start** until status is `running`.
-3. Open host firewall for that port.
-4. Point payloads/shells at `HOST:port`.
-
-| Kind | Use |
-|------|-----|
-| `reverse_shell` | bash `/dev/tcp`, python reverse shells |
-| `http` | HTTP beacon check-ins |
-| `tcp` | Generic TCP channel |
-| `dns` | DNS TXT C2 (set zone) |
+3. Open host firewall for that port (and UDP for DNS if applicable).
+4. Point payloads/shells at `HOST:port` (or DNS zone for DNS beacons).
+5. Confirm with Event stream / sessions list.
 
 ### Privileged ports
 
@@ -318,24 +395,48 @@ sc5 listeners list
 
 Docker **host** networking binds real host ports. Bridge mode requires publishing every listener port.
 
+### Common failure modes
+
+| Symptom | Check |
+|---------|--------|
+| Listener created but not `running` | Start failed—port in use, privilege, bind host |
+| Target cannot connect | Firewall, NAT, wrong public host, wrong port |
+| Flood of rejections | Scanners hitting the port—expected; false-shell filter works |
+
 ---
 
 ## Payloads and implants
 
 ### What
 
-Deterministic stagers/agents that call back to your listeners.
+**Payloads** are the generated scripts/binaries you deliver to an authorized target. **Implants** are the resident agents those payloads become once running—beacons, memory-resident helpers, stagers, etc.
+
+In SquidC5, generators are **deterministic templates**: same inputs → reviewable output you can diff and archive for the engagement file.
+
+**Learn more:** [Grokpedia: payload](https://grok.com/pedia/payload) · [implant](https://grok.com/pedia/implant) · [beacon](https://grok.com/pedia/beacon)
 
 ### Why
 
-Generated payloads are reviewable and reproducible. Prefer templates over opaque loaders for authorized ops and audit.
+- **Auditability** — know exactly what you executed  
+- **Reproducibility** — regenerate for a new host/port without mystery tooling  
+- **Channel match** — reverse-shell templates need reverse-shell listeners; HTTP beacons need HTTP (+ profile shape)  
+- **OpSec** — pair with [C2 profiles](#c2-profiles) so HTTP traffic is not a default fingerprint  
 
 ### How
 
-1. Choose template or implant family.
+1. Choose **template** or **implant family**.
 2. Set callback **host** and **port** (scheme/zone if needed).
-3. **Generate** and run **only on authorized targets**.
-4. For HTTP surface shape, activate a **C2 profile** first, then generate.
+3. Prefer activating a **C2 profile** first for HTTP surface shape.
+4. **Generate** → review output → stage via approved delivery (never outside ROE).
+5. Confirm check-in on Event stream / Sessions.
+
+### Stager vs full implant (concept)
+
+| Stage | Role in SquidC5 |
+|-------|-----------------|
+| Stager / template | Small first stage (`reverse_shell_*`, simple beacons) |
+| Stage-2 stabilize | Server-injected reconnect agent on captured shells |
+| Implant family | Higher-level generators (`http_beacon`, `dns_beacon`, `linux_memfd`, `bof`, …) |
 
 ### Example templates
 
@@ -345,12 +446,23 @@ Generated payloads are reviewable and reproducible. Prefer templates over opaque
 | `http_beacon_python` / `http_beacon_bash` | `http` (often on API port) |
 | `dns_beacon_python` | `dns` + zone |
 | `ws_beacon_python` | WebSocket routes |
+| `memory_beacon_python` / `linux_memfd` | Evasion-oriented Linux paths |
+| `windows_ps_beacon` | Windows PowerShell beacon |
+| `bof_c` | BOF-style C skeleton (advanced) |
 
 ```bash
 sc5 payloads templates
 sc5 payloads generate reverse_shell_bash 203.0.113.10 4444 --raw
 sc5 payloads generate http_beacon_python 203.0.113.10 8443 --raw
 ```
+
+### Safety checklist
+
+- [ ] Written authorization / ROE covers the target  
+- [ ] Callback host/port are *your* infrastructure  
+- [ ] Listener is `running` before execution  
+- [ ] Payload archived for the engagement record  
+- [ ] Cleanup plan exists  
 
 ---
 
@@ -430,17 +542,27 @@ UI: **Metrics** / **Audit log** buttons dump JSON into the panel outbox.
 
 ### What
 
-Sandboxed, **allow-listed** AI capabilities on the server (not free-form agents).
+Sandboxed, **allow-listed** AI capabilities on the server (not free-form agents). Capabilities are fixed functions (`recon_assist`, `shell_classify`, …) with structured inputs—not an open chat that can chain arbitrary tools.
 
 ### Why
 
-Assist recon docs, shell classification, payload hints — without feeding raw hostile session output into unconstrained agent loops. Untrusted text is sanitized.
+Assist recon notes, shell classification, payload hints, and engagement docs—without:
+
+- Feeding raw hostile session output into unconstrained agent loops  
+- Giving external models direct shell  
+- Shipping API keys back to browsers  
+
+Untrusted text is passed through `sanitize_untrusted` before prompts.
+
+**Phishing-related capabilities** exist only for **authorized** engagements (phishing simulations under ROE).  
+**Learn more:** [Grokpedia: phishing](https://grok.com/pedia/phishing)
 
 ### How
 
 1. Configure an LLM under **LLM connections** (optional).
-2. Without LLM → offline/deterministic fallbacks.
+2. Without LLM → offline/deterministic fallbacks still return structured guidance.
 3. Pick capability + input → **Run AI**.
+4. Review **Status** / **Debug** (never returns API keys).
 
 | Capability | Intent |
 |------------|--------|
@@ -542,17 +664,26 @@ Send message → stored server-side → visible to `collab:use` / admin tokens.
 
 ### What
 
-**Malleable** traffic profiles: how HTTP (and related) beacons look on the wire — paths, headers, jitter, decoy behavior.
+**Malleable C2 profiles** define the *shape* of implant traffic—especially HTTP(S): URI paths, headers, body wrapping, jitter, and decoy-friendly patterns. The *active* profile is the contract between **generators** and the **server parser**.
+
+Industry context: commercial C2 frameworks popularized “malleable profiles” so operators can mimic CDNs, APIs, or static sites instead of a fixed default URI.
+
+**Learn more:** [Grokpedia: command-and-control](https://grok.com/pedia/command-and-control) · [beacon](https://grok.com/pedia/beacon)
 
 ### Why
 
-Default C2 fingerprints are easy to detect. Profiles change the expected surface so traffic can blend with legitimate patterns for the engagement.
+Default C2 fingerprints are easy for defenders to signature. Profiles:
+
+- Change URI/header surface  
+- Support jitter so check-ins are not metronomic  
+- Align redirector configs (see [Redirector and certificates](#redirector-and-certificates))  
 
 ### How
 
 1. List profiles → **activate** one.
 2. **Generate beacon (active)** so implants match that profile.
 3. After switching profiles, **regenerate** implants — old beacons may miss the new surface.
+4. If you front with nginx/CDN, update redirector URIs to match the profile.
 
 ### Example
 
@@ -560,6 +691,14 @@ Default C2 fingerprints are easy to detect. Profiles change the expected surface
 Ops → C2 profiles → activate "jquery-cdn" → Generate beacon (active)
 # payload uses profile paths/headers; server expects the same
 ```
+
+### Operator pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| Activate profile B, keep beacons built for A | Check-ins fail or never task |
+| Redirector paths ≠ profile paths | 404 / silent drop at edge |
+| Change profile mid-op without regen | Split fleet behavior |
 
 ---
 
@@ -613,24 +752,41 @@ sc5 policy set --file rules.json
 
 ### What
 
-Bridge for **external** AI/tools (Model Context Protocol style) under per-token allow-lists.
+Bridge for **external** AI/tools using an allow-listed tool-call pattern (Model Context Protocol style). External models invoke *named tools* with JSON arguments; SquidC5 executes only tools on that token’s allow-list.
+
+**Learn more:** [Grokpedia: model-context-protocol](https://grok.com/pedia/model-context-protocol)
 
 ### Why
 
-External models must not get open-ended shell on the C2. Each tool call is single-step, scoped, and auditable. MCP is **off by default** until enabled.
+External models must not get open-ended shell on the C2. Design goals:
+
+- **Least privilege** — `mcp:connect` + explicit `mcp_tools`  
+- **Determinism** — prefer single-step tools over autonomous multi-hop agents  
+- **Audit** — each call is logged  
+- **Default off** — feature flag until an engagement needs it  
 
 ### How
 
 1. Enable MCP via features/settings when approved.
-2. Token needs `mcp:connect` + `mcp_tools` allow-list.
-3. **List tools** / **Call** with JSON args.
+2. Mint a token with `mcp:connect` and a tight `mcp_tools` list (e.g. `list_sessions`, `create_task`).
+3. **List tools** / **Call** with JSON args from Ops or CLI.
 
 ### Example
 
 ```bash
+sc5 tokens create ext-ai --scopes "mcp:connect,sessions:read,tasks:read,tasks:write,metrics:read"
+# ensure mcp_tools allow-list set via API/UI as supported
 sc5 mcp tools
 sc5 mcp call list_sessions --args-json '{}'
 ```
+
+### Contrast: MCP vs Admin AI
+
+| | Admin AI | MCP |
+|--|----------|-----|
+| Who | Operators on the team server | External models / agents |
+| Gate | `ai:use` + capability allow-list | `mcp:connect` + per-tool allow-list |
+| Default | Offline fallback if no LLM | Often feature-off |
 
 ---
 

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -68,7 +68,7 @@
   // ----- Shell interact -----
   if (can("shell:interact")) {
     parts.push(panel("quickRunCard", "⌨ Shell", `
-      ${hint("Interactive command runner for <strong>verified reverse shells</strong> only (exec-probe passed). Pick a live session, run a command, or broadcast to all verified shells. Buffer shows recent session output already captured by the server — not a live PTY stream.", "shell")}
+      ${hint("Interactive command runner for <strong>verified reverse shells</strong> only (exec-probe passed). Pick a live session, run a command, or broadcast to all verified shells. Buffer shows recent session output already captured by the server — not a live PTY stream. Background: <a class=\"doc-link\" href=\"https://grok.com/pedia/reverse-shell\" target=\"_blank\" rel=\"noopener noreferrer\">reverse shell</a>.", "shell")}
       <label for="shellSelect">Target shell</label>
       <select id="shellSelect"><option value="">(none)</option></select>
       <label for="shellCmd">Command</label>
@@ -99,7 +99,7 @@
   // ----- Tasks (beacons) -----
   if (can("tasks:read") || can("tasks:write")) {
     parts.push(panel("tasksPanel", "📋 Tasks", `
-      ${hint("Async work queue for <strong>beacon</strong> implants (not interactive reverse shells). Create a task against a beacon session id; the implant picks it up on next check-in and returns output when complete. Use List tasks to poll status.", "tasks")}
+      ${hint("Async work queue for <strong>beacon</strong> implants (not interactive reverse shells). Create a task against a beacon session id; the implant picks it up on next check-in and returns output when complete. Use List tasks to poll status. Background: <a class=\"doc-link\" href=\"https://grok.com/pedia/beacon\" target=\"_blank\" rel=\"noopener noreferrer\">beacon</a> · <a class=\"doc-link\" href=\"https://grok.com/pedia/implant\" target=\"_blank\" rel=\"noopener noreferrer\">implant</a>.", "tasks")}
       ${can("tasks:write") ? `
         <label for="taskSession">Session id</label>
         <input id="taskSession" placeholder="beacon session id" autocomplete="off" />
@@ -117,7 +117,7 @@
   // ----- Listeners -----
   if (can("listeners:read") || can("listeners:write")) {
     parts.push(panel("listenersPanel", "🎧 Listeners", `
-      ${hint("Server-side sockets that accept implant traffic. <strong>How to set up:</strong> (1) Create with a name + port + kind, (2) ensure Start shows running, (3) open the host firewall for that port, (4) point payloads/shells at this host:port. <strong>Kinds:</strong> <code>reverse_shell</code> = raw TCP shells (bash /dev/tcp, etc.); <code>http</code> = HTTP beacon check-ins; <code>tcp</code> = generic TCP channel; <code>dns</code> = DNS TXT C2 (set zone). Privileged ports (&lt;1024) need host sysctl if the process is non-root.", "listeners")}
+      ${hint("Server-side sockets that accept implant traffic. <strong>How to set up:</strong> (1) Create with a name + port + kind, (2) ensure Start shows running, (3) open the host firewall for that port, (4) point payloads/shells at this host:port. <strong>Kinds:</strong> <code>reverse_shell</code> = raw TCP shells; <code>http</code> = HTTP beacons; <code>tcp</code> = generic TCP; <code>dns</code> = DNS TXT C2 (set zone). Privileged ports (&lt;1024) need host sysctl if non-root. Background: <a class=\"doc-link\" href=\"https://grok.com/pedia/reverse-shell\" target=\"_blank\" rel=\"noopener noreferrer\">reverse shell</a> · <a class=\"doc-link\" href=\"https://grok.com/pedia/dns-tunneling\" target=\"_blank\" rel=\"noopener noreferrer\">DNS tunneling</a>.", "listeners")}
       <label for="listenerSelect">Listener</label>
       <select id="listenerSelect"><option value="">(none)</option></select>
       ${can("listeners:write") ? `
@@ -150,7 +150,7 @@
   // ----- Payloads -----
   if (can("payloads:generate")) {
     parts.push(panel("payloadsPanel", "💣 Payloads / implants", `
-      ${hint("Deterministic stagers/agents that call back to your listeners. Pick a template (or implant family), set callback host/port (and scheme/zone if needed), Generate, then run only on authorized targets. Reverse-shell templates need a <code>reverse_shell</code> listener; HTTP/DNS/WS beacons need matching listener kinds and usually an active C2 profile for HTTP surface shape.", "payloads-and-implants")}
+      ${hint("Deterministic stagers/agents that call back to your listeners. Pick a template (or implant family), set callback host/port (and scheme/zone if needed), Generate, then run only on authorized targets. Reverse-shell templates need a <code>reverse_shell</code> listener; HTTP/DNS/WS beacons need matching listener kinds and usually an active C2 profile for HTTP surface shape. Background: <a class=\"doc-link\" href=\"https://grok.com/pedia/payload\" target=\"_blank\" rel=\"noopener noreferrer\">payload</a> · <a class=\"doc-link\" href=\"https://grok.com/pedia/implant\" target=\"_blank\" rel=\"noopener noreferrer\">implant</a> · <a class=\"doc-link\" href=\"https://grok.com/pedia/beacon\" target=\"_blank\" rel=\"noopener noreferrer\">beacon</a>.", "payloads-and-implants")}
       <label for="payTpl">Template</label>
       <select id="payTpl">
         <option value="http_beacon_python">http_beacon_python</option>
@@ -245,7 +245,7 @@
   // ----- Admin AI -----
   if (can("ai:use")) {
     parts.push(panel("aiCard", "✨ Admin AI", `
-      ${hint("Sandboxed, allow-listed AI capabilities on the server (not free-form agents). Uses your configured LLM if present, otherwise offline/deterministic fallbacks. Untrusted session text is sanitized before prompts. Pick a capability, pass structured input, Run AI — results are auditable.", "admin-ai")}
+      ${hint("Sandboxed, allow-listed AI capabilities on the server (not free-form agents). Uses your configured LLM if present, otherwise offline/deterministic fallbacks. Untrusted session text is sanitized before prompts. Pick a capability, pass structured input, Run AI — results are auditable. Phishing-related caps are for <strong>authorized</strong> sims only — <a class=\"doc-link\" href=\"https://grok.com/pedia/phishing\" target=\"_blank\" rel=\"noopener noreferrer\">phishing</a>.", "admin-ai")}
       <div class="stats" style="margin-bottom:8px">
         <div class="stat"><div class="n" id="aiStatusN" style="font-size:0.95rem">—</div><div class="l">Status</div></div>
         <div class="stat"><div class="n" id="aiModeN" style="font-size:0.95rem">—</div><div class="l">Mode</div></div>
@@ -356,7 +356,7 @@
   // ----- C2 Profiles -----
   if (can("profiles:read") || can("admin")) {
     parts.push(panel("profilesPanel", "📡 C2 profiles", `
-      ${hint("<strong>What they are:</strong> malleable traffic profiles that define how HTTP (and related) beacons look on the wire — paths, headers, jitter, decoy behavior — so C2 blends with legitimate traffic. <strong>What they do:</strong> the active profile is the surface generators and the server expect for implant check-ins. Activate a profile, then Generate beacon (active) so payloads match that profile. Switching profiles mid-op changes the expected beacon shape; regenerate implants after a switch.", "c2-profiles")}
+      ${hint("<strong>What they are:</strong> malleable traffic profiles that define how HTTP (and related) beacons look on the wire — paths, headers, jitter, decoy behavior — so C2 blends with legitimate traffic. <strong>What they do:</strong> the active profile is the surface generators and the server expect for implant check-ins. Activate a profile, then Generate beacon (active) so payloads match that profile. Switching profiles mid-op changes the expected beacon shape; regenerate implants after a switch. Background: <a class=\"doc-link\" href=\"https://grok.com/pedia/command-and-control\" target=\"_blank\" rel=\"noopener noreferrer\">C2</a> · <a class=\"doc-link\" href=\"https://grok.com/pedia/beacon\" target=\"_blank\" rel=\"noopener noreferrer\">beacon</a>.", "c2-profiles")}
       <div id="profList" class="empty">—</div>
       <div class="row" style="margin-top:8px">
         <button type="button" id="profReloadBtn">Reload</button>
@@ -397,7 +397,7 @@
   // ----- MCP -----
   if (can("mcp:connect")) {
     parts.push(panel("mcpPanel", "🔌 MCP tools", `
-      ${hint("External AI / MCP bridge: tools exposed to models under a per-token allow-list (not open-ended autonomy). List tools shows what this token may call; Call runs one tool with JSON args. MCP is off by default until features/settings enable it.", "mcp-tools")}
+      ${hint("External AI / MCP bridge: tools exposed to models under a per-token allow-list (not open-ended autonomy). List tools shows what this token may call; Call runs one tool with JSON args. MCP is off by default until features/settings enable it. Background: <a class=\"doc-link\" href=\"https://grok.com/pedia/model-context-protocol\" target=\"_blank\" rel=\"noopener noreferrer\">Model Context Protocol</a>.", "mcp-tools")}
       <div class="row">
         <button type="button" id="mcpToolsBtn">List tools</button>
       </div>

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -4,35 +4,31 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="theme-color" content="#140814" />
+  <meta name="theme-color" content="#09090b" />
   <link rel="icon" href="https://i.imgur.com/m1FBjqj.png" type="image/png" />
   <link rel="stylesheet" href="https://squidoffense.com/css/typography.css" />
   <title>SquidC5</title>
   <style>
     :root {
-      --pink: #ff2ec4;
-      --pink-hot: #ff5ad5;
-      --purple: #e040ff;
-      --ok: #3dffa8;
-      --warn: #ffd23f;
-      --bad: #ff6b8a;
-      --cyan: #22d3ee;
-      --muted: #b4b4be;
-      --border: rgba(255, 80, 200, 0.22);
-      --card: rgba(22, 10, 28, 0.94);
-      --glow: 0 0 28px rgba(255, 46, 196, 0.35);
+      --pink: #e91e8c;
+      --pink-hot: #f472b6;
+      --purple: #a855f7;
+      --ok: #34d399;
+      --warn: #fbbf24;
+      --bad: #f87171;
+      --cyan: #38bdf8;
+      --muted: #a1a1aa;
+      --border: rgba(255, 255, 255, 0.1);
+      --card: rgba(24, 24, 27, 0.92);
+      --glow: none;
       --radius: 14px;
       --font: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Arial, sans-serif;
       --mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     }
     * { box-sizing: border-box; }
     body {
-      margin: 0; font-family: var(--font); color: #fff;
-      background:
-        radial-gradient(1200px 600px at 10% -10%, rgba(255, 46, 196, 0.22), transparent 55%),
-        radial-gradient(900px 500px at 100% 0%, rgba(224, 64, 255, 0.16), transparent 50%),
-        radial-gradient(800px 400px at 50% 100%, rgba(61, 255, 168, 0.06), transparent 45%),
-        linear-gradient(180deg, #050008 0%, #140814 45%, #0a0610 100%);
+      margin: 0; font-family: var(--font); color: #f4f4f5;
+      background: linear-gradient(180deg, #09090b 0%, #121016 55%, #0c0a0f 100%);
       min-height: 100dvh;
       padding: max(12px, env(safe-area-inset-top)) 12px calc(20px + env(safe-area-inset-bottom));
     }
@@ -47,55 +43,53 @@
     /* Full-width work surfaces (used by multi-column layouts) */
     .col-span-all { width: 100%; }
 
-    .brand img { width: 48px; height: 48px; object-fit: contain; filter: drop-shadow(0 0 18px var(--pink)); }
+    .brand img { width: 48px; height: 48px; object-fit: contain; filter: drop-shadow(0 0 8px rgba(233,30,140,0.35)); }
     .brand h1 { margin: 0; font-size: 1.25rem; letter-spacing: -0.02em; }
-    .brand h1 .p { color: var(--pink-hot); text-shadow: 0 0 14px var(--pink), 0 0 28px rgba(255,46,196,0.5); }
+    .brand h1 .p { color: var(--pink); text-shadow: none; }
     .brand .sub { font-size: 0.68rem; color: var(--muted); letter-spacing: 0.12em; text-transform: uppercase; }
     .badge {
       margin-left: auto; font: 700 0.65rem/1 var(--mono); letter-spacing: 0.06em;
       text-transform: uppercase; padding: 6px 10px; border-radius: 8px;
-      border: 1px solid rgba(255,255,255,0.2); color: var(--muted);
+      border: 1px solid rgba(255,255,255,0.16); color: var(--muted);
     }
-    .badge.ok { color: var(--ok); border-color: rgba(61,255,168,0.55); box-shadow: 0 0 12px rgba(61,255,168,0.25); }
-    .badge.bad { color: var(--bad); border-color: rgba(255,107,138,0.55); box-shadow: 0 0 12px rgba(255,107,138,0.2); }
-    .badge.admin { color: var(--pink-hot); border-color: rgba(255,46,196,0.55); margin-left: 6px; box-shadow: 0 0 12px rgba(255,46,196,0.25); }
+    .badge.ok { color: var(--ok); border-color: rgba(52,211,153,0.35); }
+    .badge.bad { color: var(--bad); border-color: rgba(248,113,113,0.35); }
+    .badge.admin { color: var(--pink-hot); border-color: rgba(233,30,140,0.35); margin-left: 6px; }
     .hero {
-      border: 1px solid rgba(255,46,196,0.55); border-radius: 16px; padding: 12px;
-      margin-bottom: 12px; background: linear-gradient(145deg, rgba(40,8,28,0.95), rgba(12,6,18,0.96));
-      position: relative; box-shadow: var(--glow), inset 0 0 40px rgba(255,46,196,0.06);
+      border: 1px solid rgba(233,30,140,0.28); border-radius: 16px; padding: 12px;
+      margin-bottom: 12px; background: rgba(18,18,22,0.95);
+      position: relative;
     }
     .hero::before {
-      content: ""; position: absolute; top: 0; left: 0; width: 4px; height: 100%;
+      content: ""; position: absolute; top: 0; left: 0; width: 3px; height: 100%;
       border-radius: 16px 0 0 16px;
-      background: linear-gradient(180deg, var(--pink-hot), var(--purple), var(--cyan));
-      box-shadow: 0 0 16px var(--pink);
+      background: var(--pink);
+      box-shadow: none;
     }
-    .hero-host { font: 0.85rem var(--mono); color: var(--pink-hot); word-break: break-all; margin-bottom: 10px; text-shadow: 0 0 12px rgba(255,46,196,0.45); }
+    .hero-host { font: 0.85rem var(--mono); color: var(--pink-hot); word-break: break-all; margin-bottom: 10px; }
     .stats { display: grid; grid-template-columns: repeat(3, 1fr); gap: 8px; }
     .stat {
-      background: linear-gradient(160deg, rgba(255,46,196,0.12), rgba(0,0,0,0.45));
-      border: 1px solid rgba(255,46,196,0.28); border-radius: 12px;
+      background: rgba(0,0,0,0.35);
+      border: 1px solid var(--border); border-radius: 12px;
       padding: 10px 6px; text-align: center;
-      box-shadow: inset 0 0 20px rgba(255,46,196,0.06);
     }
-    .stat .n { font-size: 1.35rem; font-weight: 800; color: #fff; text-shadow: 0 0 12px rgba(255,255,255,0.15); }
+    .stat .n { font-size: 1.35rem; font-weight: 800; color: #fafafa; text-shadow: none; }
     .stat .l { font-size: 0.62rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin-top: 2px; }
-    .stat.tone-ok { border-color: rgba(61,255,168,0.4); background: linear-gradient(160deg, rgba(61,255,168,0.14), rgba(0,0,0,0.45)); }
-    .stat.tone-ok .n { color: var(--ok); text-shadow: 0 0 14px rgba(61,255,168,0.45); }
-    .stat.tone-pink { border-color: rgba(255,46,196,0.5); }
-    .stat.tone-pink .n { color: var(--pink-hot); text-shadow: 0 0 14px rgba(255,46,196,0.5); }
-    .stat.tone-purple { border-color: rgba(224,64,255,0.45); background: linear-gradient(160deg, rgba(224,64,255,0.14), rgba(0,0,0,0.45)); }
-    .stat.tone-purple .n { color: #f0abfc; text-shadow: 0 0 14px rgba(224,64,255,0.45); }
-    .stat.tone-cyan { border-color: rgba(34,211,238,0.4); background: linear-gradient(160deg, rgba(34,211,238,0.12), rgba(0,0,0,0.45)); }
-    .stat.tone-cyan .n { color: var(--cyan); text-shadow: 0 0 14px rgba(34,211,238,0.4); }
-    .stat.tone-warn { border-color: rgba(255,210,63,0.4); background: linear-gradient(160deg, rgba(255,210,63,0.1), rgba(0,0,0,0.45)); }
-    .stat.tone-warn .n { color: var(--warn); text-shadow: 0 0 12px rgba(255,210,63,0.35); }
-    .stat.tone-bad { border-color: rgba(255,107,138,0.4); background: linear-gradient(160deg, rgba(255,107,138,0.12), rgba(0,0,0,0.45)); }
-    .stat.tone-bad .n { color: var(--bad); text-shadow: 0 0 12px rgba(255,107,138,0.35); }
+    .stat.tone-ok { border-color: rgba(52,211,153,0.28); }
+    .stat.tone-ok .n { color: var(--ok); text-shadow: none; }
+    .stat.tone-pink { border-color: rgba(233,30,140,0.3); }
+    .stat.tone-pink .n { color: var(--pink-hot); text-shadow: none; }
+    .stat.tone-purple { border-color: rgba(168,85,247,0.28); }
+    .stat.tone-purple .n { color: #d8b4fe; text-shadow: none; }
+    .stat.tone-cyan { border-color: rgba(56,189,248,0.28); }
+    .stat.tone-cyan .n { color: var(--cyan); text-shadow: none; }
+    .stat.tone-warn { border-color: rgba(251,191,36,0.28); }
+    .stat.tone-warn .n { color: var(--warn); text-shadow: none; }
+    .stat.tone-bad { border-color: rgba(248,113,113,0.28); }
+    .stat.tone-bad .n { color: var(--bad); text-shadow: none; }
     .card {
       background: var(--card); border: 1px solid var(--border); border-radius: var(--radius);
       padding: 12px; margin-bottom: 10px;
-      box-shadow: 0 0 20px rgba(255,46,196,0.08);
     }
     .card h2 {
       margin: 0 0 8px; font-size: 0.72rem; letter-spacing: 0.12em;
@@ -105,29 +99,29 @@
     .hint {
       color: var(--muted); font-size: 0.78rem; line-height: 1.45;
       margin: 0 0 10px; padding: 8px 10px;
-      background: rgba(255,46,196,0.08); border-left: 3px solid var(--pink);
+      background: rgba(255,255,255,0.03); border-left: 3px solid rgba(233,30,140,0.55);
       border-radius: 0 8px 8px 0;
     }
     .hint code {
-      font-family: var(--mono); font-size: 0.72rem; color: #f9a8ff;
+      font-family: var(--mono); font-size: 0.72rem; color: #e9d5ff;
     }
     .hint strong { color: #e4e4e7; font-weight: 700; }
     a.doc-link {
-      color: var(--pink-hot); font-weight: 700; text-decoration: none;
-      border-bottom: 1px solid rgba(255,46,196,0.45);
+      color: var(--pink-hot); font-weight: 600; text-decoration: none;
+      border-bottom: 1px solid rgba(233,30,140,0.35);
     }
-    a.doc-link:hover { color: #fff; border-bottom-color: var(--pink-hot); text-shadow: 0 0 10px rgba(255,46,196,0.5); }
+    a.doc-link:hover { color: #fff; border-bottom-color: var(--pink-hot); }
     a.doc-link.summary-doc {
       font: 700 0.65rem/1 var(--mono); letter-spacing: 0.06em; text-transform: uppercase;
-      border: 1px solid rgba(255,46,196,0.4); border-radius: 6px; padding: 4px 8px;
-      border-bottom: 1px solid rgba(255,46,196,0.4); flex-shrink: 0;
-      background: rgba(255,46,196,0.1);
+      border: 1px solid rgba(255,255,255,0.14); border-radius: 6px; padding: 4px 8px;
+      border-bottom: 1px solid rgba(255,255,255,0.14); flex-shrink: 0;
+      background: rgba(255,255,255,0.04); color: var(--muted);
     }
-    a.doc-link.summary-doc:hover { background: rgba(255,46,196,0.22); }
+    a.doc-link.summary-doc:hover { color: var(--pink-hot); border-color: rgba(233,30,140,0.4); background: rgba(233,30,140,0.08); }
     .mono { font-family: var(--mono); font-size: 0.75rem; word-break: break-all; }
     table { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
-    th, td { text-align: left; padding: 8px 4px; border-bottom: 1px solid rgba(255,0,170,0.1); vertical-align: top; }
-    th { color: #ff9aef; font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    th, td { text-align: left; padding: 8px 4px; border-bottom: 1px solid rgba(255,255,255,0.06); vertical-align: top; }
+    th { color: #d4d4d8; font-size: 0.65rem; text-transform: uppercase; letter-spacing: 0.05em; }
     tr:last-child td { border-bottom: 0; }
     .pill {
       display: inline-block; font: 700 0.62rem var(--mono); padding: 2px 6px;
@@ -141,12 +135,11 @@
       --panel-head-h: 40px;
     }
     details.panel {
-      background: linear-gradient(165deg, rgba(36,12,32,0.96), rgba(14,8,20,0.96));
-      border: 1px solid rgba(255,46,196,0.28);
+      background: var(--card);
+      border: 1px solid var(--border);
       border-radius: var(--radius);
       padding: 10px 12px; margin-bottom: 10px;
       box-sizing: border-box;
-      box-shadow: 0 0 22px rgba(255,46,196,0.1);
     }
     details.panel summary {
       cursor: pointer; font-weight: 700; font-size: 0.9rem; list-style: none;
@@ -161,7 +154,7 @@
       transition: transform 0.12s ease;
     }
     details.panel[open] summary::before { transform: rotate(90deg); }
-    details.panel[open] summary { margin-bottom: 6px; color: var(--pink); }
+    details.panel[open] summary { margin-bottom: 6px; color: var(--pink-hot); }
     details.panel .panel-title { flex: 1; min-width: 0; }
     /* Equal-size open tiles; body scrolls when content overflows.
        Use grid (not flex) — details+flex overflow is unreliable in Chromium. */
@@ -205,7 +198,7 @@
       overscroll-behavior: auto;
       -webkit-overflow-scrolling: touch;
       scrollbar-width: thin;
-      scrollbar-color: rgba(255,0,170,0.45) rgba(0,0,0,0.2);
+      scrollbar-color: rgba(233,30,140,0.35) rgba(0,0,0,0.2);
       padding-right: 4px;
       padding-bottom: 28px;
       box-sizing: border-box;
@@ -232,7 +225,7 @@
       padding-bottom: 40px;
     }
     details.panel > .panel-body.scroll-focus {
-      outline: 1px solid rgba(255,0,170,0.25);
+      outline: 1px solid rgba(233,30,140,0.25);
       outline-offset: -1px;
       overscroll-behavior: contain;
     }
@@ -256,23 +249,23 @@
       background: rgba(255,255,255,0.06); color: var(--muted);
       cursor: pointer; box-shadow: none !important;
     }
-    .wide-btn:hover { color: var(--pink); border-color: rgba(255,0,170,0.4); }
+    .wide-btn:hover { color: var(--pink-hot); border-color: rgba(233,30,140,0.35); }
     details.panel.is-wide .wide-btn {
-      color: var(--pink); border-color: rgba(255,0,170,0.45);
-      background: rgba(255,0,170,0.12);
+      color: var(--pink-hot); border-color: rgba(233,30,140,0.4);
+      background: rgba(233,30,140,0.1);
     }
     .drag-handle {
       cursor: grab; color: var(--muted); font: 700 0.85rem/1 var(--mono);
       letter-spacing: -0.08em; padding: 4px 6px; margin: -4px 0 -4px -2px;
       border-radius: 6px; flex-shrink: 0; touch-action: none;
     }
-    .drag-handle:hover { color: var(--pink); background: rgba(255,0,170,0.12); }
+    .drag-handle:hover { color: var(--pink-hot); background: rgba(233,30,140,0.1); }
     .drag-handle:active { cursor: grabbing; }
     details.panel.is-dragging {
-      opacity: 0.55; outline: 1px dashed rgba(255,0,170,0.55);
+      opacity: 0.55; outline: 1px dashed rgba(233,30,140,0.45);
     }
     details.panel.drag-over {
-      box-shadow: 0 0 0 2px rgba(255,0,170,0.45);
+      box-shadow: 0 0 0 2px rgba(233,30,140,0.35);
     }
     .layout-hint {
       font-size: 0.68rem; color: var(--muted); margin: 0 0 8px;
@@ -288,7 +281,7 @@
     }
     textarea { min-height: 72px; resize: vertical; font-family: var(--mono); font-size: 0.85rem; }
     input:focus, select:focus, textarea:focus {
-      outline: none; border-color: var(--pink); box-shadow: 0 0 0 3px rgba(255,0,170,0.15);
+      outline: none; border-color: rgba(233,30,140,0.55); box-shadow: 0 0 0 2px rgba(233,30,140,0.12);
     }
     .row { display: flex; gap: 8px; margin-top: 10px; flex-wrap: wrap; }
     button {
@@ -297,10 +290,11 @@
       padding: 11px 12px; font: 700 0.85rem var(--font); cursor: pointer;
     }
     button.primary {
-      background: linear-gradient(135deg, var(--pink-hot), var(--purple));
-      color: #120018; border-color: transparent;
-      box-shadow: 0 0 24px rgba(255,46,196,0.55), 0 0 8px rgba(224,64,255,0.35);
+      background: var(--pink);
+      color: #fff; border-color: transparent;
+      box-shadow: none;
     }
+    button.primary:hover { background: #d4157a; }
     button.danger { border-color: rgba(251,113,133,0.4); color: #fecdd3; }
     button:disabled { opacity: 0.45; cursor: not-allowed; }
     button:active:not(:disabled) { transform: scale(0.98); }
@@ -317,15 +311,14 @@
     .chips { display: flex; flex-wrap: wrap; gap: 6px; }
     .chip {
       font: 0.68rem var(--mono); padding: 5px 8px; border-radius: 8px;
-      background: rgba(255,46,196,0.1); border: 1px solid rgba(255,46,196,0.35); color: #f5e1ff;
+      background: rgba(255,255,255,0.04); border: 1px solid var(--border); color: #e4e4e7;
     }
-    .chip b { color: var(--pink-hot); text-shadow: 0 0 8px rgba(255,46,196,0.4); }
+    .chip b { color: var(--pink-hot); }
     .outbox {
-      margin-top: 8px; background: #050508; border: 1px solid rgba(61,255,168,0.45);
+      margin-top: 8px; background: #0a0a0b; border: 1px solid rgba(52,211,153,0.28);
       border-radius: 10px; padding: 12px; font: 0.85rem/1.45 var(--mono);
       white-space: pre-wrap; word-break: break-word; max-height: 280px; overflow: auto;
       color: var(--ok); min-height: 3.2em;
-      box-shadow: inset 0 0 24px rgba(61,255,168,0.06);
     }
     .outbox.empty-out { color: var(--muted); border-color: var(--border); }
     .empty { color: var(--muted); font-size: 0.85rem; padding: 6px 0; }
@@ -346,11 +339,10 @@
 
     /* Live event stream (top of ops surface) */
     details.panel.event-stream {
-      background: linear-gradient(160deg, rgba(48,10,36,0.96) 0%, rgba(12,8,20,0.96) 100%);
-      border: 1px solid rgba(255,46,196,0.45);
+      background: var(--card);
+      border: 1px solid rgba(233,30,140,0.22);
       border-radius: 16px;
       margin-bottom: 12px;
-      box-shadow: 0 0 32px rgba(255,46,196,0.2), inset 0 0 40px rgba(255,46,196,0.05);
     }
     .event-stream-head {
       display: flex; align-items: center; gap: 10px; flex: 1; min-width: 0;
@@ -358,7 +350,7 @@
     }
     .event-stream-head .live-dot {
       width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
-      background: var(--ok); box-shadow: 0 0 12px var(--ok), 0 0 22px rgba(61,255,168,0.5);
+      background: var(--ok); box-shadow: 0 0 6px rgba(52,211,153,0.5);
       animation: pulse-live 1.6s ease-in-out infinite;
     }
     @keyframes pulse-live {


### PR DESCRIPTION
## Summary
- Expanded docs/user-guide.md with Grokpedia concept links
- Ops panel hints link to payload/implant/beacon/etc.
- Toned-down color theme (less neon/glow)

## Test plan
- [ ] Docs render on GitHub with working anchors
- [ ] /ops theme readable; Grokpedia links open