### PR TITLE
fix(plugins): require non-default signing secret

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,3 +21,5 @@ SQUIDC5_PUBLIC_HOST=
 SQUIDC5_SHELL_AUTO_STABILIZE=true
 # Optional: set a known bootstrap admin token (otherwise auto-generated)
 # SQUIDC5_ADMIN_TOKEN_BOOTSTRAP=sc5_your_secure_token_here
+# Plugin HMAC signing secret (or auto-generated under data/plugin_signing.secret)
+# SQUIDC5_PLUGIN_SIGNING_SECRET=

--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -37,6 +37,8 @@ class Settings(BaseSettings):
     rate_limit_per_minute: int = 60
     # Stricter per-IP cap on failed authentications (credential stuffing)
     auth_fail_limit_per_minute: int = 20
+    # Plugin HMAC secret (env or data_dir/plugin_signing.secret). Never use the legacy default in prod.
+    plugin_signing_secret: str | None = None
     # Reverse-shell auto-stabilization (stage-2 reconnect agents)
     shell_auto_stabilize: bool = True
     # Host/IP implants should call back to (defaults to request/local bind if empty)

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -63,7 +63,14 @@ async def build_state(settings: Settings) -> AppState:
     await profiles.load()
     implants = ImplantRegistry()
     teams = TeamService(db)
-    plugins = PluginRegistry(db=db)
+    from squidc5.plugins.registry import resolve_plugin_signing_secret
+
+    plugin_secret = resolve_plugin_signing_secret(
+        explicit=settings.plugin_signing_secret,
+        data_dir=settings.data_dir,
+        debug=settings.debug,
+    )
+    plugins = PluginRegistry(signing_secret=plugin_secret, db=db)
     await plugins.load_from_db()
     timeline = TimelineService(db)
     oast = OastService(

--- a/src/squidc5/plugins/registry.py
+++ b/src/squidc5/plugins/registry.py
@@ -5,12 +5,59 @@ from __future__ import annotations
 import hashlib
 import hmac
 import json
+import logging
+import secrets
+from pathlib import Path
 from typing import Any
 
 # db is optional Database-like
 
+log = logging.getLogger("squidc5.plugins")
+
+# Legacy default — refused outside debug (see resolve_plugin_signing_secret).
+LEGACY_DEV_PLUGIN_SECRET = b"sc5-dev-plugin-secret-change-me"
+PLUGIN_SECRET_FILENAME = "plugin_signing.secret"
+
 # Built-in deterministic plugin handlers (allow-listed capabilities only)
 _BUILTIN_HANDLERS: dict[str, Any] = {}
+
+
+def resolve_plugin_signing_secret(
+    *,
+    explicit: str | None,
+    data_dir: Path,
+    debug: bool = False,
+) -> bytes:
+    """Resolve HMAC secret from env/settings, data_dir file, or generate once.
+
+    Refuses the legacy hardcoded default when debug is False.
+    """
+    secret: bytes | None = None
+    if explicit is not None and str(explicit).strip():
+        secret = str(explicit).strip().encode("utf-8")
+    else:
+        path = Path(data_dir) / PLUGIN_SECRET_FILENAME
+        if path.is_file():
+            secret = path.read_bytes().strip()
+        if not secret:
+            Path(data_dir).mkdir(parents=True, exist_ok=True)
+            secret = secrets.token_hex(32).encode("utf-8")
+            path.write_bytes(secret + b"\n")
+            try:
+                path.chmod(0o600)
+            except OSError:
+                log.warning("Could not chmod 0600 on %s", path)
+            log.info("Generated plugin signing secret at %s", path)
+
+    if secret == LEGACY_DEV_PLUGIN_SECRET and not debug:
+        raise RuntimeError(
+            "Refusing legacy default plugin signing secret outside debug mode. "
+            "Set SQUIDC5_PLUGIN_SIGNING_SECRET or remove a stale "
+            f"{PLUGIN_SECRET_FILENAME} containing the default."
+        )
+    if not secret:
+        raise RuntimeError("Plugin signing secret is empty")
+    return secret
 
 
 def _handle_recon_summary(args: dict[str, Any]) -> dict[str, Any]:
@@ -96,7 +143,9 @@ class PluginRegistry:
 
     def __init__(self, signing_secret: bytes | None = None, db: Any = None) -> None:
         self._plugins: dict[str, dict[str, Any]] = {}
-        self._signing_secret = signing_secret or b"sc5-dev-plugin-secret-change-me"
+        # Callers in production must pass resolve_plugin_signing_secret(...).
+        # Unit tests may pass an explicit secret; bare None uses legacy only for isolated unit tests.
+        self._signing_secret = signing_secret if signing_secret is not None else LEGACY_DEV_PLUGIN_SECRET
         self._enabled: set[str] = set()
         self.db = db
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,7 @@ async def app(tmp_path):
         public_host="",  # default: Origin null denied
         cors_origins=[],
         admin_token_bootstrap=ADMIN_BOOTSTRAP,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
     )
     application = create_app(settings)
     async with application.router.lifespan_context(application):
@@ -47,6 +48,7 @@ async def app_with_public_host(tmp_path):
         public_host="c2.example.test",
         cors_origins=[],
         admin_token_bootstrap=ADMIN_BOOTSTRAP,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
     )
     application = create_app(settings)
     async with application.router.lifespan_context(application):

--- a/tests/test_plugins_signing.py
+++ b/tests/test_plugins_signing.py
@@ -1,0 +1,76 @@
+"""Plugin signing secret resolution (A05)."""
+
+from __future__ import annotations
+
+import pytest
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+from squidc5.plugins.registry import (
+    LEGACY_DEV_PLUGIN_SECRET,
+    PLUGIN_SECRET_FILENAME,
+    PluginRegistry,
+    resolve_plugin_signing_secret,
+)
+
+
+def test_resolve_explicit_secret(tmp_path):
+    s = resolve_plugin_signing_secret(
+        explicit="my-explicit-secret",
+        data_dir=tmp_path,
+        debug=False,
+    )
+    assert s == b"my-explicit-secret"
+
+
+def test_resolve_generates_file_mode(tmp_path):
+    s = resolve_plugin_signing_secret(explicit=None, data_dir=tmp_path, debug=False)
+    path = tmp_path / PLUGIN_SECRET_FILENAME
+    assert path.is_file()
+    assert path.read_bytes().strip() == s
+    assert path.stat().st_mode & 0o777 == 0o600
+    # second resolve reads same
+    s2 = resolve_plugin_signing_secret(explicit=None, data_dir=tmp_path, debug=False)
+    assert s2 == s
+
+
+def test_refuse_legacy_default_outside_debug(tmp_path):
+    with pytest.raises(RuntimeError, match="legacy default"):
+        resolve_plugin_signing_secret(
+            explicit=LEGACY_DEV_PLUGIN_SECRET.decode(),
+            data_dir=tmp_path,
+            debug=False,
+        )
+
+
+def test_legacy_default_allowed_in_debug(tmp_path):
+    s = resolve_plugin_signing_secret(
+        explicit=LEGACY_DEV_PLUGIN_SECRET.decode(),
+        data_dir=tmp_path,
+        debug=True,
+    )
+    assert s == LEGACY_DEV_PLUGIN_SECRET
+
+
+def test_sign_verify_roundtrip():
+    reg = PluginRegistry(signing_secret=b"unit-test-secret")
+    man = {"name": "x", "version": "1", "capabilities": []}
+    sig = reg.sign_manifest(man)
+    assert reg.verify(man, sig)
+    assert not reg.verify(man, "00" * 32)
+
+
+@pytest.mark.asyncio
+async def test_app_boots_with_generated_secret(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_plug",
+        debug=False,
+        mcp_enabled=False,
+        admin_token_bootstrap="sc5_test_admin_token_bootstrap_plug1",
+        plugin_signing_secret=None,
+    )
+    application = create_app(settings)
+    async with application.router.lifespan_context(application):
+        secret_path = settings.data_dir / PLUGIN_SECRET_FILENAME
+        assert secret_path.is_file()
+        assert application.state.app_state.plugins._signing_secret == secret_path.read_bytes().strip()

--- a/tests/test_roadmap_complete.py
+++ b/tests/test_roadmap_complete.py
@@ -126,7 +126,7 @@ async def test_plugin_persist_and_execute(client, admin_headers):
     # Call through admin by constructing signature matching server default
     from squidc5.plugins.registry import PluginRegistry
 
-    reg = PluginRegistry()  # same default secret as server
+    reg = PluginRegistry(signing_secret=b"test-plugin-signing-secret-for-ci")
     man = {
         "name": "lab_recon",
         "version": "1.0.0",


### PR DESCRIPTION
## Summary
- `SQUIDC5_PLUGIN_SIGNING_SECRET` or auto-generated `data/plugin_signing.secret` (0600)
- Refuse legacy `sc5-dev-plugin-secret-change-me` when `debug=false`
- Wire resolved secret into `PluginRegistry` at startup

## Test plan
- [x] plugin signing unit tests
- [x] full pytest
- [ ] CI green

A05 prod-readiness.