### PR TITLE
fix(api): enforce rate_limit_per_minute

### DIFF
--- a/src/squidc5/api/rate_limit.py
+++ b/src/squidc5/api/rate_limit.py
@@ -1,0 +1,97 @@
+"""In-memory sliding-window rate limits for the HTTP API."""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict, deque
+
+
+class SlidingWindowLimiter:
+    """Per-key sliding window counter."""
+
+    def __init__(self, limit: int, window_sec: float = 60.0) -> None:
+        self.limit = max(0, int(limit))
+        self.window = float(window_sec)
+        self._hits: dict[str, deque[float]] = defaultdict(deque)
+
+    @property
+    def disabled(self) -> bool:
+        return self.limit <= 0
+
+    def _prune(self, key: str, now: float) -> deque[float]:
+        q = self._hits[key]
+        while q and now - q[0] > self.window:
+            q.popleft()
+        return q
+
+    def would_allow(self, key: str) -> bool:
+        if self.disabled:
+            return True
+        q = self._prune(key, time.time())
+        return len(q) < self.limit
+
+    def allow(self, key: str) -> bool:
+        if self.disabled:
+            return True
+        now = time.time()
+        q = self._prune(key, now)
+        if len(q) >= self.limit:
+            return False
+        q.append(now)
+        return True
+
+    def record(self, key: str) -> None:
+        if self.disabled:
+            return
+        now = time.time()
+        q = self._prune(key, now)
+        q.append(now)
+
+    def retry_after_sec(self, key: str) -> int:
+        if self.disabled:
+            return 0
+        q = self._hits[key]
+        if not q:
+            return max(1, int(self.window))
+        now = time.time()
+        remain = self.window - (now - q[0])
+        return max(1, int(remain) + 1)
+
+
+class ApiRateLimitState:
+    """IP request limit + stricter auth-failure limit."""
+
+    def __init__(
+        self,
+        limit_per_minute: int = 60,
+        auth_fail_limit_per_minute: int = 20,
+        window_sec: float = 60.0,
+    ) -> None:
+        self.requests = SlidingWindowLimiter(limit_per_minute, window_sec)
+        self.auth_fails = SlidingWindowLimiter(auth_fail_limit_per_minute, window_sec)
+
+    def check_request(self, client_key: str) -> tuple[bool, int]:
+        """Return (allowed, retry_after_seconds). Records a general request hit when allowed."""
+        if not self.auth_fails.would_allow(client_key):
+            return False, self.auth_fails.retry_after_sec(client_key)
+        if not self.requests.allow(client_key):
+            return False, self.requests.retry_after_sec(client_key)
+        return True, 0
+
+    def record_auth_failure(self, client_key: str) -> None:
+        self.auth_fails.record(client_key)
+
+
+def client_key_from_request(request) -> str:
+    if request.client and request.client.host:
+        return request.client.host
+    forwarded = request.headers.get("x-forwarded-for")
+    if forwarded:
+        return forwarded.split(",")[0].strip() or "unknown"
+    return "unknown"
+
+
+def path_is_rate_limit_exempt(path: str) -> bool:
+    """Public liveness probes must not be starved."""
+    p = path.rstrip("/") or "/"
+    return p == "/api/v1/health"

--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -35,6 +35,8 @@ class Settings(BaseSettings):
     ai_enabled: bool = True
     audit_retention_days: int = 90
     rate_limit_per_minute: int = 60
+    # Stricter per-IP cap on failed authentications (credential stuffing)
+    auth_fail_limit_per_minute: int = 20
     # Reverse-shell auto-stabilization (stage-2 reconnect agents)
     shell_auto_stabilize: bool = True
     # Host/IP implants should call back to (defaults to request/local bind if empty)

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -166,11 +166,24 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         redoc_url=None,
         openapi_url=None,
     )
+    from squidc5.api.rate_limit import (
+        ApiRateLimitState,
+        client_key_from_request,
+        path_is_rate_limit_exempt,
+    )
+
+    rate_limit_state = ApiRateLimitState(
+        limit_per_minute=settings.rate_limit_per_minute,
+        auth_fail_limit_per_minute=settings.auth_fail_limit_per_minute,
+    )
+    app.state.rate_limit = rate_limit_state
+
     # Secure CORS: no wildcard. Allow:
     #  - explicit SQUIDC5_CORS_ORIGINS
     #  - same-host origins (so /ops on this server can use Authorization)
     from urllib.parse import urlparse
 
+    from starlette.responses import JSONResponse
     from starlette.responses import Response as StarletteResponse
 
     def _cors_origin_allowed(origin: str | None, host_header: str | None) -> str | None:
@@ -229,7 +242,29 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 resp.headers["X-Frame-Options"] = "DENY"
             return resp
 
+        path = request.url.path
+        ckey = client_key_from_request(request)
+        rl: ApiRateLimitState = request.app.state.rate_limit
+        if not path_is_rate_limit_exempt(path):
+            ok, retry_after = rl.check_request(ckey)
+            if not ok:
+                resp = JSONResponse(
+                    status_code=429,
+                    content={"detail": "Rate limit exceeded"},
+                    headers={"Retry-After": str(retry_after or 60)},
+                )
+                if allow_origin:
+                    resp.headers["Access-Control-Allow-Origin"] = allow_origin
+                    resp.headers["Vary"] = "Origin"
+                if settings.security_headers:
+                    resp.headers.setdefault("X-Content-Type-Options", "nosniff")
+                    resp.headers.setdefault("X-Frame-Options", "DENY")
+                    resp.headers.setdefault("Cache-Control", "no-store")
+                return resp
+
         response = await call_next(request)
+        if response.status_code == 401 and not path_is_rate_limit_exempt(path):
+            rl.record_auth_failure(ckey)
         if allow_origin:
             response.headers["Access-Control-Allow-Origin"] = allow_origin
             response.headers["Vary"] = "Origin"

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -1,0 +1,82 @@
+"""API rate limit enforcement (A01)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN_BOOTSTRAP = "sc5_test_admin_token_bootstrap_0001"
+
+
+@pytest.fixture
+async def limited_app(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_rl",
+        port=8443,
+        debug=True,
+        mcp_enabled=False,
+        rate_limit_per_minute=5,
+        auth_fail_limit_per_minute=3,
+        admin_token_bootstrap=ADMIN_BOOTSTRAP,
+        security_headers=True,
+    )
+    application = create_app(settings)
+    async with application.router.lifespan_context(application):
+        yield application
+
+
+@pytest.fixture
+async def limited_client(limited_app):
+    transport = ASGITransport(app=limited_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_burst_over_limit_returns_429(limited_client):
+    headers = {"Authorization": f"Bearer {ADMIN_BOOTSTRAP}"}
+    codes = []
+    for _ in range(8):
+        r = await limited_client.get("/api/v1/sessions", headers=headers)
+        codes.append(r.status_code)
+    assert 429 in codes
+    assert codes.count(200) == 5
+    r429 = await limited_client.get("/api/v1/sessions", headers=headers)
+    assert r429.status_code == 429
+    assert "Retry-After" in r429.headers
+    body = r429.json()
+    assert body.get("detail") == "Rate limit exceeded"
+
+
+@pytest.mark.asyncio
+async def test_health_exempt_from_rate_limit(limited_client):
+    codes = []
+    for _ in range(20):
+        r = await limited_client.get("/api/v1/health")
+        codes.append(r.status_code)
+    assert all(c == 200 for c in codes)
+
+
+@pytest.mark.asyncio
+async def test_auth_failures_stricter_limit(limited_client):
+    """Invalid tokens trip a stricter per-IP auth-fail bucket."""
+    bad = {"Authorization": "Bearer sc5_definitely_invalid_token_xxx"}
+    codes = []
+    for _ in range(6):
+        r = await limited_client.get("/api/v1/sessions", headers=bad)
+        codes.append(r.status_code)
+    assert 401 in codes
+    assert 429 in codes
+    # Once auth-fail limited, further bad auth stays 429
+    r = await limited_client.get("/api/v1/sessions", headers=bad)
+    assert r.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_root_minimal_banner_not_rate_starved_early(limited_client):
+    """A few root hits succeed under limit (still counted toward the cap)."""
+    r = await limited_client.get("/")
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- Enforce `SQUIDC5_RATE_LIMIT_PER_MINUTE` via middleware (was config-only)
- Stricter per-IP `auth_fail_limit_per_minute` after 401 responses
- Exempt `GET /api/v1/health` so probes are not starved
- Return 429 + `Retry-After` when limited

## Test plan
- [x] `pytest -q tests/test_rate_limit.py`
- [x] Full suite `pytest -q` (151 passed)
- [ ] CI green

Part of prod-readiness plan A01.