### PR TITLE
feat(policy): server-side HITL approval queue

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -14,8 +14,16 @@ from pydantic import BaseModel, Field
 from squidc5.api.deps import get_auth, get_state, require_scope
 from squidc5.auth.tokens import ALL_MCP_TOOLS, DEFAULT_MCP_TOOLS, SCOPES, AuthContext
 from squidc5.paths import web_file
+from squidc5.policy.engine import PolicyDecision
 
 # --- Request models ---
+
+
+def _policy_http_error(decision: PolicyDecision) -> HTTPException:
+    detail: dict[str, Any] = {"detail": decision.reason, "require_hitl": decision.require_hitl}
+    if decision.hitl_request_id:
+        detail["hitl_request_id"] = decision.hitl_request_id
+    return HTTPException(status_code=403, detail=detail)
 
 
 class TokenCreate(BaseModel):
@@ -46,7 +54,8 @@ class TaskCreate(BaseModel):
     session_id: str
     command: str
     args: dict[str, Any] = Field(default_factory=dict)
-    hitl_approved: bool = False
+    hitl_approved: bool = False  # ignored; use hitl_request_id
+    hitl_request_id: str | None = None
 
 
 class PayloadRequest(BaseModel):
@@ -78,7 +87,8 @@ class AIRunRequest(BaseModel):
 class ShellCommand(BaseModel):
     session_id: str
     command: str
-    hitl_approved: bool = False
+    hitl_approved: bool = False  # ignored; use hitl_request_id
+    hitl_request_id: str | None = None
     wait_sec: float = 2.5
     idle_sec: float = 0.45
 
@@ -469,10 +479,13 @@ def build_api_router() -> APIRouter:
             auth,
             "tasks.create",
             resource=body.session_id,
-            extra={"hitl_approved": body.hitl_approved, "command": body.command[:100]},
+            extra={
+                "hitl_request_id": body.hitl_request_id,
+                "command": body.command[:100],
+            },
         )
         if not decision.allowed:
-            raise HTTPException(403, decision.reason)
+            raise _policy_http_error(decision)
         try:
             return await state.tasks.create(
                 session_id=body.session_id,
@@ -660,10 +673,13 @@ def build_api_router() -> APIRouter:
             auth,
             "shell.interact",
             resource=body.session_id,
-            extra={"hitl_approved": body.hitl_approved},
+            extra={
+                "hitl_request_id": body.hitl_request_id,
+                "command": body.command[:100],
+            },
         )
         if not decision.allowed:
-            raise HTTPException(403, decision.reason)
+            raise _policy_http_error(decision)
         if not state.listeners.is_live(body.session_id):
             # Stale DB row looking "active" but TCP is gone
             await state.sessions.close(body.session_id)
@@ -698,15 +714,15 @@ def build_api_router() -> APIRouter:
             raise HTTPException(400, "command required")
         wait_sec = float(body.get("wait_sec", 2.5))
         idle_sec = float(body.get("idle_sec", 0.45))
-        hitl = bool(body.get("hitl_approved", False))
+        hitl_rid = body.get("hitl_request_id")
         decision = await state.policy.check_and_audit(
             auth,
             "shell.interact",
             resource="broadcast",
-            extra={"hitl_approved": hitl, "command": command[:100]},
+            extra={"hitl_request_id": hitl_rid, "command": command[:100]},
         )
         if not decision.allowed:
-            raise HTTPException(403, decision.reason)
+            raise _policy_http_error(decision)
 
         # Drop TCP-dead + non-executing zombies before broadcast
         await state.sessions.close_orphaned_shells(probe=True)
@@ -819,6 +835,60 @@ def build_api_router() -> APIRouter:
         state = get_state(request)
         await state.policy.update(body.rules, auth.name)
         return await state.policy.get_rules()
+
+    @api.get("/policy/hitl")
+    async def list_hitl(
+        request: Request,
+        status: str | None = "pending",
+        limit: int = 100,
+        auth: AuthContext = Depends(require_scope("policy:manage", "admin")),
+    ) -> dict[str, Any]:
+        rows = await get_state(request).db.list_hitl_requests(status=status, limit=limit)
+        return {"requests": rows}
+
+    @api.post("/policy/hitl/{request_id}/approve")
+    async def approve_hitl(
+        request_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        ok = await state.db.resolve_hitl_request(
+            request_id, status="approved", resolved_by=auth.name
+        )
+        if not ok:
+            raise HTTPException(404, "HITL request not found or not pending")
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="policy.hitl.approve",
+            resource=request_id,
+            risk_score=6,
+        )
+        row = await state.db.get_hitl_request(request_id)
+        return {"ok": True, "request": row}
+
+    @api.post("/policy/hitl/{request_id}/deny")
+    async def deny_hitl(
+        request_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        ok = await state.db.resolve_hitl_request(
+            request_id, status="denied", resolved_by=auth.name
+        )
+        if not ok:
+            raise HTTPException(404, "HITL request not found or not pending")
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="policy.hitl.deny",
+            resource=request_id,
+            risk_score=4,
+        )
+        row = await state.db.get_hitl_request(request_id)
+        return {"ok": True, "request": row}
 
     # ----- Feature flags (admin) -----
 

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -481,7 +481,7 @@ def build_api_router() -> APIRouter:
             resource=body.session_id,
             extra={
                 "hitl_request_id": body.hitl_request_id,
-                "command": body.command[:100],
+                "command": body.command,
             },
         )
         if not decision.allowed:
@@ -675,7 +675,7 @@ def build_api_router() -> APIRouter:
             resource=body.session_id,
             extra={
                 "hitl_request_id": body.hitl_request_id,
-                "command": body.command[:100],
+                "command": body.command,
             },
         )
         if not decision.allowed:
@@ -719,7 +719,7 @@ def build_api_router() -> APIRouter:
             auth,
             "shell.interact",
             resource="broadcast",
-            extra={"hitl_request_id": hitl_rid, "command": command[:100]},
+            extra={"hitl_request_id": hitl_rid, "command": command},
         )
         if not decision.allowed:
             raise _policy_http_error(decision)

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -662,6 +662,23 @@ def cmd_policy_get(args: argparse.Namespace, client: Client) -> None:
     pp(client.get("/api/v1/policy"))
 
 
+def cmd_policy_hitl_list(args: argparse.Namespace, client: Client) -> None:
+    params: dict[str, Any] = {}
+    if args.status:
+        params["status"] = args.status
+    if args.limit:
+        params["limit"] = args.limit
+    pp(client.get("/api/v1/policy/hitl", params=params))
+
+
+def cmd_policy_hitl_approve(args: argparse.Namespace, client: Client) -> None:
+    pp(client.post(f"/api/v1/policy/hitl/{args.request_id}/approve"))
+
+
+def cmd_policy_hitl_deny(args: argparse.Namespace, client: Client) -> None:
+    pp(client.post(f"/api/v1/policy/hitl/{args.request_id}/deny"))
+
+
 def cmd_policy_set(args: argparse.Namespace, client: Client) -> None:
     rules = json.loads(Path(args.file).read_text(encoding="utf-8") if args.file else args.json)
     pp(client.put("/api/v1/policy", json={"rules": rules}))
@@ -1149,6 +1166,18 @@ def build_parser() -> argparse.ArgumentParser:
     pol_set.add_argument("--json", dest="json")
     pol_set.add_argument("--file")
     pol_set.set_defaults(func=cmd_policy_set, needs_client=True)
+    pol_hitl = pol_sub.add_parser("hitl", help="HITL approval queue")
+    pol_hitl_sub = pol_hitl.add_subparsers(dest="policy_hitl_cmd", required=True)
+    ph_list = pol_hitl_sub.add_parser("list")
+    ph_list.add_argument("--status", default="pending")
+    ph_list.add_argument("--limit", type=int, default=50)
+    ph_list.set_defaults(func=cmd_policy_hitl_list, needs_client=True)
+    ph_ok = pol_hitl_sub.add_parser("approve")
+    ph_ok.add_argument("request_id")
+    ph_ok.set_defaults(func=cmd_policy_hitl_approve, needs_client=True)
+    ph_no = pol_hitl_sub.add_parser("deny")
+    ph_no.add_argument("request_id")
+    ph_no.set_defaults(func=cmd_policy_hitl_deny, needs_client=True)
 
     # oast collaborator
     oast = sub.add_parser("oast", help="OAST Collaborator (tokens + hits)")

--- a/src/squidc5/db/migrate.py
+++ b/src/squidc5/db/migrate.py
@@ -191,9 +191,29 @@ CREATE INDEX IF NOT EXISTS idx_oast_interactions_client ON oast_interactions(cli
 CREATE INDEX IF NOT EXISTS idx_oast_interactions_token ON oast_interactions(token);
 """
 
+HITL_REQUESTS_SQL = """
+CREATE TABLE IF NOT EXISTS hitl_requests (
+    id TEXT PRIMARY KEY,
+    action TEXT NOT NULL,
+    resource TEXT,
+    actor TEXT NOT NULL,
+    actor_type TEXT NOT NULL DEFAULT 'operator',
+    details TEXT NOT NULL DEFAULT '{}',
+    risk_score INTEGER NOT NULL DEFAULT 0,
+    status TEXT NOT NULL DEFAULT 'pending',
+    created_at REAL NOT NULL,
+    resolved_at REAL,
+    resolved_by TEXT,
+    expires_at REAL
+);
+CREATE INDEX IF NOT EXISTS idx_hitl_status ON hitl_requests(status);
+CREATE INDEX IF NOT EXISTS idx_hitl_actor ON hitl_requests(actor);
+"""
+
 # (version, description, sql) — versions must be contiguous starting at 1
 MIGRATIONS: Sequence[tuple[int, str, str]] = (
     (1, "baseline schema", BASELINE_SQL),
+    (2, "HITL approval queue", HITL_REQUESTS_SQL),
 )
 
 SCHEMA_VERSION_TABLE = """

--- a/src/squidc5/db/migrate.py
+++ b/src/squidc5/db/migrate.py
@@ -199,6 +199,7 @@ CREATE TABLE IF NOT EXISTS hitl_requests (
     actor TEXT NOT NULL,
     actor_type TEXT NOT NULL DEFAULT 'operator',
     details TEXT NOT NULL DEFAULT '{}',
+    binding_hash TEXT NOT NULL DEFAULT '',
     risk_score INTEGER NOT NULL DEFAULT 0,
     status TEXT NOT NULL DEFAULT 'pending',
     created_at REAL NOT NULL,

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -241,6 +241,7 @@ class Database:
         actor_type: str = "operator",
         resource: str | None = None,
         details: dict[str, Any] | None = None,
+        binding_hash: str = "",
         risk_score: int = 0,
         ttl_sec: float = 900.0,
     ) -> str:
@@ -248,8 +249,8 @@ class Database:
         now = _now()
         await self.execute(
             """INSERT INTO hitl_requests
-               (id, action, resource, actor, actor_type, details, risk_score, status, created_at, expires_at)
-               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
+               (id, action, resource, actor, actor_type, details, binding_hash, risk_score, status, created_at, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
             (
                 hid,
                 action,
@@ -257,6 +258,7 @@ class Database:
                 actor,
                 actor_type,
                 json.dumps(details or {}),
+                binding_hash or "",
                 risk_score,
                 now,
                 now + float(ttl_sec),

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -231,6 +231,68 @@ class Database:
         cur = await self.execute("DELETE FROM listeners WHERE id = ?", (listener_id,))
         return cur.rowcount > 0
 
+    # --- HITL approval queue ---
+
+    async def create_hitl_request(
+        self,
+        *,
+        action: str,
+        actor: str,
+        actor_type: str = "operator",
+        resource: str | None = None,
+        details: dict[str, Any] | None = None,
+        risk_score: int = 0,
+        ttl_sec: float = 900.0,
+    ) -> str:
+        hid = _uid("hitl_")
+        now = _now()
+        await self.execute(
+            """INSERT INTO hitl_requests
+               (id, action, resource, actor, actor_type, details, risk_score, status, created_at, expires_at)
+               VALUES (?, ?, ?, ?, ?, ?, ?, 'pending', ?, ?)""",
+            (
+                hid,
+                action,
+                resource,
+                actor,
+                actor_type,
+                json.dumps(details or {}),
+                risk_score,
+                now,
+                now + float(ttl_sec),
+            ),
+        )
+        return hid
+
+    async def get_hitl_request(self, request_id: str) -> dict[str, Any] | None:
+        return await self.fetchone("SELECT * FROM hitl_requests WHERE id = ?", (request_id,))
+
+    async def list_hitl_requests(
+        self, *, status: str | None = "pending", limit: int = 100
+    ) -> list[dict[str, Any]]:
+        lim = min(max(int(limit), 1), 500)
+        if status:
+            return await self.fetchall(
+                "SELECT * FROM hitl_requests WHERE status = ? ORDER BY created_at DESC LIMIT ?",
+                (status, lim),
+            )
+        return await self.fetchall(
+            "SELECT * FROM hitl_requests ORDER BY created_at DESC LIMIT ?",
+            (lim,),
+        )
+
+    async def resolve_hitl_request(
+        self, request_id: str, *, status: str, resolved_by: str
+    ) -> bool:
+        if status not in ("approved", "denied"):
+            raise ValueError("status must be approved or denied")
+        cur = await self.execute(
+            """UPDATE hitl_requests SET status = ?, resolved_at = ?, resolved_by = ?
+               WHERE id = ? AND status = 'pending'""",
+            (status, _now(), resolved_by, request_id),
+        )
+        return cur.rowcount > 0
+
     # --- Tasks ---
 
     async def create_task(

--- a/src/squidc5/policy/engine.py
+++ b/src/squidc5/policy/engine.py
@@ -17,12 +17,13 @@ def hitl_binding_hash(
     resource: str | None,
     extra: dict[str, Any] | None,
 ) -> str:
-    """Bind approval to action + resource + command (or other intent fields)."""
+    """Bind approval to action + resource + full command (or other intent fields)."""
     extra = extra or {}
+    # Full command — do not truncate (truncation enables prefix-collision bypass)
     intent = {
         "action": action,
         "resource": resource or "",
-        "command": str(extra.get("command") or "")[:500],
+        "command": str(extra.get("command") or ""),
         "capability": str(extra.get("capability") or ""),
     }
     raw = json.dumps(intent, sort_keys=True, separators=(",", ":")).encode()
@@ -218,6 +219,9 @@ class PolicyEngine:
                     for k, v in (extra or {}).items()
                     if k not in ("hitl_approved", "api_key", "token", "hitl_request_id")
                 }
+                # Cap stored detail length only (binding uses full command separately)
+                if isinstance(safe_details.get("command"), str) and len(safe_details["command"]) > 2000:
+                    safe_details["command"] = safe_details["command"][:2000] + "…[truncated]"
                 binding = hitl_binding_hash(action, resource, extra)
                 hid = await self.db.create_hitl_request(
                     action=action,

--- a/src/squidc5/policy/engine.py
+++ b/src/squidc5/policy/engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import time
 from dataclasses import dataclass, field
@@ -9,6 +10,23 @@ from typing import Any
 
 from squidc5.auth.tokens import AuthContext
 from squidc5.db.store import Database
+
+
+def hitl_binding_hash(
+    action: str,
+    resource: str | None,
+    extra: dict[str, Any] | None,
+) -> str:
+    """Bind approval to action + resource + command (or other intent fields)."""
+    extra = extra or {}
+    intent = {
+        "action": action,
+        "resource": resource or "",
+        "command": str(extra.get("command") or "")[:500],
+        "capability": str(extra.get("capability") or ""),
+    }
+    raw = json.dumps(intent, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(raw).hexdigest()
 
 DEFAULT_POLICY: dict[str, Any] = {
     "version": 1,
@@ -139,6 +157,11 @@ class PolicyEngine:
         res = row.get("resource")
         if res and resource and res != resource:
             return False
+        # Must match command/intent binding from original request
+        expected = hitl_binding_hash(action, resource, extra)
+        stored = (row.get("binding_hash") or "").strip()
+        if not stored or stored != expected:
+            return False
         return True
 
     async def evaluate(
@@ -193,14 +216,16 @@ class PolicyEngine:
                 safe_details = {
                     k: v
                     for k, v in (extra or {}).items()
-                    if k not in ("hitl_approved", "api_key", "token")
+                    if k not in ("hitl_approved", "api_key", "token", "hitl_request_id")
                 }
+                binding = hitl_binding_hash(action, resource, extra)
                 hid = await self.db.create_hitl_request(
                     action=action,
                     actor=auth.name,
                     actor_type=auth.actor_type,
                     resource=resource,
                     details=safe_details,
+                    binding_hash=binding,
                     risk_score=risk,
                 )
             return PolicyDecision(

--- a/src/squidc5/policy/engine.py
+++ b/src/squidc5/policy/engine.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
 from typing import Any
 
 from squidc5.auth.tokens import AuthContext
@@ -69,6 +70,8 @@ class PolicyDecision:
     reason: str
     risk_score: int
     require_hitl: bool = False
+    hitl_request_id: str | None = None
+    details: dict[str, Any] = field(default_factory=dict)
 
 
 class PolicyEngine:
@@ -109,12 +112,43 @@ class PolicyEngine:
     def score(self, action: str, rules: dict[str, Any]) -> int:
         return int(rules.get("action_risk", {}).get(action, 5))
 
+    async def _server_hitl_approved(
+        self,
+        auth: AuthContext,
+        action: str,
+        resource: str | None,
+        extra: dict[str, Any] | None,
+    ) -> bool:
+        """True only when a server-side approved HITL request is presented."""
+        rid = (extra or {}).get("hitl_request_id")
+        if not rid or not isinstance(rid, str):
+            return False
+        row = await self.db.get_hitl_request(rid)
+        if not row:
+            return False
+        if row.get("status") != "approved":
+            return False
+        exp = row.get("expires_at")
+        if exp is not None and float(exp) < time.time():
+            return False
+        if row.get("action") != action:
+            return False
+        # Same operator (or admin using the grant)
+        if row.get("actor") != auth.name and "admin" not in auth.scopes:
+            return False
+        res = row.get("resource")
+        if res and resource and res != resource:
+            return False
+        return True
+
     async def evaluate(
         self,
         auth: AuthContext,
         action: str,
         resource: str | None = None,
         extra: dict[str, Any] | None = None,
+        *,
+        create_hitl: bool = True,
     ) -> PolicyDecision:
         rules = await self.get_rules()
         risk = self.score(action, rules)
@@ -144,12 +178,38 @@ class PolicyEngine:
             return PolicyDecision(False, f"Risk score {risk} exceeds deny threshold", risk)
 
         require_hitl = action in hitl_actions or risk >= int(thresholds.get("hitl_min", 7))
-        if require_hitl and "admin" not in auth.scopes and not (extra or {}).get("hitl_approved"):
+        # Admins bypass HITL; client-asserted hitl_approved is IGNORED
+        if require_hitl and "admin" not in auth.scopes:
+            if await self._server_hitl_approved(auth, action, resource, extra):
+                return PolicyDecision(
+                    True,
+                    "allowed (HITL approved)",
+                    risk,
+                    require_hitl=True,
+                    hitl_request_id=str((extra or {}).get("hitl_request_id")),
+                )
+            hid: str | None = None
+            if create_hitl:
+                safe_details = {
+                    k: v
+                    for k, v in (extra or {}).items()
+                    if k not in ("hitl_approved", "api_key", "token")
+                }
+                hid = await self.db.create_hitl_request(
+                    action=action,
+                    actor=auth.name,
+                    actor_type=auth.actor_type,
+                    resource=resource,
+                    details=safe_details,
+                    risk_score=risk,
+                )
             return PolicyDecision(
                 False,
                 f"Human-in-the-loop required for {action}",
                 risk,
                 require_hitl=True,
+                hitl_request_id=hid,
+                details={"hitl_request_id": hid} if hid else {},
             )
 
         return PolicyDecision(True, "allowed", risk, require_hitl=require_hitl)
@@ -161,17 +221,28 @@ class PolicyEngine:
         resource: str | None = None,
         extra: dict[str, Any] | None = None,
     ) -> PolicyDecision:
-        decision = await self.evaluate(auth, action, resource, extra)
+        # Strip spoofable client flag before evaluate
+        clean_extra = dict(extra or {})
+        clean_extra.pop("hitl_approved", None)
+        decision = await self.evaluate(auth, action, resource, clean_extra)
+        audit_details = {
+            "reason": decision.reason,
+            **{k: v for k, v in clean_extra.items() if k != "hitl_approved"},
+        }
+        if decision.hitl_request_id:
+            audit_details["hitl_request_id"] = decision.hitl_request_id
         await self.db.audit(
             actor=auth.name,
             actor_type=auth.actor_type,
             action=action,
             resource=resource,
-            details={"reason": decision.reason, **(extra or {})},
+            details=audit_details,
             risk_score=decision.risk_score,
             allowed=decision.allowed,
         )
         await self.db.incr_metric("policy.checks")
         if not decision.allowed:
             await self.db.incr_metric("policy.denies")
+            if decision.require_hitl:
+                await self.db.incr_metric("policy.hitl_required")
         return decision

--- a/tests/test_hitl_queue.py
+++ b/tests/test_hitl_queue.py
@@ -1,0 +1,103 @@
+"""Server-side HITL approval queue (A10)."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import bearer, mint_token
+
+
+@pytest.mark.asyncio
+async def test_client_hitl_approved_does_not_bypass(client, admin_headers):
+    """Non-admin cannot spoof hitl_approved: true."""
+    t = await mint_token(
+        client,
+        admin_headers,
+        "op-hitl",
+        ["shell:interact", "sessions:read", "sessions:write"],
+    )
+    headers = bearer(t["token"])
+    # Create a fake reverse_shell session row won't be live; policy runs first
+    r = await client.post(
+        "/api/v1/shell/command",
+        headers=headers,
+        json={
+            "session_id": "ses_nonexistent",
+            "command": "id",
+            "hitl_approved": True,
+        },
+    )
+    assert r.status_code == 403
+    detail = r.json()["detail"]
+    if isinstance(detail, dict):
+        assert detail.get("require_hitl") is True
+        assert detail.get("hitl_request_id")
+        rid = detail["hitl_request_id"]
+    else:
+        # string detail fallback
+        assert "Human-in-the-loop" in str(detail)
+        lst = await client.get("/api/v1/policy/hitl", headers=admin_headers)
+        assert lst.status_code == 200
+        reqs = lst.json()["requests"]
+        assert reqs
+        rid = reqs[0]["id"]
+
+    # Approve as admin
+    ap = await client.post(f"/api/v1/policy/hitl/{rid}/approve", headers=admin_headers)
+    assert ap.status_code == 200
+    assert ap.json()["request"]["status"] == "approved"
+
+    # Retry with server approval id — gets past policy (then 404 no live shell)
+    r2 = await client.post(
+        "/api/v1/shell/command",
+        headers=headers,
+        json={
+            "session_id": "ses_nonexistent",
+            "command": "id",
+            "hitl_request_id": rid,
+        },
+    )
+    assert r2.status_code == 404  # policy passed; no live channel
+
+
+@pytest.mark.asyncio
+async def test_admin_bypasses_hitl(client, admin_headers):
+    r = await client.post(
+        "/api/v1/shell/command",
+        headers=admin_headers,
+        json={"session_id": "ses_x", "command": "whoami"},
+    )
+    # admin not blocked by HITL
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_hitl_list_and_deny(client, admin_headers):
+    t = await mint_token(
+        client, admin_headers, "op-hitl2", ["shell:interact", "sessions:read"]
+    )
+    r = await client.post(
+        "/api/v1/shell/command",
+        headers=bearer(t["token"]),
+        json={"session_id": "ses_y", "command": "id", "hitl_approved": True},
+    )
+    assert r.status_code == 403
+    detail = r.json()["detail"]
+    rid = detail["hitl_request_id"] if isinstance(detail, dict) else None
+    assert rid
+    dn = await client.post(f"/api/v1/policy/hitl/{rid}/deny", headers=admin_headers)
+    assert dn.status_code == 200
+    # Denied grant cannot be used
+    r2 = await client.post(
+        "/api/v1/shell/command",
+        headers=bearer(t["token"]),
+        json={"session_id": "ses_y", "command": "id", "hitl_request_id": rid},
+    )
+    assert r2.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_hitl_table(client, app):
+    row = await app.state.app_state.db.fetchone(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='hitl_requests'"
+    )
+    assert row is not None

--- a/tests/test_hitl_queue.py
+++ b/tests/test_hitl_queue.py
@@ -46,7 +46,19 @@ async def test_client_hitl_approved_does_not_bypass(client, admin_headers):
     assert ap.status_code == 200
     assert ap.json()["request"]["status"] == "approved"
 
-    # Retry with server approval id — gets past policy (then 404 no live shell)
+    # Wrong command must not reuse approval
+    r_wrong = await client.post(
+        "/api/v1/shell/command",
+        headers=headers,
+        json={
+            "session_id": "ses_nonexistent",
+            "command": "cat /etc/shadow",
+            "hitl_request_id": rid,
+        },
+    )
+    assert r_wrong.status_code == 403
+
+    # Same command as original — gets past policy (then 404 no live shell)
     r2 = await client.post(
         "/api/v1/shell/command",
         headers=headers,


### PR DESCRIPTION
## Summary
- Client \`hitl_approved: true\` no longer bypasses policy
- Pending HITL requests created server-side (\`hitl_requests\` migration v2)
- Admin API: list / approve / deny
- CLI: \`sc5 policy hitl list|approve|deny\`
- Operators retry with \`hitl_request_id\` after approval

## Test plan
- [x] \`pytest -q tests/test_hitl_queue.py\`
- [x] Full suite
- [ ] CI green

A10 prod-readiness.