### PR TITLE
feat(config): fail-fast startup validation

### DIFF
--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from functools import lru_cache
 from pathlib import Path
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -62,10 +62,56 @@ class Settings(BaseSettings):
     tls_key_file: Path | None = None
     tls_force_new: bool = False  # regenerate cert/key on next start
 
+    @field_validator("port", "default_listener_port", "oast_http_port")
+    @classmethod
+    def _port_range(cls, v: int) -> int:
+        if not 1 <= int(v) <= 65535:
+            raise ValueError("port must be 1-65535")
+        return int(v)
+
+    @field_validator("max_body_bytes", "rate_limit_per_minute", "auth_fail_limit_per_minute")
+    @classmethod
+    def _non_negative(cls, v: int) -> int:
+        if int(v) < 0:
+            raise ValueError("must be >= 0")
+        return int(v)
+
+    @model_validator(mode="after")
+    def _cross_field(self) -> Settings:
+        cert = self.tls_cert_file
+        key = self.tls_key_file
+        if (cert is None) ^ (key is None):
+            raise ValueError("SQUIDC5_TLS_CERT_FILE and SQUIDC5_TLS_KEY_FILE must both be set or both unset")
+        if self.tls_enabled and cert is not None and key is not None:
+            if not Path(cert).is_file():
+                raise ValueError(f"TLS cert file not found: {cert}")
+            if not Path(key).is_file():
+                raise ValueError(f"TLS key file not found: {key}")
+        if self.shell_auto_stabilize and not (self.public_host or "").strip() and not self.debug:
+            # Warn-level only at runtime; hard fail would break many lab installs.
+            # Production operators should set public_host — enforced as soft check in validate().
+            pass
+        if self.audit_retention_days < 1:
+            raise ValueError("audit_retention_days must be >= 1")
+        return self
+
     def resolve_db_path(self) -> Path:
         if self.db_path is not None:
             return self.db_path
         return self.data_dir / "squidc5.db"
+
+    def validate_runtime(self) -> list[str]:
+        """Extra runtime checks. Returns warnings; raises ValueError on hard errors."""
+        warnings: list[str] = []
+        if self.shell_auto_stabilize and not (self.public_host or "").strip():
+            warnings.append(
+                "SQUIDC5_PUBLIC_HOST is empty while shell_auto_stabilize is on — "
+                "stage-2 implants may reconnect to the wrong host"
+            )
+        if self.tls_enabled and self.tls_cert_file and self.tls_key_file:
+            if not Path(self.tls_cert_file).is_file() or not Path(self.tls_key_file).is_file():
+                raise ValueError("TLS cert/key pair missing on disk")
+        return warnings
 
 
 @lru_cache

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -153,6 +153,8 @@ async def build_state(settings: Settings) -> AppState:
 
 def create_app(settings: Settings | None = None) -> FastAPI:
     settings = settings or get_settings()
+    for w in settings.validate_runtime():
+        log.warning("config: %s", w)
 
     @asynccontextmanager
     async def lifespan(app: FastAPI) -> AsyncIterator[None]:
@@ -409,6 +411,11 @@ def create_app(settings: Settings | None = None) -> FastAPI:
 
 def cli() -> None:
     settings = get_settings()
+    try:
+        for w in settings.validate_runtime():
+            log.warning("config: %s", w)
+    except ValueError as e:
+        raise SystemExit(f"Invalid configuration: {e}") from e
     ssl_kwargs: dict = {}
     if settings.tls_enabled:
         from squidc5.tls.certs import ensure_instance_tls

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -1,0 +1,66 @@
+"""Startup config validation (B08)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from squidc5.config import Settings
+
+
+def test_port_out_of_range():
+    with pytest.raises(ValidationError):
+        Settings(port=0)
+    with pytest.raises(ValidationError):
+        Settings(port=70000)
+
+
+def test_tls_pair_must_be_both_or_neither(tmp_path: Path):
+    cert = tmp_path / "c.pem"
+    cert.write_text("x", encoding="utf-8")
+    with pytest.raises(ValidationError, match="both"):
+        Settings(tls_cert_file=cert, tls_key_file=None)
+    with pytest.raises(ValidationError, match="both"):
+        Settings(tls_cert_file=None, tls_key_file=tmp_path / "k.pem")
+
+
+def test_tls_files_must_exist_when_set(tmp_path: Path):
+    with pytest.raises(ValidationError, match="not found"):
+        Settings(
+            tls_enabled=True,
+            tls_cert_file=tmp_path / "missing.crt",
+            tls_key_file=tmp_path / "missing.key",
+        )
+
+
+def test_tls_pair_ok_when_files_exist(tmp_path: Path):
+    c = tmp_path / "server.crt"
+    k = tmp_path / "server.key"
+    c.write_text("cert", encoding="utf-8")
+    k.write_text("key", encoding="utf-8")
+    s = Settings(tls_enabled=True, tls_cert_file=c, tls_key_file=k, debug=True)
+    assert s.tls_cert_file == c
+    assert s.validate_runtime()  # may warn about public_host
+
+
+def test_negative_rate_limit_rejected():
+    with pytest.raises(ValidationError):
+        Settings(rate_limit_per_minute=-1)
+
+
+def test_audit_retention_min():
+    with pytest.raises(ValidationError):
+        Settings(audit_retention_days=0)
+
+
+def test_public_host_warning_when_stabilize(tmp_path: Path):
+    s = Settings(
+        data_dir=tmp_path,
+        shell_auto_stabilize=True,
+        public_host="",
+        debug=True,
+    )
+    warns = s.validate_runtime()
+    assert any("PUBLIC_HOST" in w for w in warns)


### PR DESCRIPTION
## Summary
- Pydantic validators for ports, TLS pair, rate limits, audit retention
- Runtime warnings for empty PUBLIC_HOST with shell auto-stabilize
- cli() exits on hard config errors

## Test plan
- [x] \`pytest -q tests/test_config_validation.py\`
- [x] Full suite
- [ ] CI green

B08 prod-readiness.