### PR TITLE
docs: align URLs with TLS-by-default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
           squidc5-linux-x64 / squidc5-windows-x64.exe   C2 server
 
           Server defaults: 0.0.0.0:8443  data in ./data/
-          Ops console: http://HOST:8443/ops
+          Ops console: https://HOST:8443/ops (self-signed TLS by default)
           Authorized use only.
           EOF
           ls -lah release/
@@ -227,12 +227,12 @@ jobs:
           chmod +x squidc5-linux-x64
           ./squidc5-linux-x64
           # token: ./data/admin_token.txt
-          # console: http://HOST:8443/ops
+          # console: https://HOST:8443/ops
           \`\`\`
 
           ### CLI
           \`\`\`bash
-          ./sc5-linux-x64 login --url http://HOST:8443 --token sc5_...
+          ./sc5-linux-x64 login --url https://HOST:8443 --token sc5_... --insecure
           ./sc5-linux-x64 sessions list
           \`\`\`
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Lightweight, security-first, AI-native C5 platform for authorized red team opera
 
 ```bash
 docker compose up --build -d
-curl -s http://127.0.0.1:8443/api/v1/health
+# TLS is on by default (self-signed under data/tls/)
+curl -sk https://127.0.0.1:8443/api/v1/health
 docker compose exec squidc5 cat /data/admin_token.txt
 ```
 
@@ -43,8 +44,11 @@ docker compose exec squidc5 cat /data/admin_token.txt
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements-dev.txt && pip install -e .
-uvicorn squidc5.main:create_app --factory --host 0.0.0.0 --port 8443
-# Admin token printed path: data/admin_token.txt
+# Prefer package entrypoint (enables per-instance TLS under data/tls/):
+squidc5
+# Admin token: data/admin_token.txt  |  console: https://HOST:8443/ops
+# Plain uvicorn has no TLS unless you pass --ssl-*:
+# uvicorn squidc5.main:create_app --factory --host 0.0.0.0 --port 8443
 ```
 
 ## Standalone binaries (no venv)
@@ -65,10 +69,10 @@ Every successful push to `main`/`master`:
 ```bash
 # Server (Linux release asset)
 chmod +x squidc5-linux-x64 && ./squidc5-linux-x64
-# token: ./data/admin_token.txt   console: http://HOST:8443/ops
+# token: ./data/admin_token.txt   console: https://HOST:8443/ops
 
-# Operator CLI
-./sc5-linux-x64 login --url http://HOST:8443 --token sc5_...
+# Operator CLI (--insecure for lab self-signed certs)
+./sc5-linux-x64 login --url https://HOST:8443 --token sc5_... --insecure
 ./sc5-linux-x64 sessions list
 ```
 
@@ -81,7 +85,7 @@ Local harness to control a remote SquidC5 instance:
 ```bash
 pip install -e .
 # or use the standalone sc5 binary from CI artifacts
-sc5 login --url http://YOUR_HOST:8443 --token sc5_...
+sc5 login --url https://YOUR_HOST:8443 --token sc5_... --insecure
 sc5 health
 sc5 sessions list
 sc5 tasks create <session_id> "whoami"
@@ -123,7 +127,7 @@ Auth header: `Authorization: Bearer <token>` or `X-API-Token: <token>`
 ```bash
 ADMIN=$(cat data/admin_token.txt)
 
-curl -s -X POST http://127.0.0.1:8443/api/v1/tokens \
+curl -sk -X POST https://127.0.0.1:8443/api/v1/tokens \
   -H "Authorization: Bearer $ADMIN" \
   -H "Content-Type: application/json" \
   -d '{"name":"ops","scopes":["sessions:read","sessions:write","tasks:read","tasks:write","listeners:read","listeners:write","payloads:generate","metrics:read","audit:read"]}'
@@ -132,19 +136,19 @@ curl -s -X POST http://127.0.0.1:8443/api/v1/tokens \
 ### Example: restricted external AI (MCP)
 
 ```bash
-curl -s -X POST http://127.0.0.1:8443/api/v1/tokens \
+curl -sk -X POST https://127.0.0.1:8443/api/v1/tokens \
   -H "Authorization: Bearer $ADMIN" \
   -H "Content-Type: application/json" \
   -d '{"name":"ext-ai","scopes":["mcp:connect","sessions:read","tasks:read","tasks:write","metrics:read"],"mcp_tools":["list_sessions","get_session","list_tasks","create_task","get_metrics"]}'
 
 # List only allow-listed tools
-curl -s http://127.0.0.1:8443/mcp/tools -H "Authorization: Bearer $AI_TOKEN"
+curl -sk https://127.0.0.1:8443/mcp/tools -H "Authorization: Bearer $AI_TOKEN"
 ```
 
 ### Example: Admin AI (offline deterministic mode)
 
 ```bash
-curl -s -X POST http://127.0.0.1:8443/api/v1/ai/run \
+curl -sk -X POST https://127.0.0.1:8443/api/v1/ai/run \
   -H "Authorization: Bearer $ADMIN" \
   -H "Content-Type: application/json" \
   -d '{"capability":"shell_classify","user_data":"uid=0(root) gid=0(root)"}'

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -5,7 +5,8 @@
 ```bash
 docker compose up --build -d
 docker exec squidc5 cat /data/admin_token.txt   # once; store securely
-curl -s http://127.0.0.1:8443/api/v1/health
+# TLS on by default (self-signed) — use -k for lab probes
+curl -sk https://127.0.0.1:8443/api/v1/health
 ```
 
 ### Host networking (default in compose)

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -114,7 +114,7 @@ cat data/admin_token.txt   # local
 # docker exec squidc5 cat /data/admin_token.txt
 
 # Default: HTTPS with unique self-signed cert (data/tls/)
-sc5 login --url https://HOST:8443 --token sc5_...
+sc5 login --url https://HOST:8443 --token sc5_... --insecure
 sc5 whoami
 ```
 
@@ -164,7 +164,7 @@ The UI is a pure client. Without a token, only public shell HTML loads; admin pa
 
 | Field | Meaning |
 |-------|---------|
-| Server URL | Base URL, e.g. `http://159.x.x.x:8443` |
+| Server URL | Base URL, e.g. `https://159.x.x.x:8443` |
 | API token | `sc5_…` Bearer token |
 | Refresh | Poll interval for sessions/metrics/events |
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -144,7 +144,7 @@ Operators need a phone-friendly and desktop console without shipping secrets bac
 ### Example
 
 ```text
-http://127.0.0.1:8443/ops
+https://127.0.0.1:8443/ops
 Token: sc5_… (from data/admin_token.txt)
 ```
 
@@ -171,7 +171,7 @@ The UI is a pure client. Without a token, only public shell HTML loads; admin pa
 ### Example (CLI equivalent)
 
 ```bash
-sc5 login --url http://HOST:8443 --token sc5_...
+sc5 login --url https://HOST:8443 --insecure --token sc5_...
 sc5 config
 ```
 
@@ -733,7 +733,7 @@ Incident response: disable a capability without redeploying. Defaults stay secur
 
 ```bash
 # API (admin)
-curl -H "Authorization: Bearer $TOK" http://HOST:8443/api/v1/features
+curl -sk -H "Authorization: Bearer $TOK" https://HOST:8443/api/v1/features
 ```
 
 UI: flip toggles → **Save features**.


### PR DESCRIPTION
## Summary
- README, deployment, user-guide, release notes use \`https://\`
- Document \`curl -sk\` and \`sc5 --insecure\` for lab self-signed TLS

## Test plan
- [ ] Docs review
- [ ] CI green

A09 prod-readiness.