### PR TITLE
fix(ops): serve admin.js only to admin scope

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -797,20 +797,44 @@ def build_api_router() -> APIRouter:
         flags = await state.features.set_many(body.features, auth.name)
         return {"features": flags, "catalog": state.features.catalog()}
 
-    # ----- Ops console UI (any authenticated token; panels self-gate by scope) -----
-    # Admin-only controls (feature flags, token mint) still require admin via API.
+    # ----- Ops console UI -----
+    # /ops/admin.js: admin scope only (never ship admin control code to non-admins).
+    # /ops/console.js: any authenticated token (operator shell; API still scope-gated).
+
+    def _ops_js_path() -> Path | None:
+        candidates = [
+            web_file("ops-admin.js"),
+            Path("/app/web/ops-admin.js"),
+        ]
+        return next((p for p in candidates if p.is_file()), None)
 
     @api.get("/ops/admin.js")
+    async def ops_admin_js(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> Response:
+        path = _ops_js_path()
+        if path is None:
+            raise HTTPException(404, "ops admin module missing")
+        await get_state(request).db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="ops.admin_ui.load",
+            details={"admin": True},
+            risk_score=2,
+        )
+        return PlainTextResponse(
+            path.read_text(encoding="utf-8"),
+            media_type="application/javascript",
+            headers={"Cache-Control": "no-store"},
+        )
+
     @api.get("/ops/console.js")
     async def ops_console_js(
         request: Request,
         auth: AuthContext = Depends(get_auth),
     ) -> Response:
-        candidates = [
-            web_file("ops-admin.js"),
-            Path("/app/web/ops-admin.js"),
-        ]
-        path = next((p for p in candidates if p.is_file()), None)
+        path = _ops_js_path()
         if path is None:
             raise HTTPException(404, "ops console module missing")
         await get_state(request).db.audit(

--- a/tests/test_ops_console_gate.py
+++ b/tests/test_ops_console_gate.py
@@ -18,10 +18,22 @@ async def test_console_js_any_authenticated_token(client, admin_headers):
 
 
 @pytest.mark.asyncio
-async def test_console_js_admin_alias(client, admin_headers):
+async def test_admin_js_requires_admin_scope(client, admin_headers):
     r = await client.get("/api/v1/ops/admin.js", headers=admin_headers)
     assert r.status_code == 200
     assert "no-store" in (r.headers.get("cache-control") or "")
+    body = r.text
+    assert "SquidC5" in body or "__SC5_" in body or "can(" in body
+
+
+@pytest.mark.asyncio
+async def test_admin_js_non_admin_403(client, admin_headers):
+    t = await mint_token(client, admin_headers, "op-no-admin-js", ["sessions:read"])
+    r = await client.get("/api/v1/ops/admin.js", headers=bearer(t["token"]))
+    assert r.status_code == 403
+    # Must not leak admin module body
+    assert "mintTokBtn" not in r.text
+    assert "saveFeaturesBtn" not in r.text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `/api/v1/ops/admin.js` requires **admin** scope (AGENTS contract)
- Non-admin authenticated tokens receive 403 and no module body
- `/api/v1/ops/console.js` remains available to any authenticated operator

## Test plan
- [x] `pytest -q tests/test_ops_console_gate.py`
- [ ] CI green

A03 prod-readiness.