### PR TITLE
ci: fail on pip-audit findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
       - name: Install pip-audit
         run: pip install pip-audit
       - name: Audit dependencies
-        run: pip-audit -r requirements.txt || true
+        # Fail the job on known vulnerable dependencies (A08)
+        run: pip-audit -r requirements.txt
 
   # Standalone operator CLI + server binaries (no venv required).
   # Runs on pushes to main/master after tests pass.


### PR DESCRIPTION
## Summary
- Remove \`|| true\` from pip-audit step so vulnerable deps fail CI

## Test plan
- [x] Local \`pip-audit -r requirements.txt\` clean
- [ ] CI security job green

A08 prod-readiness.