### PR TITLE
fix(bootstrap): chmod 0600 admin_token.txt

### DIFF
--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -109,6 +109,10 @@ async def build_state(settings: Settings) -> AppState:
     if admin_once:
         token_file = settings.data_dir / "admin_token.txt"
         token_file.write_text(admin_once + "\n", encoding="utf-8")
+        try:
+            token_file.chmod(0o600)
+        except OSError:
+            log.warning("Could not chmod 0600 on %s", token_file)
         log.warning("Bootstrap admin token written to %s — store securely and rotate", token_file)
 
     return AppState(

--- a/tests/test_admin_token_perms.py
+++ b/tests/test_admin_token_perms.py
@@ -1,0 +1,30 @@
+"""Bootstrap admin_token.txt permissions (A04)."""
+
+from __future__ import annotations
+
+import stat
+
+import pytest
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN_BOOTSTRAP = "sc5_test_admin_token_bootstrap_perms_01"
+
+
+@pytest.mark.asyncio
+async def test_admin_token_file_mode_0600(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_tok",
+        port=8443,
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN_BOOTSTRAP,
+    )
+    application = create_app(settings)
+    async with application.router.lifespan_context(application):
+        token_file = settings.data_dir / "admin_token.txt"
+        assert token_file.is_file()
+        mode = stat.S_IMODE(token_file.stat().st_mode)
+        assert mode == 0o600, f"expected 0o600, got {oct(mode)}"
+        assert token_file.read_text(encoding="utf-8").strip() == ADMIN_BOOTSTRAP


### PR DESCRIPTION
## Summary
- After writing bootstrap `admin_token.txt`, set mode `0600`
- Mirrors TLS material permission hygiene

## Test plan
- [x] `pytest -q tests/test_admin_token_perms.py`
- [ ] CI green

A04 prod-readiness.