### PR TITLE
TLS instance certs, C5 branding, Connection toolbar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,12 @@ SQUIDC5_HOST=0.0.0.0
 SQUIDC5_PORT=8443
 SQUIDC5_DATA_DIR=data
 SQUIDC5_DEBUG=false
+# TLS: unique self-signed cert auto-generated under data/tls/ (ops, API, MCP)
+SQUIDC5_TLS_ENABLED=true
+# Optional overrides (both required if set):
+# SQUIDC5_TLS_CERT_FILE=/path/to/fullchain.pem
+# SQUIDC5_TLS_KEY_FILE=/path/to/privkey.pem
+# SQUIDC5_TLS_FORCE_NEW=false
 # Secure defaults
 SQUIDC5_MCP_ENABLED=false
 SQUIDC5_AI_ENABLED=true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Classification & Mission
 
-**SquidC5 is a military-grade, security-first, AI-native Command & Control platform under active development** for **authorized** red team, penetration testing, and defensive security operations only.
+**SquidC5 is a military-grade, security-first, AI-native C5 platform** — **Command • Control • Cognitive • Collaborative • Coordination** — under active development for **authorized** red team, penetration testing, and defensive security operations only.
 
 Treat every change as if the system will be deployed in high-threat environments:
 
@@ -340,8 +340,12 @@ pip install -r requirements-dev.txt
 pip install -e .
 pytest -q
 ruff check src tests
-uvicorn squidc5.main:create_app --factory --host 0.0.0.0 --port 8443
-sc5 login --url http://127.0.0.1:8443 --token "$(cat data/admin_token.txt)"
+# Prefer the package entrypoint (enables unique instance TLS under data/tls/):
+squidc5
+# or: python -m squidc5
+# Plain uvicorn factory has no TLS unless you pass --ssl-*:
+# uvicorn squidc5.main:create_app --factory --host 0.0.0.0 --port 8443
+sc5 login --url https://127.0.0.1:8443 --token "$(cat data/admin_token.txt)"
 ```
 
 Docker:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,22 @@
 # SquidC5
 
-**Lightweight, security-first, AI-native Command & Control for authorized red team operations.**
+**Command • Control • Cognitive • Collaborative • Coordination**
+
+Lightweight, security-first, AI-native C5 platform for authorized red team operations.
 
 [![CI](https://github.com/DotNetRussell/SquidC5/actions/workflows/ci.yml/badge.svg)](https://github.com/DotNetRussell/SquidC5/actions/workflows/ci.yml)
 
 > ⚠️ **Authorized use only.** SquidC5 is intended for legitimate penetration testing and red team engagements with explicit permission. Unauthorized access to systems is illegal.
+
+### What “C5” means
+
+| Pillar | Role in SquidC5 |
+|--------|-----------------|
+| **Command** | Operator tasking of shells, beacons, and implants |
+| **Control** | Scoped tokens, policy, feature flags, listeners |
+| **Cognitive** | Sandboxed Admin AI + restricted external MCP tools |
+| **Collaborative** | Multi-operator handoff, chat, shared sessions |
+| **Coordination** | Profiles, task queues, timelines, audit, reports |
 
 ## Features
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # SquidC5 documentation (GitHub only)
 
+**Command • Control • Cognitive • Collaborative • Coordination**
+
 These files ship in the **repository**. They are **not** exposed by the running C2 server (`/docs` and OpenAPI stay disabled).
 
 ## Start here

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -63,6 +63,35 @@ Disable unused services that might bind ports (ModemManager, etc.) on the host. 
 
 Environment variables: see `.env.example` (`SQUIDC5_*`).
 
+## TLS (HTTPS) — default on new instances
+
+On first start, SquidC5 generates a **unique self-signed certificate** under:
+
+```text
+$SQUIDC5_DATA_DIR/tls/server.crt
+$SQUIDC5_DATA_DIR/tls/server.key
+$SQUIDC5_DATA_DIR/tls/instance_id
+```
+
+All traffic on the process port (ops UI, REST API, MCP) is served over **HTTPS** via uvicorn.
+
+| Env | Default | Meaning |
+|-----|---------|---------|
+| `SQUIDC5_TLS_ENABLED` | `true` | Serve TLS |
+| `SQUIDC5_TLS_CERT_FILE` / `SQUIDC5_TLS_KEY_FILE` | unset | Use auto paths under `data/tls/` |
+| `SQUIDC5_TLS_FORCE_NEW` | `false` | Regenerate cert/key on next start |
+| `SQUIDC5_PUBLIC_HOST` | empty | Added to cert SAN when set |
+
+Browsers will warn on self-signed certs — expected. For production, put a real cert on a redirector (see Redirector / cert plan in ops) or override cert/key paths with CA-issued material.
+
+```bash
+# After start
+curl -k https://127.0.0.1:8443/api/v1/health
+# Ops: https://HOST:8443/ops  (accept warning)
+```
+
+Disable only for lab debugging: `SQUIDC5_TLS_ENABLED=false` (plaintext — not recommended).
+
 ## Production: binary-only deploy (required)
 
 Prod is **not** updated from a local working tree or Docker rebuild of WIP.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,5 +1,7 @@
 # SquidC5 Operator Runbook
 
+**Command • Control • Cognitive • Collaborative • Coordination**
+
 Authorized red team / pen-test use only.
 
 ## Prerequisites

--- a/docs/squidc5-vision.md
+++ b/docs/squidc5-vision.md
@@ -1,12 +1,16 @@
 # SquidC5 Vision & System Specification
 
 **Version:** 0.1.0  
-**Status:** Active development — **military-grade, security-first C2**  
+**Status:** Active development — **military-grade, security-first C5**  
 **Purpose:** Authorized penetration testing, red team, and defensive security operations only  
+**C5:** Command • Control • Cognitive • Collaborative • Coordination  
 **Roadmap:** See `docs/roadmap-2026-2027.md` (malleable profiles → implants → evasion → multi-op → AI → plugins → observability → deploy → testing → community)
+
 ## Overview
 
-SquidC5 is a professional, lightweight, **military-grade**, security-first, AI-native Command & Control framework under active development. It is designed open-source-ready from the first commit, with strong emphasis on **secure defaults**, AI restriction, determinism, auditability, and low resource usage.
+**C5** expands to **Command, Control, Cognitive, Collaborative, Coordination** — the five pillars SquidC5 is built around (tasking, authority rails, AI assist, multi-operator work, and engagement orchestration).
+
+SquidC5 is a professional, lightweight, **military-grade**, security-first, AI-native C5 / command-and-control framework under active development. It is designed open-source-ready from the first commit, with strong emphasis on **secure defaults**, AI restriction, determinism, auditability, and low resource usage.
 
 Hardened posture includes: no public API documentation surface, scoped tokens, server-gated admin UI, feature flags, false-shell filtering, shell exec verification, and dual AI controls (restricted MCP + sandboxed Admin AI).
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,9 +1,21 @@
 # SquidC5 User Guide
 
+**Command • Control • Cognitive • Collaborative • Coordination**
+
 **Authorized red team / penetration testing only.**  
 This guide lives in the GitHub repository. It is **not** served by the C2 process (`/docs` on the server stays disabled).
 
 **Source of truth:** [docs/user-guide.md](https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md) on branch `master`.
+
+### What C5 stands for
+
+| Pillar | In SquidC5 |
+|--------|------------|
+| **Command** | Task shells and beacons; issue operator intent |
+| **Control** | Auth scopes, policy engine, listeners, feature kill-switches |
+| **Cognitive** | Admin AI (railed) + external MCP tools (allow-listed) |
+| **Collaborative** | Teams, chat, handoff, shared ops console |
+| **Coordination** | C2 profiles, task queues, metrics, timeline, reports |
 
 | Related docs | Purpose |
 |--------------|---------|
@@ -39,7 +51,7 @@ If a Grokpedia slug 404s or is empty (SPA), search from [grok.com/pedia](https:/
 
 ### What SquidC5 is
 
-SquidC5 is a **security-first, AI-native command-and-control (C2)** platform for **authorized** engagements. In industry language, a C2 *team server* is the hub operators use to task implants, receive output, and manage listeners during a red-team or pen-test. SquidC5 implements that hub with strong defaults (scoped tokens, audit, AI rails).
+SquidC5 is a **security-first, AI-native C5** platform — **Command, Control, Cognitive, Collaborative, Coordination** — for **authorized** engagements. In industry language it fills the role of a command-and-control (C2) *team server*: the hub operators use to task implants, receive output, and manage listeners during a red-team or pen-test, with AI assist and multi-operator coordination built in under secure defaults (scoped tokens, audit, AI rails).
 
 Operators use:
 
@@ -101,9 +113,14 @@ A compromised browser or leaked non-admin token must not receive admin control s
 cat data/admin_token.txt   # local
 # docker exec squidc5 cat /data/admin_token.txt
 
-sc5 login --url http://HOST:8443 --token sc5_...
+# Default: HTTPS with unique self-signed cert (data/tls/)
+sc5 login --url https://HOST:8443 --token sc5_...
 sc5 whoami
 ```
+
+### Transport encryption (TLS)
+
+New instances **generate a unique self-signed certificate** on first start (`data/tls/server.crt` + `server.key`) and serve **ops UI, API, and MCP** over HTTPS. Tokens are encrypted on the wire to the browser/CLI (after you accept the self-signed warning or pin the cert). Override with CA certs via `SQUIDC5_TLS_CERT_FILE` / `SQUIDC5_TLS_KEY_FILE`, or terminate TLS on a redirector. See [deployment.md](deployment.md#tls-https--default-on-new-instances).
 
 ---
 
@@ -111,7 +128,7 @@ sc5 whoami
 
 ### What
 
-Browser UI at `http://HOST:8443/ops`. Connection settings stay in **browser localStorage** only. Layout order, wide tiles, and panel open state are also local — **never** persisted to the C2 server.
+Browser UI at `https://HOST:8443/ops` (HTTPS by default). Connection settings stay in **browser localStorage** only. Layout order, wide tiles, and panel open state are also local — **never** persisted to the C2 server.
 
 ### Why
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "squidc5"
 version = "0.1.0"
-description = "SquidC5 — lightweight, security-first, AI-native C2 for authorized red team operations"
+description = "SquidC5 — Command • Control • Cognitive • Collaborative • Coordination; AI-native C5 for authorized red team operations"
 readme = "README.md"
 license = { text = "MIT" }
 requires-python = ">=3.11"

--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -44,6 +44,11 @@ class Settings(BaseSettings):
     # Hardened defaults
     expose_health_details: bool = False
     security_headers: bool = True
+    # TLS: unique self-signed cert under data_dir/tls/ (ops UI, API, MCP)
+    tls_enabled: bool = True
+    tls_cert_file: Path | None = None  # override paths if set (both must be set)
+    tls_key_file: Path | None = None
+    tls_force_new: bool = False  # regenerate cert/key on next start
 
     def resolve_db_path(self) -> Path:
         if self.db_path is not None:

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI, HTTPException, Request
@@ -329,6 +330,49 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
 def cli() -> None:
     settings = get_settings()
+    ssl_kwargs: dict = {}
+    if settings.tls_enabled:
+        from squidc5.tls.certs import ensure_instance_tls
+
+        if settings.tls_cert_file and settings.tls_key_file:
+            cert_path = Path(settings.tls_cert_file)
+            key_path = Path(settings.tls_key_file)
+            if not cert_path.is_file() or not key_path.is_file():
+                raise SystemExit(
+                    f"SQUIDC5_TLS_CERT_FILE / SQUIDC5_TLS_KEY_FILE not found: {cert_path} {key_path}"
+                )
+            created = False
+        else:
+            cert_path, key_path, created = ensure_instance_tls(
+                settings.data_dir,
+                public_host=settings.public_host or "",
+                force_new=settings.tls_force_new,
+            )
+        ssl_kwargs["ssl_certfile"] = str(cert_path)
+        ssl_kwargs["ssl_keyfile"] = str(key_path)
+        scheme = "https"
+        if created:
+            log.warning(
+                "TLS is ON with a new self-signed cert. Use https://%s:%s/ops "
+                "(accept browser warning) — tokens on the wire are encrypted.",
+                settings.host if settings.host not in ("0.0.0.0", "::") else "HOST",
+                settings.port,
+            )
+        else:
+            log.info("TLS enabled (%s)", cert_path)
+    else:
+        scheme = "http"
+        log.warning(
+            "TLS disabled (SQUIDC5_TLS_ENABLED=false) — ops/API/MCP traffic is plaintext"
+        )
+
+    log.info(
+        "Starting SquidC5 %s on %s://%s:%s",
+        __version__,
+        scheme,
+        settings.host,
+        settings.port,
+    )
     uvicorn.run(
         "squidc5.main:create_app",
         factory=True,
@@ -336,6 +380,7 @@ def cli() -> None:
         port=settings.port,
         log_level="debug" if settings.debug else "info",
         workers=1,
+        **ssl_kwargs,
     )
 
 

--- a/src/squidc5/tls/__init__.py
+++ b/src/squidc5/tls/__init__.py
@@ -1,0 +1,7 @@
+"""TLS helpers for SquidC5 listeners (ops UI, API, MCP)."""
+
+from __future__ import annotations
+
+from squidc5.tls.certs import ensure_instance_tls, tls_material_paths
+
+__all__ = ["ensure_instance_tls", "tls_material_paths"]

--- a/src/squidc5/tls/certs.py
+++ b/src/squidc5/tls/certs.py
@@ -1,0 +1,193 @@
+"""Per-instance self-signed TLS certificate generation and paths."""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import secrets
+import socket
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+log = logging.getLogger("squidc5.tls")
+
+CERT_DIRNAME = "tls"
+CERT_FILENAME = "server.crt"
+KEY_FILENAME = "server.key"
+INSTANCE_ID_FILENAME = "instance_id"
+
+
+def tls_material_paths(data_dir: Path) -> tuple[Path, Path]:
+    """Return (cert_path, key_path) under data_dir/tls/."""
+    base = Path(data_dir) / CERT_DIRNAME
+    return base / CERT_FILENAME, base / KEY_FILENAME
+
+
+def _instance_id(tls_dir: Path) -> str:
+    path = tls_dir / INSTANCE_ID_FILENAME
+    if path.is_file():
+        existing = path.read_text(encoding="utf-8").strip()
+        if existing:
+            return existing
+    iid = secrets.token_hex(8)
+    path.write_text(iid + "\n", encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return iid
+
+
+def _san_entries(public_host: str, extra_hosts: list[str] | None = None) -> list[x509.GeneralName]:
+    names: list[x509.GeneralName] = [
+        x509.DNSName("localhost"),
+        x509.IPAddress(ipaddress.IPv4Address("127.0.0.1")),
+        x509.IPAddress(ipaddress.IPv6Address("::1")),
+    ]
+    seen: set[str] = {"localhost", "127.0.0.1", "::1"}
+
+    def add_host(raw: str) -> None:
+        h = (raw or "").strip()
+        if not h or h in seen:
+            return
+        seen.add(h)
+        try:
+            names.append(x509.IPAddress(ipaddress.ip_address(h)))
+            return
+        except ValueError:
+            pass
+        # Strip scheme/port if operator pasted a URL
+        if "://" in h:
+            h = h.split("://", 1)[1]
+        h = h.split("/", 1)[0].split(":", 1)[0]
+        if not h or h in seen:
+            return
+        seen.add(h)
+        try:
+            names.append(x509.IPAddress(ipaddress.ip_address(h)))
+        except ValueError:
+            names.append(x509.DNSName(h))
+
+    add_host(public_host)
+    for h in extra_hosts or []:
+        add_host(h)
+    try:
+        add_host(socket.gethostname())
+    except OSError:
+        pass
+    return names
+
+
+def generate_self_signed(
+    cert_path: Path,
+    key_path: Path,
+    *,
+    public_host: str = "",
+    instance_id: str = "",
+    days: int = 825,
+) -> None:
+    """Write a new unique self-signed server certificate and private key."""
+    cert_path.parent.mkdir(parents=True, exist_ok=True)
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    iid = instance_id or secrets.token_hex(8)
+    cn = f"squidc5-{iid}"
+    subject = issuer = x509.Name(
+        [
+            x509.NameAttribute(NameOID.COUNTRY_NAME, "XX"),
+            x509.NameAttribute(NameOID.ORGANIZATION_NAME, "SquidC5 Instance"),
+            x509.NameAttribute(NameOID.COMMON_NAME, cn),
+        ]
+    )
+    now = datetime.now(UTC)
+    builder = (
+        x509.CertificateBuilder()
+        .subject_name(subject)
+        .issuer_name(issuer)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=5))
+        .not_valid_after(now + timedelta(days=days))
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                key_encipherment=True,
+                content_commitment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.ExtendedKeyUsage([ExtendedKeyUsageOID.SERVER_AUTH]),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectAlternativeName(_san_entries(public_host)),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(key.public_key()),
+            critical=False,
+        )
+    )
+    cert = builder.sign(private_key=key, algorithm=hashes.SHA256())
+
+    key_bytes = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    cert_bytes = cert.public_bytes(serialization.Encoding.PEM)
+    key_path.write_bytes(key_bytes)
+    cert_path.write_bytes(cert_bytes)
+    try:
+        key_path.chmod(0o600)
+        cert_path.chmod(0o644)
+    except OSError:
+        pass
+
+
+def ensure_instance_tls(
+    data_dir: Path,
+    *,
+    public_host: str = "",
+    force_new: bool = False,
+) -> tuple[Path, Path, bool]:
+    """
+    Ensure data_dir/tls/server.crt + server.key exist.
+
+    Returns (cert_path, key_path, created) where created is True if newly generated.
+    Each new instance gets a unique cert (random serial + CN/instance id).
+    """
+    data_dir = Path(data_dir)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    tls_dir = data_dir / CERT_DIRNAME
+    tls_dir.mkdir(parents=True, exist_ok=True)
+    cert_path, key_path = tls_material_paths(data_dir)
+    iid = _instance_id(tls_dir)
+
+    if not force_new and cert_path.is_file() and key_path.is_file():
+        if cert_path.stat().st_size > 0 and key_path.stat().st_size > 0:
+            return cert_path, key_path, False
+
+    generate_self_signed(
+        cert_path,
+        key_path,
+        public_host=public_host or "",
+        instance_id=iid,
+    )
+    log.warning(
+        "Generated unique instance TLS certificate → %s (self-signed; browsers will warn)",
+        cert_path,
+    )
+    return cert_path, key_path, True

--- a/tests/test_tls_instance_cert.py
+++ b/tests/test_tls_instance_cert.py
@@ -1,0 +1,64 @@
+"""Per-instance TLS certificate generation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+
+from squidc5.tls.certs import ensure_instance_tls, generate_self_signed, tls_material_paths
+
+
+def test_tls_paths(tmp_path: Path) -> None:
+    cert, key = tls_material_paths(tmp_path)
+    assert cert.name == "server.crt"
+    assert key.name == "server.key"
+    assert cert.parent == tmp_path / "tls"
+
+
+def test_generate_unique_certs(tmp_path: Path) -> None:
+    c1, k1 = tmp_path / "a.crt", tmp_path / "a.key"
+    c2, k2 = tmp_path / "b.crt", tmp_path / "b.key"
+    generate_self_signed(c1, k1, public_host="10.0.0.5", instance_id="aaaa")
+    generate_self_signed(c2, k2, public_host="10.0.0.5", instance_id="bbbb")
+    assert c1.read_bytes() != c2.read_bytes()
+    assert k1.read_bytes() != k2.read_bytes()
+
+    cert1 = x509.load_pem_x509_certificate(c1.read_bytes())
+    cert2 = x509.load_pem_x509_certificate(c2.read_bytes())
+    assert cert1.serial_number != cert2.serial_number
+    cn1 = cert1.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
+    cn2 = cert2.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
+    assert "aaaa" in str(cn1)
+    assert "bbbb" in str(cn2)
+
+    san = cert1.extensions.get_extension_for_class(x509.SubjectAlternativeName).value
+    dns = san.get_values_for_type(x509.DNSName)
+    ips = [str(i) for i in san.get_values_for_type(x509.IPAddress)]
+    assert "localhost" in dns
+    assert "127.0.0.1" in ips
+    assert "10.0.0.5" in ips
+
+
+def test_ensure_instance_tls_idempotent(tmp_path: Path) -> None:
+    data = tmp_path / "data"
+    cert, key, created = ensure_instance_tls(data, public_host="c2.lab")
+    assert created is True
+    assert cert.is_file() and key.is_file()
+    body1 = cert.read_bytes()
+
+    cert2, key2, created2 = ensure_instance_tls(data, public_host="c2.lab")
+    assert created2 is False
+    assert cert2 == cert and key2 == key
+    assert cert.read_bytes() == body1
+
+    _, _, created3 = ensure_instance_tls(data, force_new=True)
+    assert created3 is True
+    assert cert.read_bytes() != body1
+
+
+def test_key_is_private(tmp_path: Path) -> None:
+    cert, key, _ = ensure_instance_tls(tmp_path / "d")
+    serialization.load_pem_private_key(key.read_bytes(), password=None)
+    x509.load_pem_x509_certificate(cert.read_bytes())

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -7,7 +7,7 @@
   <meta name="theme-color" content="#09090b" />
   <link rel="icon" href="https://i.imgur.com/m1FBjqj.png" type="image/png" />
   <link rel="stylesheet" href="https://squidoffense.com/css/typography.css" />
-  <title>SquidC5</title>
+  <title>SquidC5 — Command • Control • Cognitive • Collaborative • Coordination</title>
   <style>
     :root {
       --pink: #e91e8c;
@@ -33,7 +33,8 @@
       padding: max(12px, env(safe-area-inset-top)) 12px calc(20px + env(safe-area-inset-bottom));
     }
     .wrap { max-width: 520px; margin: 0 auto; width: 100%; }
-    .brand { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; }
+    .brand { display: flex; align-items: center; gap: 12px; margin-bottom: 10px; flex-wrap: wrap; }
+    .brand .brand-text { min-width: 0; }
     .toolbar { margin-bottom: 10px; }
     .overview { display: flex; flex-direction: column; }
     .overview > * { min-width: 0; }
@@ -47,6 +48,12 @@
     .brand h1 { margin: 0; font-size: 1.25rem; letter-spacing: -0.02em; }
     .brand h1 .p { color: var(--pink); text-shadow: none; }
     .brand .sub { font-size: 0.68rem; color: var(--muted); letter-spacing: 0.12em; text-transform: uppercase; }
+    .brand .c5-expand {
+      font-size: 0.62rem; color: var(--pink-hot); letter-spacing: 0.04em;
+      margin-top: 4px; line-height: 1.35; font-weight: 600;
+      text-transform: none;
+    }
+    .brand .c5-expand .dot { color: var(--muted); margin: 0 0.15em; font-weight: 400; }
     .badge {
       margin-left: auto; font: 700 0.65rem/1 var(--mono); letter-spacing: 0.06em;
       text-transform: uppercase; padding: 6px 10px; border-radius: 8px;
@@ -455,9 +462,12 @@
       <img src="/ops/assets/squidsec-logo-256.png"
            onerror="this.onerror=null;this.src='https://i.imgur.com/m1FBjqj.png'"
            alt="SquidC5" width="48" height="48" />
-      <div>
+      <div class="brand-text">
         <h1>SQUID<span class="p">C5</span></h1>
         <div class="sub">operator console</div>
+        <div class="c5-expand" title="What C5 stands for">
+          Command<span class="dot">•</span>Control<span class="dot">•</span>Cognitive<span class="dot">•</span>Collaborative<span class="dot">•</span>Coordination
+        </div>
       </div>
       <span id="statusBadge" class="badge">offline</span>
       <span id="roleBadge" class="badge admin hidden">—</span>
@@ -470,7 +480,7 @@
       <summary>Connection <a class="doc-link summary-doc" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#connection" target="_blank" rel="noopener noreferrer" onclick="event.stopPropagation()">Docs</a></summary>
       <p class="hint">Browser credentials for this console. Server URL is the SquidC5 base (usually this host when opened via <code>/ops</code>). API token is a scoped <code>sc5_…</code> secret stored only in localStorage. Admin panels load only after the server accepts the token. Refresh interval polls sessions/listeners/metrics. <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md#connection" target="_blank" rel="noopener noreferrer">Full docs →</a></p>
       <label for="url">Server URL</label>
-      <input id="url" type="url" placeholder="http://HOST:8443" autocomplete="off" />
+      <input id="url" type="url" placeholder="https://HOST:8443" autocomplete="off" />
       <label for="token">API token</label>
       <input id="token" type="password" placeholder="sc5_…" autocomplete="off" />
       <label for="refresh">Refresh (sec)</label>
@@ -479,12 +489,11 @@
         <button type="button" class="primary" id="saveBtn">Save &amp; Connect</button>
         <button type="button" id="toggleToken">Show token</button>
       </div>
+      <div class="row toolbar" style="margin-top:10px;margin-bottom:0">
+        <button type="button" id="refreshBtn">Refresh</button>
+        <button type="button" class="primary" id="shareBtn">Phone QR</button>
+      </div>
     </details>
-
-    <div class="row toolbar">
-      <button type="button" id="refreshBtn">Refresh</button>
-      <button type="button" class="primary" id="shareBtn">Phone QR</button>
-    </div>
 
     <details class="panel event-stream" id="eventStream" aria-label="Live event stream">
       <summary>
@@ -544,8 +553,12 @@
 
     <footer>
       <div id="footer">Last update: never</div>
+      <div style="margin-top:6px;font-size:0.65rem;color:var(--muted);line-height:1.4">
+        <strong style="color:var(--pink)">SquidC5</strong>
+        — Command • Control • Cognitive • Collaborative • Coordination
+      </div>
       <div style="margin-top:4px;letter-spacing:0.12em;text-transform:uppercase;font-size:0.62rem">
-        <strong style="color:var(--pink)">SquidC5</strong> · authorized ops only
+        authorized ops only
       </div>
       <div style="margin-top:8px;font-size:0.72rem">
         <a class="doc-link" href="https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md" target="_blank" rel="noopener noreferrer">User guide (GitHub)</a>


### PR DESCRIPTION
## Summary
- Unique self-signed TLS on first start (ops/API/MCP over HTTPS)
- C5 expansion on ops banner, README, docs
- Refresh + Phone QR inside Connection panel

## Test plan
- [ ] squidc5 starts with data/tls certs; curl -k https://.../health
- [ ] /ops banner shows C5 pillars; Connection has Refresh/QR
- [ ] pytest tests/test_tls_instance_cert.py