### PR TITLE
ci(squidgate): use xAI Grok for LLM_API_KEY

### DIFF
--- a/.github/squidgate.yml
+++ b/.github/squidgate.yml
@@ -3,8 +3,8 @@
 version: 1
 
 llm:
-  provider: openai
-  model: gpt-4o
+  provider: custom
+  model: grok-build-0.1
 
 policy:
   block_on: high

--- a/.github/workflows/squidgate.yml
+++ b/.github/workflows/squidgate.yml
@@ -27,6 +27,10 @@ jobs:
         with:
           llm-api-key: ${{ env.LLM_API_KEY }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+          # Repo secret is an xAI key (xai-...)
+          llm-provider: custom
+          llm-model: grok-build-0.1
+          llm-base-url: https://api.x.ai/v1
 
       - name: SquidGate not configured
         if: env.LLM_API_KEY == ''


### PR DESCRIPTION
## Summary
- Configure SquidGate for xAI (\`custom\` + \`https://api.x.ai/v1\` + \`grok-build-0.1\`)
- Fixes 401 when \`LLM_API_KEY\` is an xAI key used against OpenAI

## Test plan
- [ ] SquidGate job success on this PR
- [ ] CI green