### PR TITLE
feat(api): authenticated deep health endpoint

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -217,6 +217,53 @@ def build_api_router() -> APIRouter:
             "version": "0.1.0",
         }
 
+    @api.get("/health/deep")
+    async def health_deep(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("metrics:read", "admin")),
+    ) -> dict[str, Any]:
+        """Authenticated deep health — no secrets/tokens/keys."""
+        from squidc5 import __version__
+
+        state = get_state(request)
+        db_ok = False
+        try:
+            await state.db.fetchone("SELECT 1 AS ok")
+            db_ok = True
+        except Exception:
+            db_ok = False
+
+        data_dir = state.settings.data_dir
+        disk: dict[str, Any] = {"path": str(data_dir), "writable": False}
+        try:
+            data_dir.mkdir(parents=True, exist_ok=True)
+            probe = data_dir / ".health_write_probe"
+            probe.write_text("ok", encoding="utf-8")
+            probe.unlink(missing_ok=True)
+            disk["writable"] = True
+        except OSError as e:
+            disk["error"] = type(e).__name__
+
+        listeners = await state.listeners.list()
+        running = [x for x in listeners if x.get("status") == "running"]
+        live_binds = sorted(
+            set(state.listeners._servers.keys()) | set(state.listeners._udp.keys())
+        )
+        overall = "ok" if db_ok and disk.get("writable") else "degraded"
+        return {
+            "status": overall,
+            "version": __version__,
+            "db": {"ok": db_ok},
+            "disk": disk,
+            "listeners": {
+                "configured": len(listeners),
+                "running_status": len(running),
+                "live_binds": len(live_binds),
+            },
+            "tls_enabled": bool(state.settings.tls_enabled),
+            "mcp_enabled_setting": bool(state.settings.mcp_enabled),
+        }
+
     @api.get("/meta")
     async def meta(auth: AuthContext = Depends(get_auth)) -> dict[str, Any]:
         return {

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -1,4 +1,5 @@
 import pytest
+from conftest import bearer, mint_token
 
 
 @pytest.mark.asyncio
@@ -25,3 +26,39 @@ async def test_health(client):
     assert body["status"] == "ok"
     # secure default: no version/app fingerprint
     assert "version" not in body
+
+
+@pytest.mark.asyncio
+async def test_health_deep_requires_auth(client):
+    assert (await client.get("/api/v1/health/deep")).status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_health_deep_admin(client, admin_headers):
+    r = await client.get("/api/v1/health/deep", headers=admin_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["status"] in ("ok", "degraded")
+    assert body["db"]["ok"] is True
+    assert body["disk"]["writable"] is True
+    assert "listeners" in body
+    assert "version" in body
+    # no secrets
+    blob = r.text.lower()
+    assert "api_key" not in blob
+    assert "sc5_" not in blob or "sc5_test" not in blob
+
+
+@pytest.mark.asyncio
+async def test_health_deep_metrics_scope(client, admin_headers):
+    t = await mint_token(client, admin_headers, "metrics-health", ["metrics:read"])
+    r = await client.get("/api/v1/health/deep", headers=bearer(t["token"]))
+    assert r.status_code == 200
+    assert r.json()["db"]["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_health_deep_denied_without_scope(client, admin_headers):
+    t = await mint_token(client, admin_headers, "no-deep", ["sessions:read"])
+    r = await client.get("/api/v1/health/deep", headers=bearer(t["token"]))
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary
- \`GET /api/v1/health/deep\` (metrics:read or admin)
- Reports db/disk/listener bind counts without secrets
- Public \`/health\` unchanged (minimal)

## Test plan
- [x] \`pytest -q tests/test_health.py\`
- [ ] CI green

B05 prod-readiness.