### PR TITLE
fix(api): enforce max_body_bytes

### DIFF
--- a/src/squidc5/api/max_body.py
+++ b/src/squidc5/api/max_body.py
@@ -1,0 +1,78 @@
+"""Request body size limits."""
+
+from __future__ import annotations
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Message, Receive, Scope, Send
+
+
+class MaxBodySizeMiddleware:
+    """Reject requests whose body exceeds max_body_bytes (413)."""
+
+    def __init__(self, app: ASGIApp, max_body_bytes: int) -> None:
+        self.app = app
+        self.max_body_bytes = max(0, int(max_body_bytes))
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        if scope["type"] != "http" or self.max_body_bytes <= 0:
+            await self.app(scope, receive, send)
+            return
+
+        headers = {
+            k.decode("latin-1").lower(): v.decode("latin-1")
+            for k, v in scope.get("headers") or []
+        }
+        cl = headers.get("content-length")
+        if cl is not None:
+            try:
+                length = int(cl)
+            except ValueError:
+                length = -1
+            if length > self.max_body_bytes:
+                resp = JSONResponse(
+                    status_code=413,
+                    content={"detail": "Request body too large"},
+                )
+                await resp(scope, receive, send)
+                return
+
+        max_bytes = self.max_body_bytes
+        received = 0
+        overflow = False
+        chunks: list[bytes] = []
+        more = True
+        while more:
+            message = await receive()
+            if message["type"] != "http.request":
+                async def passthrough() -> Message:
+                    return message
+
+                await self.app(scope, passthrough, send)
+                return
+            body = message.get("body", b"") or b""
+            chunks.append(body)
+            received += len(body)
+            if received > max_bytes:
+                overflow = True
+                break
+            more = bool(message.get("more_body"))
+
+        if overflow:
+            resp = JSONResponse(
+                status_code=413,
+                content={"detail": "Request body too large"},
+            )
+            await resp(scope, receive, send)
+            return
+
+        full = b"".join(chunks)
+        sent = False
+
+        async def replay_receive() -> Message:
+            nonlocal sent
+            if not sent:
+                sent = True
+                return {"type": "http.request", "body": full, "more_body": False}
+            return await receive()
+
+        await self.app(scope, replay_receive, send)

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -178,6 +178,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     )
     app.state.rate_limit = rate_limit_state
 
+    from squidc5.api.max_body import MaxBodySizeMiddleware
+
+    app.add_middleware(MaxBodySizeMiddleware, max_body_bytes=settings.max_body_bytes)
+
     # Secure CORS: no wildcard. Allow:
     #  - explicit SQUIDC5_CORS_ORIGINS
     #  - same-host origins (so /ops on this server can use Authorization)

--- a/tests/test_max_body.py
+++ b/tests/test_max_body.py
@@ -1,0 +1,70 @@
+"""Max request body size enforcement (A02)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN_BOOTSTRAP = "sc5_test_admin_token_bootstrap_0001"
+
+
+@pytest.fixture
+async def body_limited_app(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_body",
+        port=8443,
+        debug=True,
+        mcp_enabled=False,
+        max_body_bytes=256,
+        rate_limit_per_minute=1000,
+        admin_token_bootstrap=ADMIN_BOOTSTRAP,
+        security_headers=True,
+    )
+    application = create_app(settings)
+    async with application.router.lifespan_context(application):
+        yield application
+
+
+@pytest.fixture
+async def body_client(body_limited_app):
+    transport = ASGITransport(app=body_limited_app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac
+
+
+@pytest.mark.asyncio
+async def test_oversized_body_returns_413(body_client):
+    headers = {
+        "Authorization": f"Bearer {ADMIN_BOOTSTRAP}",
+        "Content-Type": "application/json",
+    }
+    # well over 256 bytes
+    payload = {"name": "x", "scopes": ["sessions:read"], "pad": "A" * 400}
+    r = await body_client.post("/api/v1/tokens", headers=headers, json=payload)
+    assert r.status_code == 413
+    assert "body" in r.json().get("detail", "").lower() or "large" in r.json().get("detail", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_normal_body_still_succeeds(body_client):
+    headers = {
+        "Authorization": f"Bearer {ADMIN_BOOTSTRAP}",
+        "Content-Type": "application/json",
+    }
+    r = await body_client.post(
+        "/api/v1/tokens",
+        headers=headers,
+        json={"name": "small", "scopes": ["sessions:read"]},
+    )
+    assert r.status_code == 200
+    assert r.json()["token"].startswith("sc5_")
+
+
+@pytest.mark.asyncio
+async def test_get_without_body_unaffected(body_client):
+    headers = {"Authorization": f"Bearer {ADMIN_BOOTSTRAP}"}
+    r = await body_client.get("/api/v1/sessions", headers=headers)
+    assert r.status_code == 200


### PR DESCRIPTION
## Summary
- Enforce `Settings.max_body_bytes` (was config-only)
- 413 Request body too large for Content-Length and streamed bodies
- Default remains 1 MiB

## Test plan
- [x] `pytest -q tests/test_max_body.py`
- [x] Full suite 154 passed
- [ ] CI green

Part of prod-readiness A02.