### PR TITLE
feat(listeners): restore running listeners on startup

### DIFF
--- a/src/squidc5/listeners/manager.py
+++ b/src/squidc5/listeners/manager.py
@@ -176,7 +176,7 @@ class ListenerManager:
         updated = await self.db.get_listener(listener_id)
         return self._norm(updated)  # type: ignore[arg-type]
 
-    async def stop(self, listener_id: str) -> dict[str, Any]:
+    async def stop(self, listener_id: str, *, persist_status: bool = True) -> dict[str, Any]:
         async with self._lock:
             task = self._tasks.pop(listener_id, None)
             server = self._servers.pop(listener_id, None)
@@ -192,7 +192,8 @@ class ListenerManager:
                 await server.wait_closed()
             if udp:
                 udp.close()
-            await self.db.set_listener_status(listener_id, "stopped")
+            if persist_status:
+                await self.db.set_listener_status(listener_id, "stopped")
         await self.metrics.emit("listener.stopped", {"id": listener_id})
         row = await self.db.get_listener(listener_id)
         return self._norm(row)  # type: ignore[arg-type]
@@ -202,13 +203,41 @@ class ListenerManager:
             await self.stop(listener_id)
         return await self.db.delete_listener(listener_id)
 
-    async def stop_all(self) -> None:
+    async def stop_all(self, *, persist_status: bool = False) -> None:
+        """Stop in-process sockets. Default leaves DB status for restart restore."""
         ids = list(set(self._servers.keys()) | set(self._udp.keys()))
         for lid in ids:
             try:
-                await self.stop(lid)
+                await self.stop(lid, persist_status=persist_status)
             except Exception:
                 log.exception("Error stopping listener %s", lid)
+
+    async def restore_running(self) -> dict[str, Any]:
+        """Start listeners marked running in DB (process restart recovery)."""
+        restored: list[str] = []
+        errors: list[dict[str, str]] = []
+        rows = await self.db.list_listeners()
+        for row in rows:
+            if (row.get("status") or "") != "running":
+                continue
+            lid = row["id"]
+            try:
+                await self.start(lid)
+                restored.append(lid)
+            except Exception as e:
+                log.exception("Failed to restore listener %s", lid)
+                try:
+                    await self.db.set_listener_status(lid, "error")
+                except Exception:
+                    pass
+                errors.append({"id": lid, "error": str(e)[:200]})
+                await self.metrics.emit(
+                    "listener.restore_failed",
+                    {"id": lid, "error": str(e)[:200]},
+                )
+        if restored:
+            log.info("Restored %s listener(s) from DB: %s", len(restored), restored)
+        return {"restored": restored, "errors": errors}
 
     def _enable_keepalive(self, writer: asyncio.StreamWriter) -> None:
         sock = writer.get_extra_info("socket")

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -153,11 +153,21 @@ def create_app(settings: Settings | None = None) -> FastAPI:
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         state = await build_state(settings)
         app.state.app_state = state
+        try:
+            restore = await state.listeners.restore_running()
+        except Exception:
+            log.exception("Listener restore failed")
+            restore = {"restored": [], "errors": [{"error": "restore crashed"}]}
         await state.db.audit(
             actor="system",
             actor_type="system",
             action="server.start",
-            details={"version": __version__, "port": settings.port},
+            details={
+                "version": __version__,
+                "port": settings.port,
+                "listeners_restored": restore.get("restored") or [],
+                "listeners_restore_errors": restore.get("errors") or [],
+            },
         )
         log.info("SquidC5 v%s listening on %s:%s", __version__, settings.host, settings.port)
         yield

--- a/tests/test_listener_restore.py
+++ b/tests/test_listener_restore.py
@@ -1,0 +1,98 @@
+"""Listener restore on boot (B02)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_lrest01"
+
+
+@pytest.mark.asyncio
+async def test_restore_running_listeners_on_startup(tmp_path):
+    data = tmp_path / "data_lr"
+    settings = Settings(
+        data_dir=data,
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=1000,
+    )
+    # First boot: create + start a reverse_shell listener on ephemeral port
+    app1 = create_app(settings)
+    lid = None
+    port = 18765
+    async with app1.router.lifespan_context(app1):
+        transport = ASGITransport(app=app1)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            headers = {"Authorization": f"Bearer {ADMIN}"}
+            cr = await client.post(
+                "/api/v1/listeners",
+                headers=headers,
+                json={
+                    "name": "rev-restore",
+                    "kind": "reverse_shell",
+                    "host": "127.0.0.1",
+                    "port": port,
+                },
+            )
+            assert cr.status_code == 200, cr.text
+            lid = cr.json()["id"]
+            st = await client.post(f"/api/v1/listeners/{lid}/start", headers=headers)
+            assert st.status_code == 200, st.text
+            assert st.json()["status"] == "running"
+
+    # Second boot: same DB — must restore running listener
+    app2 = create_app(settings)
+    async with app2.router.lifespan_context(app2):
+        row = await app2.state.app_state.db.get_listener(lid)
+        assert row is not None
+        assert row["status"] == "running"
+        # live server map should include it
+        assert lid in app2.state.app_state.listeners._servers
+
+
+@pytest.mark.asyncio
+async def test_restore_bind_failure_marks_error(tmp_path):
+    """If port cannot bind, status becomes error and app still starts."""
+    data = tmp_path / "data_lr2"
+    settings = Settings(
+        data_dir=data,
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN + "b",
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=1000,
+    )
+    # Occupy a port
+    import asyncio
+
+    async def _hold(reader, writer):
+        await asyncio.sleep(3600)
+
+    holder = await asyncio.start_server(_hold, host="127.0.0.1", port=0)
+    sock = holder.sockets[0]
+    port = sock.getsockname()[1]
+
+    app1 = create_app(settings)
+    lid = None
+    async with app1.router.lifespan_context(app1):
+        # Insert a fake running listener pointing at occupied port via DB
+        lid = await app1.state.app_state.db.create_listener(
+            "conflict", "reverse_shell", port, "127.0.0.1", {}
+        )
+        await app1.state.app_state.db.set_listener_status(lid, "running")
+
+    app2 = create_app(settings)
+    async with app2.router.lifespan_context(app2):
+        row = await app2.state.app_state.db.get_listener(lid)
+        assert row is not None
+        assert row["status"] == "error"
+        assert lid not in app2.state.app_state.listeners._servers
+
+    holder.close()
+    await holder.wait_closed()


### PR DESCRIPTION
## Summary
- \`restore_running()\` on lifespan start
- Bind failures → status \`error\`, app continues
- Clean shutdown keeps DB \`running\` so restart restores listeners

## Test plan
- [x] \`pytest -q tests/test_listener_restore.py\`
- [x] Full suite
- [ ] CI green

B02 prod-readiness.