### PR TITLE
fix(ai): encrypt LLM API keys at rest

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,3 +23,5 @@ SQUIDC5_SHELL_AUTO_STABILIZE=true
 # SQUIDC5_ADMIN_TOKEN_BOOTSTRAP=sc5_your_secure_token_here
 # Plugin HMAC signing secret (or auto-generated under data/plugin_signing.secret)
 # SQUIDC5_PLUGIN_SIGNING_SECRET=
+# At-rest encryption master key for LLM API keys (or data/secrets.key)
+# SQUIDC5_SECRETS_KEY=

--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -8,6 +8,7 @@ from typing import Any
 
 import httpx
 
+from squidc5.crypto.secrets import SecretBox
 from squidc5.db.store import Database
 from squidc5.metrics.collector import MetricsCollector
 from squidc5.policy.engine import PolicyEngine
@@ -99,10 +100,12 @@ class AdminAI:
         db: Database,
         metrics: MetricsCollector,
         policy: PolicyEngine,
+        secrets: SecretBox | None = None,
     ) -> None:
         self.db = db
         self.metrics = metrics
         self.policy = policy
+        self.secrets = secrets
         self._busy = False
         self._last: dict[str, Any] = {
             "status": "idle",
@@ -183,13 +186,15 @@ class AdminAI:
         llm_id: str | None = None,
     ) -> str:
         caps = [c for c in (capabilities or list(ALLOWED_CAPABILITIES)) if c in ALLOWED_CAPABILITIES]
-        # Store key as-is in DB for MVP; production should encrypt at rest
+        stored_key = api_key
+        if api_key and self.secrets is not None:
+            stored_key = self.secrets.encrypt(api_key)
         return await self.db.upsert_llm(
             name=name,
             provider=provider,
             model=model,
             base_url=base_url,
-            api_key_enc=api_key,
+            api_key_enc=stored_key,
             capabilities=caps,
             llm_id=llm_id,
         )
@@ -352,7 +357,26 @@ class AdminAI:
         )
         base = (llm.get("base_url") or "https://api.openai.com/v1").rstrip("/")
         model = llm["model"]
-        api_key = llm.get("api_key_enc") or ""
+        raw_key = llm.get("api_key_enc") or ""
+        if self.secrets is not None and raw_key:
+            api_key = self.secrets.decrypt(raw_key) or ""
+            # Re-encrypt legacy plaintext on use
+            if raw_key and not self.secrets.is_encrypted(raw_key) and api_key:
+                try:
+                    enc = self.secrets.encrypt(api_key)
+                    await self.db.upsert_llm(
+                        name=llm["name"],
+                        provider=llm["provider"],
+                        model=llm["model"],
+                        base_url=llm.get("base_url"),
+                        api_key_enc=enc,
+                        capabilities=list(llm.get("capabilities") or []),
+                        llm_id=llm["id"],
+                    )
+                except Exception:
+                    pass
+        else:
+            api_key = raw_key
 
         headers = {"Content-Type": "application/json"}
         if api_key:

--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -39,6 +39,8 @@ class Settings(BaseSettings):
     auth_fail_limit_per_minute: int = 20
     # Plugin HMAC secret (env or data_dir/plugin_signing.secret). Never use the legacy default in prod.
     plugin_signing_secret: str | None = None
+    # Master key for at-rest encryption (LLM API keys). Or data_dir/secrets.key.
+    secrets_key: str | None = None
     # Reverse-shell auto-stabilization (stage-2 reconnect agents)
     shell_auto_stabilize: bool = True
     # Host/IP implants should call back to (defaults to request/local bind if empty)

--- a/src/squidc5/crypto/__init__.py
+++ b/src/squidc5/crypto/__init__.py
@@ -1,0 +1,1 @@
+"""Crypto helpers (at-rest secrets)."""

--- a/src/squidc5/crypto/secrets.py
+++ b/src/squidc5/crypto/secrets.py
@@ -1,0 +1,82 @@
+"""At-rest encryption for server secrets (LLM API keys, etc.)."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import secrets
+from pathlib import Path
+
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+
+log = logging.getLogger("squidc5.crypto")
+
+ENC_PREFIX = "enc:v1:"
+SECRETS_KEY_FILENAME = "secrets.key"
+_SALT = b"squidc5-secrets-v1"
+
+
+def _derive_fernet_key(material: bytes) -> bytes:
+    """Derive a url-safe 32-byte Fernet key from arbitrary material."""
+    if material.startswith(b"fernet:"):
+        return material[len(b"fernet:") :].strip()
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=_SALT,
+        iterations=480_000,
+    )
+    raw = kdf.derive(material)
+    return base64.urlsafe_b64encode(raw)
+
+
+def resolve_secrets_key(*, explicit: str | None, data_dir: Path) -> bytes:
+    """Load or generate master key material for at-rest encryption."""
+    if explicit is not None and str(explicit).strip():
+        return str(explicit).strip().encode("utf-8")
+    path = Path(data_dir) / SECRETS_KEY_FILENAME
+    if path.is_file():
+        data = path.read_bytes().strip()
+        if data:
+            return data
+    Path(data_dir).mkdir(parents=True, exist_ok=True)
+    material = secrets.token_urlsafe(48).encode("utf-8")
+    path.write_bytes(material + b"\n")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        log.warning("Could not chmod 0600 on %s", path)
+    log.info("Generated secrets master key at %s", path)
+    return material
+
+
+class SecretBox:
+    """Encrypt/decrypt small secrets; plaintext legacy values pass through on decrypt."""
+
+    def __init__(self, key_material: bytes) -> None:
+        self._fernet = Fernet(_derive_fernet_key(key_material))
+
+    def encrypt(self, plaintext: str | None) -> str | None:
+        if plaintext is None or plaintext == "":
+            return plaintext
+        if plaintext.startswith(ENC_PREFIX):
+            return plaintext
+        token = self._fernet.encrypt(plaintext.encode("utf-8")).decode("ascii")
+        return ENC_PREFIX + token
+
+    def decrypt(self, stored: str | None) -> str | None:
+        if stored is None or stored == "":
+            return stored
+        if not stored.startswith(ENC_PREFIX):
+            # Legacy plaintext row
+            return stored
+        token = stored[len(ENC_PREFIX) :].encode("ascii")
+        try:
+            return self._fernet.decrypt(token).decode("utf-8")
+        except InvalidToken as e:
+            raise ValueError("Failed to decrypt secret (wrong SQUIDC5_SECRETS_KEY?)") from e
+
+    def is_encrypted(self, stored: str | None) -> bool:
+        return bool(stored and stored.startswith(ENC_PREFIX))

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -56,7 +56,12 @@ async def build_state(settings: Settings) -> AppState:
     sessions = SessionManager(db, metrics)
     tasks = TaskManager(db, metrics)
     payloads = PayloadGenerator()
-    admin_ai = AdminAI(db, metrics, policy)
+    from squidc5.crypto.secrets import SecretBox, resolve_secrets_key
+
+    secret_box = SecretBox(
+        resolve_secrets_key(explicit=settings.secrets_key, data_dir=settings.data_dir)
+    )
+    admin_ai = AdminAI(db, metrics, policy, secrets=secret_box)
     features = FeatureFlags(db)
     await features.load()
     profiles = ProfileEngine(db)

--- a/tests/test_llm_key_encryption.py
+++ b/tests/test_llm_key_encryption.py
@@ -1,0 +1,73 @@
+"""LLM API keys encrypted at rest (A06)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.crypto.secrets import ENC_PREFIX, SECRETS_KEY_FILENAME, SecretBox, resolve_secrets_key
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_llmenc01"
+
+
+def test_secret_box_roundtrip():
+    box = SecretBox(b"unit-test-master-key-material")
+    enc = box.encrypt("sk-live-secret-value")
+    assert enc is not None
+    assert enc.startswith(ENC_PREFIX)
+    assert "sk-live" not in enc
+    assert box.decrypt(enc) == "sk-live-secret-value"
+
+
+def test_legacy_plaintext_decrypt_passthrough():
+    box = SecretBox(b"unit-test-master-key-material")
+    assert box.decrypt("plain-legacy-key") == "plain-legacy-key"
+
+
+def test_resolve_generates_secrets_key_file(tmp_path):
+    m = resolve_secrets_key(explicit=None, data_dir=tmp_path)
+    path = tmp_path / SECRETS_KEY_FILENAME
+    assert path.is_file()
+    assert path.read_bytes().strip() == m
+    assert path.stat().st_mode & 0o777 == 0o600
+
+
+@pytest.mark.asyncio
+async def test_configure_llm_stores_ciphertext(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_llm",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        secrets_key="test-secrets-master-for-ci",
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.post(
+                "/api/v1/llm",
+                headers=headers,
+                json={
+                    "name": "lab",
+                    "provider": "openai",
+                    "model": "gpt-test",
+                    "api_key": "sk-super-secret-should-not-be-plain",
+                },
+            )
+            assert r.status_code == 200, r.text
+            llm_id = r.json()["id"]
+            row = await app.state.app_state.db.get_llm(llm_id)
+            assert row is not None
+            stored = row.get("api_key_enc") or ""
+            assert stored.startswith(ENC_PREFIX)
+            assert "sk-super-secret" not in stored
+            # status must not leak key
+            st = await client.get("/api/v1/ai/status", headers=headers)
+            assert st.status_code == 200
+            assert "sk-super-secret" not in st.text


### PR DESCRIPTION
## Summary
- Encrypt LLM API keys with Fernet (\`enc:v1:\` prefix) before DB write
- Master key: \`SQUIDC5_SECRETS_KEY\` or auto \`data/secrets.key\` (0600)
- Legacy plaintext rows still decrypt; re-encrypted on LLM call

## Test plan
- [x] \`pytest -q tests/test_llm_key_encryption.py\`
- [x] Full suite 170 passed
- [ ] CI green

A06 prod-readiness.