### PR TITLE
feat(implant): authenticated AEAD check-in channel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,7 @@ SQUIDC5_SHELL_AUTO_STABILIZE=true
 # SQUIDC5_SECRETS_KEY=
 # JSON structured logs to stderr
 # SQUIDC5_LOG_JSON=true
+# Implant beacon AEAD (default: require auth; PSK auto under data/implant_psk.txt)
+# SQUIDC5_IMPLANT_REQUIRE_AUTH=true
+# SQUIDC5_IMPLANT_PSK=
+

--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -41,6 +41,9 @@ class Settings(BaseSettings):
     plugin_signing_secret: str | None = None
     # Master key for at-rest encryption (LLM API keys). Or data_dir/secrets.key.
     secrets_key: str | None = None
+    # Implant beacon AEAD (ChaCha20-Poly1305). PSK auto-generated under data/implant_psk.txt
+    implant_psk: str | None = None
+    implant_require_auth: bool = True
     # Reverse-shell auto-stabilization (stage-2 reconnect agents)
     shell_auto_stabilize: bool = True
     # Host/IP implants should call back to (defaults to request/local bind if empty)

--- a/src/squidc5/core/state.py
+++ b/src/squidc5/core/state.py
@@ -48,4 +48,5 @@ class AppState:
     oast: OastService | None = None
     ai_chain: Any = None
     admin_token_once: str = ""
+    implant_psk: str = ""
     shell_buffers: dict[str, list[str]] = field(default_factory=dict)

--- a/src/squidc5/implants/crypto.py
+++ b/src/squidc5/implants/crypto.py
@@ -1,0 +1,79 @@
+"""Implant channel AEAD (ChaCha20-Poly1305) for beacon check-ins."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+from pathlib import Path
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers.aead import ChaCha20Poly1305
+
+ALG = "chacha20-poly1305"
+PSK_FILENAME = "implant_psk.txt"
+ENVELOPE_KEYS = frozenset({"v", "n", "c", "alg"})
+
+
+def derive_key(psk: str | bytes) -> bytes:
+    raw = psk.encode("utf-8") if isinstance(psk, str) else psk
+    return hashlib.sha256(raw).digest()
+
+
+def resolve_implant_psk(*, explicit: str | None, data_dir: Path) -> str:
+    if explicit is not None and str(explicit).strip():
+        return str(explicit).strip()
+    path = Path(data_dir) / PSK_FILENAME
+    if path.is_file():
+        val = path.read_text(encoding="utf-8").strip()
+        if val:
+            return val
+    Path(data_dir).mkdir(parents=True, exist_ok=True)
+    val = secrets.token_urlsafe(32)
+    path.write_text(val + "\n", encoding="utf-8")
+    try:
+        path.chmod(0o600)
+    except OSError:
+        pass
+    return val
+
+
+def seal(psk: str | bytes, obj: dict[str, Any]) -> dict[str, Any]:
+    key = derive_key(psk)
+    aead = ChaCha20Poly1305(key)
+    nonce = os.urandom(12)
+    pt = json.dumps(obj, separators=(",", ":"), sort_keys=True).encode("utf-8")
+    ct = aead.encrypt(nonce, pt, None)
+    return {
+        "v": 1,
+        "alg": ALG,
+        "n": base64.urlsafe_b64encode(nonce).decode("ascii").rstrip("="),
+        "c": base64.urlsafe_b64encode(ct).decode("ascii").rstrip("="),
+    }
+
+
+def _b64d(s: str) -> bytes:
+    pad = "=" * (-len(s) % 4)
+    return base64.urlsafe_b64decode(s + pad)
+
+
+def is_envelope(obj: Any) -> bool:
+    return isinstance(obj, dict) and ENVELOPE_KEYS.issubset(obj.keys()) and obj.get("v") == 1
+
+
+def open_envelope(psk: str | bytes, envelope: dict[str, Any]) -> dict[str, Any]:
+    if not is_envelope(envelope):
+        raise ValueError("not an implant envelope")
+    if envelope.get("alg") != ALG:
+        raise ValueError("unsupported implant cipher")
+    key = derive_key(psk)
+    aead = ChaCha20Poly1305(key)
+    nonce = _b64d(str(envelope["n"]))
+    ct = _b64d(str(envelope["c"]))
+    pt = aead.decrypt(nonce, ct, None)
+    data = json.loads(pt.decode("utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("implant payload must be object")
+    return data

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -125,6 +125,13 @@ async def build_state(settings: Settings) -> AppState:
             log.warning("Could not chmod 0600 on %s", token_file)
         log.warning("Bootstrap admin token written to %s — store securely and rotate", token_file)
 
+    from squidc5.implants.crypto import resolve_implant_psk
+
+    implant_psk = resolve_implant_psk(
+        explicit=settings.implant_psk,
+        data_dir=settings.data_dir,
+    )
+
     return AppState(
         settings=settings,
         db=db,
@@ -146,6 +153,7 @@ async def build_state(settings: Settings) -> AppState:
         oast=oast,
         ai_chain=ai_chain,
         admin_token_once=admin_once,
+        implant_psk=implant_psk,
     )
 
 

--- a/src/squidc5/profiles/engine.py
+++ b/src/squidc5/profiles/engine.py
@@ -236,6 +236,9 @@ class ProfileEngine:
     @staticmethod
     def _looks_like_beacon(obj: dict[str, Any]) -> bool:
         keys = set(obj.keys())
+        # AEAD implant envelope (v1)
+        if obj.get("v") == 1 and {"n", "c", "alg"}.issubset(keys):
+            return True
         return bool(
             keys
             & {

--- a/src/squidc5/profiles/http_beacon.py
+++ b/src/squidc5/profiles/http_beacon.py
@@ -5,6 +5,31 @@ from __future__ import annotations
 from typing import Any
 
 from squidc5.core.state import AppState
+from squidc5.implants.crypto import is_envelope, open_envelope, seal
+
+
+def _unwrap_payload(state: AppState, payload: dict[str, Any]) -> dict[str, Any]:
+    """Decrypt AEAD envelope when present / required."""
+    require = bool(getattr(state.settings, "implant_require_auth", True))
+    psk = getattr(state, "implant_psk", "") or ""
+    if is_envelope(payload):
+        if not psk:
+            raise PermissionError("Implant PSK not configured")
+        try:
+            return open_envelope(psk, payload)
+        except Exception as e:
+            raise PermissionError("Invalid implant authentication") from e
+    if require:
+        raise PermissionError("Authenticated implant envelope required")
+    return payload
+
+
+def _wrap_response(state: AppState, result: dict[str, Any]) -> dict[str, Any]:
+    require = bool(getattr(state.settings, "implant_require_auth", True))
+    psk = getattr(state, "implant_psk", "") or ""
+    if require and psk:
+        return seal(psk, result)
+    return result
 
 
 async def process_beacon_checkin(
@@ -18,6 +43,8 @@ async def process_beacon_checkin(
     """Register/heartbeat beacon session and return next task."""
     if not await state.features.enabled("implant_beacon"):
         raise PermissionError("Implant beacon is disabled by feature flag")
+
+    payload = _unwrap_payload(state, payload)
 
     session_id = payload.get("session_id")
     hostname = payload.get("hostname")
@@ -61,10 +88,11 @@ async def process_beacon_checkin(
         )
     task = await state.tasks.poll(sid)
     await state.metrics.incr("implant.beacon")
-    return {"session_id": sid, "task": task}
+    return _wrap_response(state, {"session_id": sid, "task": task})
 
 
 async def process_beacon_result(state: AppState, payload: dict[str, Any]) -> dict[str, str]:
+    payload = _unwrap_payload(state, payload)
     task_id = payload.get("task_id")
     if not task_id:
         raise ValueError("task_id required")
@@ -73,4 +101,4 @@ async def process_beacon_result(state: AppState, payload: dict[str, Any]) -> dic
         result = ""
     status = payload.get("status") or "completed"
     await state.tasks.complete(str(task_id), str(result), str(status))
-    return {"status": "ok"}
+    return _wrap_response(state, {"status": "ok"})  # type: ignore[return-value]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,8 @@ async def app(tmp_path):
         cors_origins=[],
         admin_token_bootstrap=ADMIN_BOOTSTRAP,
         plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        implant_psk="test-implant-psk-for-ci",
     )
     application = create_app(settings)
     async with application.router.lifespan_context(application):
@@ -49,6 +51,8 @@ async def app_with_public_host(tmp_path):
         cors_origins=[],
         admin_token_bootstrap=ADMIN_BOOTSTRAP,
         plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        implant_psk="test-implant-psk-for-ci",
     )
     application = create_app(settings)
     async with application.router.lifespan_context(application):

--- a/tests/test_implant_crypto.py
+++ b/tests/test_implant_crypto.py
@@ -1,0 +1,95 @@
+"""Implant AEAD channel (A11)."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.implants.crypto import is_envelope, open_envelope, seal
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_impcr01"
+PSK = "unit-test-implant-psk-xyz"
+
+
+def test_seal_open_roundtrip():
+    env = seal(PSK, {"session_id": None, "hostname": "h1"})
+    assert is_envelope(env)
+    plain = open_envelope(PSK, env)
+    assert plain["hostname"] == "h1"
+
+
+def test_wrong_psk_fails():
+    env = seal(PSK, {"a": 1})
+    with pytest.raises(Exception):
+        open_envelope("wrong-psk", env)
+
+
+@pytest.mark.asyncio
+async def test_require_auth_rejects_plain(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=True,
+        implant_psk=PSK,
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            r = await client.post(
+                "/api/v1/implant/beacon",
+                json={"hostname": "no-auth"},
+            )
+            assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_sealed_checkin_and_task(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d2",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=True,
+        implant_psk=PSK,
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            body = seal(PSK, {"hostname": "lab-host", "session_id": None})
+            r = await client.post("/api/v1/implant/beacon", json=body)
+            assert r.status_code == 200, r.text
+            env = r.json()
+            assert is_envelope(env)
+            data = open_envelope(PSK, env)
+            assert data.get("session_id")
+            sid = data["session_id"]
+            # create task as admin
+            headers = {"Authorization": f"Bearer {ADMIN}"}
+            tr = await client.post(
+                "/api/v1/tasks",
+                headers=headers,
+                json={"session_id": sid, "command": "id"},
+            )
+            assert tr.status_code == 200
+            # poll via sealed beacon
+            body2 = seal(PSK, {"session_id": sid, "hostname": "lab-host"})
+            r2 = await client.post("/api/v1/implant/beacon", json=body2)
+            assert r2.status_code == 200
+            data2 = open_envelope(PSK, r2.json())
+            assert data2.get("task") is not None
+            tid = data2["task"]["id"]
+            # complete
+            done = seal(PSK, {"task_id": tid, "result": "uid=0", "status": "completed"})
+            r3 = await client.post("/api/v1/implant/beacon/result", json=done)
+            assert r3.status_code == 200
+            assert open_envelope(PSK, r3.json())["status"] == "ok"


### PR DESCRIPTION
## Summary
- A11: ChaCha20-Poly1305 sealed beacon envelopes
- \`SQUIDC5_IMPLANT_REQUIRE_AUTH\` default true
- Auto PSK at \`data/implant_psk.txt\`
- Plain JSON rejected when auth required

## Test plan
- [x] implant crypto + beacon e2e tests
- [x] full suite 196
- [ ] CI green