### PR TITLE
CI smoke tests use HTTPS (-k) for TLS default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         run: |
           docker run -d --name squidc5-ci -p 8443:8443 squidc5:ci
           for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:8443/api/v1/health; then
+            if curl -skf https://127.0.0.1:8443/api/v1/health; then
               echo "healthy"
               exit 0
             fi
@@ -118,9 +118,9 @@ jobs:
           pid=$!
           trap 'kill $pid 2>/dev/null || true' EXIT
           for i in $(seq 1 40); do
-            if curl -sf http://127.0.0.1:8443/api/v1/health; then
+            if curl -skf https://127.0.0.1:8443/api/v1/health; then
               echo
-              curl -sf http://127.0.0.1:8443/ops | head -c 200
+              curl -skf https://127.0.0.1:8443/ops | head -c 200
               echo
               exit 0
             fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ USER squidc5
 VOLUME ["/data"]
 EXPOSE 8443
 
-HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8443/api/v1/health', timeout=3)"
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+    CMD python -c "import ssl,urllib.request; ctx=ssl._create_unverified_context(); urllib.request.urlopen('https://127.0.0.1:8443/api/v1/health', timeout=3, context=ctx)"
 
-CMD ["python", "-m", "uvicorn", "squidc5.main:create_app", "--factory", "--host", "0.0.0.0", "--port", "8443", "--workers", "1"]
+# Package entrypoint enables unique instance TLS under SQUIDC5_DATA_DIR/tls/
+CMD ["python", "-m", "squidc5"]


### PR DESCRIPTION
Fixes main binary job after instance TLS landed.