### PR TITLE
feat(listeners,audit): supervise crashes and enforce retention

### DIFF
--- a/src/squidc5/audit/trail.py
+++ b/src/squidc5/audit/trail.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from typing import Any
 
 from squidc5.db.store import Database
@@ -33,3 +34,9 @@ class AuditTrail:
 
     async def list(self, limit: int = 100, offset: int = 0) -> list[dict[str, Any]]:
         return await self.db.list_audit(limit=limit, offset=offset)
+
+    async def purge_older_than_days(self, days: int) -> int:
+        """Enforce retention: delete rows older than N days."""
+        days = max(1, int(days))
+        cutoff = time.time() - (days * 86400.0)
+        return await self.db.purge_audit_before(cutoff)

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -374,6 +374,11 @@ class Database:
             (limit, offset),
         )
 
+    async def purge_audit_before(self, cutoff_ts: float) -> int:
+        """Delete audit rows older than cutoff. Returns rows deleted."""
+        cur = await self.execute("DELETE FROM audit_log WHERE ts < ?", (float(cutoff_ts),))
+        return int(cur.rowcount or 0)
+
     # --- LLM ---
 
     async def upsert_llm(

--- a/src/squidc5/listeners/manager.py
+++ b/src/squidc5/listeners/manager.py
@@ -56,6 +56,9 @@ class ListenerManager:
         self._writers: dict[str, asyncio.StreamWriter] = {}
         self._rejected: set[str] = set()
         self._verified: set[str] = set()
+        self._restart_counts: dict[str, int] = {}
+        self._max_restarts: int = 5
+        self._supervise: bool = True
         # Optional: async (key) -> bool feature flag checker
         self.feature_check = None
         # OAST Collaborator store (set from main)
@@ -107,6 +110,7 @@ class ListenerManager:
                 self._servers[listener_id] = server
                 task = asyncio.create_task(server.serve_forever(), name=f"listener-http-{listener_id}")
                 self._tasks[listener_id] = task
+                self._attach_supervisor(listener_id, task)
                 await self.db.set_listener_status(listener_id, "running")
                 log.info("Started http listener %s on %s:%s", listener_id, host, port)
             elif kind == "dns":
@@ -156,6 +160,7 @@ class ListenerManager:
                 self._servers[listener_id] = server
                 task = asyncio.create_task(server.serve_forever(), name=f"listener-smtp-{listener_id}")
                 self._tasks[listener_id] = task
+                self._attach_supervisor(listener_id, task)
                 await self.db.set_listener_status(listener_id, "running")
                 log.info("Started smtp listener %s on %s:%s", listener_id, host, port)
             elif kind in ("tcp", "reverse_shell"):
@@ -167,6 +172,7 @@ class ListenerManager:
                 self._servers[listener_id] = server
                 task = asyncio.create_task(server.serve_forever(), name=f"listener-{listener_id}")
                 self._tasks[listener_id] = task
+                self._attach_supervisor(listener_id, task)
                 await self.db.set_listener_status(listener_id, "running")
                 log.info("Started %s listener %s on %s:%s", kind, listener_id, host, port)
             else:
@@ -238,6 +244,67 @@ class ListenerManager:
         if restored:
             log.info("Restored %s listener(s) from DB: %s", len(restored), restored)
         return {"restored": restored, "errors": errors}
+
+    def _attach_supervisor(self, listener_id: str, task: asyncio.Task[None]) -> None:
+        if not self._supervise:
+            return
+
+        def _done(t: asyncio.Task[None]) -> None:
+            if t.cancelled():
+                return
+            exc = t.exception()
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._on_listener_crash(listener_id, exc))
+            except RuntimeError:
+                pass
+
+        task.add_done_callback(_done)
+
+    async def _on_listener_crash(self, listener_id: str, exc: BaseException | None) -> None:
+        """Restart crashed listener tasks with backoff (max_restarts)."""
+        row = await self.db.get_listener(listener_id)
+        if not row or (row.get("status") or "") != "running":
+            return
+        # Clean dead refs
+        async with self._lock:
+            self._tasks.pop(listener_id, None)
+            srv = self._servers.pop(listener_id, None)
+            if srv:
+                try:
+                    srv.close()
+                except Exception:
+                    pass
+        n = self._restart_counts.get(listener_id, 0) + 1
+        self._restart_counts[listener_id] = n
+        if n > self._max_restarts:
+            log.error("Listener %s exceeded max restarts (%s); marking error", listener_id, self._max_restarts)
+            await self.db.set_listener_status(listener_id, "error")
+            await self.metrics.emit(
+                "listener.supervise_give_up",
+                {"id": listener_id, "error": str(exc)[:200] if exc else "exit"},
+            )
+            return
+        delay = min(30.0, 0.5 * (2 ** (n - 1)))
+        log.warning(
+            "Listener %s task ended (%s); restart %s/%s in %.1fs",
+            listener_id,
+            exc or "clean exit",
+            n,
+            self._max_restarts,
+            delay,
+        )
+        await asyncio.sleep(delay)
+        try:
+            await self.start(listener_id)
+            await self.metrics.emit("listener.supervised_restart", {"id": listener_id, "n": n})
+        except Exception as e:
+            log.exception("Supervised restart failed for %s", listener_id)
+            await self.db.set_listener_status(listener_id, "error")
+            await self.metrics.emit(
+                "listener.supervise_failed",
+                {"id": listener_id, "error": str(e)[:200]},
+            )
 
     def _enable_keepalive(self, writer: asyncio.StreamWriter) -> None:
         sock = writer.get_extra_info("socket")

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -164,6 +164,13 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         except Exception:
             log.exception("Listener restore failed")
             restore = {"restored": [], "errors": [{"error": "restore crashed"}]}
+        purged = 0
+        try:
+            purged = await state.audit.purge_older_than_days(settings.audit_retention_days)
+            if purged:
+                log.info("Purged %s audit row(s) older than %s days", purged, settings.audit_retention_days)
+        except Exception:
+            log.exception("Audit retention purge failed")
         await state.db.audit(
             actor="system",
             actor_type="system",
@@ -173,6 +180,7 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "port": settings.port,
                 "listeners_restored": restore.get("restored") or [],
                 "listeners_restore_errors": restore.get("errors") or [],
+                "audit_purged": purged,
             },
         )
         log.info("SquidC5 v%s listening on %s:%s", __version__, settings.host, settings.port)

--- a/tests/test_audit_retention.py
+++ b/tests/test_audit_retention.py
@@ -1,0 +1,77 @@
+"""Audit retention purge (B07)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_audret01"
+
+
+@pytest.mark.asyncio
+async def test_purge_older_than_days(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_aud",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        audit_retention_days=30,
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        db = app.state.app_state.db
+        old_ts = time.time() - (60 * 86400)
+        await db.execute(
+            """INSERT INTO audit_log (ts, actor, actor_type, action, resource, details, risk_score, allowed)
+               VALUES (?, 'x', 'system', 'old.event', null, '{}', 0, 1)""",
+            (old_ts,),
+        )
+        await db.execute(
+            """INSERT INTO audit_log (ts, actor, actor_type, action, resource, details, risk_score, allowed)
+               VALUES (?, 'x', 'system', 'new.event', null, '{}', 0, 1)""",
+            (time.time(),),
+        )
+        n = await app.state.app_state.audit.purge_older_than_days(30)
+        assert n >= 1
+        rows = await db.fetchall("SELECT action FROM audit_log WHERE action IN ('old.event','new.event')")
+        actions = {r["action"] for r in rows}
+        assert "old.event" not in actions
+        assert "new.event" in actions
+
+
+@pytest.mark.asyncio
+async def test_startup_runs_purge(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_aud2",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN + "b",
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        audit_retention_days=7,
+        rate_limit_per_minute=1000,
+    )
+    # Pre-seed DB with old row before app start
+    from squidc5.db.store import Database
+
+    db_path = settings.resolve_db_path()
+    db = Database(db_path)
+    await db.connect()
+    await db.execute(
+        """INSERT INTO audit_log (ts, actor, actor_type, action, resource, details, risk_score, allowed)
+           VALUES (?, 'x', 'system', 'ancient', null, '{}', 0, 1)""",
+        (time.time() - 40 * 86400,),
+    )
+    await db.close()
+
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        rows = await app.state.app_state.db.fetchall(
+            "SELECT action FROM audit_log WHERE action = 'ancient'"
+        )
+        assert rows == []

--- a/tests/test_listener_supervision.py
+++ b/tests/test_listener_supervision.py
@@ -1,0 +1,60 @@
+"""Listener crash supervision (B03)."""
+
+from __future__ import annotations
+
+import pytest
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_supv01"
+
+
+@pytest.mark.asyncio
+async def test_on_listener_crash_restarts(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_sup",
+        debug=False,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        lm = app.state.app_state.listeners
+        lm._max_restarts = 3
+        lm._restart_counts.clear()
+        row = await lm.create("sup-http", "http", 18767, host="127.0.0.1")
+        lid = row["id"]
+        await lm.start(lid)
+        assert lid in lm._servers
+        # Simulate crash cleanup + supervised restart
+        await lm._on_listener_crash(lid, RuntimeError("simulated"))
+        assert lm._restart_counts.get(lid, 0) >= 1
+        row2 = await lm.db.get_listener(lid)
+        assert row2["status"] == "running"
+        assert lid in lm._servers
+
+
+@pytest.mark.asyncio
+async def test_max_restarts_marks_error(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "data_sup2",
+        debug=False,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN + "b",
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        lm = app.state.app_state.listeners
+        lm._max_restarts = 1
+        row = await lm.create("sup-lim", "http", 18768, host="127.0.0.1")
+        lid = row["id"]
+        await lm.db.set_listener_status(lid, "running")
+        lm._restart_counts[lid] = 1  # next crash exceeds max of 1
+        await lm._on_listener_crash(lid, RuntimeError("again"))
+        row2 = await lm.db.get_listener(lid)
+        assert row2["status"] == "error"


### PR DESCRIPTION
## Summary
- B03: supervised restart of crashed listener tasks (max 5, backoff)
- B07: purge audit log older than \`audit_retention_days\` on startup

## Test plan
- [x] supervision + retention tests
- [ ] CI green