### PR TITLE
feat(cli): backup and restore SQLite data

### DIFF
--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -127,6 +127,44 @@ class Client:
         return self.request("DELETE", path, **kwargs)
 
 
+def cmd_backup(args: argparse.Namespace) -> None:
+    """Local SQLite backup (no API). Stop writes for best consistency in prod."""
+    from squidc5.config import Settings
+    from squidc5.db.backup import backup_database
+
+    settings = Settings(
+        data_dir=Path(args.data_dir) if args.data_dir else Path("data"),
+        db_path=Path(args.db) if args.db else None,
+    )
+    src = settings.resolve_db_path()
+    dest = Path(args.output)
+    out = backup_database(src, dest)
+    print(json.dumps({"ok": True, "source": str(src), "backup": str(out)}, indent=2))
+
+
+def cmd_restore(args: argparse.Namespace) -> None:
+    """Restore SQLite from backup file. Stop squidc5 before restore."""
+    from squidc5.config import Settings
+    from squidc5.db.backup import restore_database
+
+    settings = Settings(
+        data_dir=Path(args.data_dir) if args.data_dir else Path("data"),
+        db_path=Path(args.db) if args.db else None,
+    )
+    target = settings.resolve_db_path()
+    out = restore_database(Path(args.backup), target)
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "restored_to": str(out),
+                "note": "Restart squidc5 after restore",
+            },
+            indent=2,
+        )
+    )
+
+
 def cmd_login(args: argparse.Namespace) -> None:
     cfg = load_config()
     if args.url:
@@ -766,6 +804,23 @@ def build_parser() -> argparse.ArgumentParser:
     cfg = sub.add_parser("config", help="Show saved config")
     cfg.add_argument("--show-token", action="store_true")
     cfg.set_defaults(func=cmd_config_show, needs_client=False)
+
+    bak = sub.add_parser("backup", help="Backup local SQLite DB (no API)")
+    bak.add_argument(
+        "output",
+        nargs="?",
+        default=".",
+        help="Output file or directory (default: .)",
+    )
+    bak.add_argument("--data-dir", default=None, help="Data dir (default: ./data)")
+    bak.add_argument("--db", default=None, help="Explicit DB path override")
+    bak.set_defaults(func=cmd_backup, needs_client=False)
+
+    rst = sub.add_parser("restore", help="Restore local SQLite DB from backup (stop server first)")
+    rst.add_argument("backup", help="Backup .db file")
+    rst.add_argument("--data-dir", default=None, help="Data dir (default: ./data)")
+    rst.add_argument("--db", default=None, help="Explicit DB path override")
+    rst.set_defaults(func=cmd_restore, needs_client=False)
 
     # simple
     for name, fn, help_ in (

--- a/src/squidc5/db/backup.py
+++ b/src/squidc5/db/backup.py
@@ -1,0 +1,60 @@
+"""SQLite backup / restore helpers."""
+
+from __future__ import annotations
+
+import shutil
+import sqlite3
+import time
+from pathlib import Path
+
+
+def backup_database(source_db: Path, dest: Path) -> Path:
+    """Hot-ish backup via SQLite backup API into dest file."""
+    source_db = Path(source_db)
+    dest = Path(dest)
+    if not source_db.is_file():
+        raise FileNotFoundError(f"database not found: {source_db}")
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists() and dest.is_dir():
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        dest = dest / f"squidc5-{stamp}.db"
+    # Use sqlite3 backup API for a consistent snapshot
+    src = sqlite3.connect(f"file:{source_db}?mode=ro", uri=True)
+    try:
+        dst = sqlite3.connect(str(dest))
+        try:
+            src.backup(dst)
+            dst.commit()
+        finally:
+            dst.close()
+    finally:
+        src.close()
+    try:
+        dest.chmod(0o600)
+    except OSError:
+        pass
+    return dest
+
+
+def restore_database(backup_path: Path, target_db: Path) -> Path:
+    """Replace target_db with backup. Caller should stop the server first."""
+    backup_path = Path(backup_path)
+    target_db = Path(target_db)
+    if not backup_path.is_file():
+        raise FileNotFoundError(f"backup not found: {backup_path}")
+    # Validate backup is a readable SQLite DB
+    con = sqlite3.connect(f"file:{backup_path}?mode=ro", uri=True)
+    try:
+        con.execute("SELECT 1 FROM sqlite_master LIMIT 1")
+    finally:
+        con.close()
+    target_db.parent.mkdir(parents=True, exist_ok=True)
+    if target_db.is_file():
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        shutil.copy2(target_db, target_db.with_suffix(target_db.suffix + f".pre-restore-{stamp}"))
+    shutil.copy2(backup_path, target_db)
+    try:
+        target_db.chmod(0o600)
+    except OSError:
+        pass
+    return target_db

--- a/tests/test_backup_restore.py
+++ b/tests/test_backup_restore.py
@@ -1,0 +1,67 @@
+"""SQLite backup/restore (B04)."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from squidc5.cli import main
+from squidc5.db.backup import backup_database, restore_database
+from squidc5.db.store import Database
+
+
+@pytest.mark.asyncio
+async def test_backup_and_restore_roundtrip(tmp_path: Path):
+    data = tmp_path / "data"
+    data.mkdir()
+    db_path = data / "squidc5.db"
+    db = Database(db_path)
+    await db.connect()
+    await db.execute(
+        "INSERT INTO tokens (id, name, token_hash, scopes, created_at) "
+        "VALUES ('t1', 'keep', 'h1', '[\"admin\"]', 1.0)"
+    )
+    await db.close()
+
+    bak = backup_database(db_path, tmp_path / "out" / "snap.db")
+    assert bak.is_file()
+
+    # mutate original
+    con = sqlite3.connect(str(db_path))
+    con.execute("DELETE FROM tokens")
+    con.commit()
+    con.close()
+
+    restore_database(bak, db_path)
+    con = sqlite3.connect(str(db_path))
+    row = con.execute("SELECT name FROM tokens WHERE id='t1'").fetchone()
+    con.close()
+    assert row is not None
+    assert row[0] == "keep"
+
+
+def test_cli_backup_restore(tmp_path: Path, capsys):
+    data = tmp_path / "d"
+    data.mkdir()
+    db_path = data / "squidc5.db"
+    con = sqlite3.connect(str(db_path))
+    con.executescript("CREATE TABLE t (id INT); INSERT INTO t VALUES (1);")
+    con.close()
+
+    out = tmp_path / "b.db"
+    main(["backup", str(out), "--data-dir", str(data)])
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["ok"] is True
+    assert Path(printed["backup"]).is_file()
+
+    # wipe and restore
+    db_path.unlink()
+    main(["restore", str(out), "--data-dir", str(data)])
+    printed2 = json.loads(capsys.readouterr().out)
+    assert printed2["ok"] is True
+    con = sqlite3.connect(str(db_path))
+    assert con.execute("SELECT id FROM t").fetchone()[0] == 1
+    con.close()


### PR DESCRIPTION
## Summary
- \`sc5 backup [path]\` — SQLite backup API snapshot
- \`sc5 restore <backup.db>\` — replace local DB (stop server first)
- Pre-restore copy of existing DB kept as \`.pre-restore-*\`

## Test plan
- [x] \`pytest -q tests/test_backup_restore.py\`
- [ ] CI green

B04 prod-readiness.