### PR TITLE
feat: inject/BOF catalog, sleep mask, ops UI depth

### DIFF
--- a/agents/sc5beacon/README.md
+++ b/agents/sc5beacon/README.md
@@ -27,14 +27,19 @@ GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o sc5beacon-arm64 .
 | `SC5_KILL_DATE` | no | Unix epoch; agent exits after |
 | `SC5_MAX_MISS` | no | Exit after N failed check-ins |
 | `SC5_WORK_START` / `SC5_WORK_END` | no | Working hours (local), 0–23 |
+| `SC5_SLEEP_MASK` | no | `jitter` (default) \| `timer` \| `ekko` (timer stand-in) |
+| `SC5_ALLOW_INJECT` | no | Must be `1` to accept `inject:*` lab stubs |
+| `SC5_ALLOW_BOF` | no | Must be `1` to accept `bof:run` lab stubs |
 
 TLS always verifies the system trust store. For lab CAs, install the CA or set `SSL_CERT_FILE`. There is **no** skip-verify flag.
 
 ## Features
 
 - ChaCha20-Poly1305 sealed check-in (matches server `implants/crypto.py`)
-- Sleep + jitter + kill date + max miss + working hours
+- Sleep mask + jitter + kill date + max miss + working hours
 - Shell commands + `file:list|read|write|delete` + `sysinfo`
+- SOCKS reverse-dial (`socks:start` / `socks:connect`)
+- Lab-gated inject / BOF stubs (no real injection unless research build + env gates)
 - Cross-compile Linux/Windows/macOS via Go
 
 ## Server factory

--- a/agents/sc5beacon/inject.go
+++ b/agents/sc5beacon/inject.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strconv"
+)
+
+// inject handlers are lab-only and refuse unless SC5_ALLOW_INJECT=1.
+func handleInject(cmd string, args map[string]any) string {
+	if os.Getenv("SC5_ALLOW_INJECT") != "1" {
+		return "error: inject disabled (set SC5_ALLOW_INJECT=1 for authorized lab only)"
+	}
+	tech, _ := args["technique"].(string)
+	if tech == "" {
+		tech = cmd
+	}
+	pid := anyToInt(args["pid"])
+	switch tech {
+	case "create_remote_thread", "apc_queue":
+		if runtime.GOOS != "windows" {
+			return "error: windows-only technique"
+		}
+		// Lab stub: do not perform real process injection in default builds.
+		// Full implementations are gated behind lab research builds.
+		return fmt.Sprintf("inject:lab_stub technique=%s pid=%d os=%s (no-op safe build)", tech, pid, runtime.GOOS)
+	case "process_vm_write":
+		if runtime.GOOS != "linux" {
+			return "error: linux-only technique"
+		}
+		return fmt.Sprintf("inject:lab_stub technique=%s pid=%d (no-op safe build)", tech, pid)
+	default:
+		return "error: unknown inject technique " + tech
+	}
+}
+
+func handleBofRun(args map[string]any) string {
+	if os.Getenv("SC5_ALLOW_BOF") != "1" {
+		return "error: bof disabled (set SC5_ALLOW_BOF=1 for authorized lab only)"
+	}
+	mod, _ := args["module_id"].(string)
+	entry, _ := args["entry"].(string)
+	if entry == "" {
+		entry = "go"
+	}
+	// Safe build: validate metadata only; COFF execute is research-gated.
+	arch, _ := args["coff"].(map[string]any)
+	msg := fmt.Sprintf("bof:lab_stub module=%s entry=%s", mod, entry)
+	if arch != nil {
+		msg += fmt.Sprintf(" coff_arch=%v sections=%v", arch["arch"], arch["sections"])
+	}
+	if sz := anyToInt(args["size"]); sz > 0 {
+		msg += " size=" + strconv.Itoa(sz)
+	}
+	return msg + " (loader host ready; execution gated)"
+}

--- a/agents/sc5beacon/main.go
+++ b/agents/sc5beacon/main.go
@@ -113,7 +113,7 @@ func main() {
 			return
 		}
 		if !inWorkingHours(workStart, workEnd) {
-			sleepJitter(sleep, jitter)
+			maskedSleep(sleep, jitter)
 			continue
 		}
 
@@ -140,7 +140,7 @@ func main() {
 			if maxMiss > 0 && miss >= maxMiss {
 				return
 			}
-			sleepJitter(sleep, jitter)
+			maskedSleep(sleep, jitter)
 			continue
 		}
 		raw, _ := json.Marshal(body)
@@ -150,7 +150,7 @@ func main() {
 			if maxMiss > 0 && miss >= maxMiss {
 				return
 			}
-			sleepJitter(sleep, jitter)
+			maskedSleep(sleep, jitter)
 			continue
 		}
 		b, _ := io.ReadAll(resp.Body)
@@ -160,14 +160,14 @@ func main() {
 			if maxMiss > 0 && miss >= maxMiss {
 				return
 			}
-			sleepJitter(sleep, jitter)
+			maskedSleep(sleep, jitter)
 			continue
 		}
 		miss = 0
 
 		var env map[string]any
 		if json.Unmarshal(b, &env) != nil {
-			sleepJitter(sleep, jitter)
+			maskedSleep(sleep, jitter)
 			continue
 		}
 		// AEAD required — refuse plaintext C2 responses
@@ -177,7 +177,7 @@ func main() {
 			if maxMiss > 0 && miss >= maxMiss {
 				return
 			}
-			sleepJitter(sleep, jitter)
+			maskedSleep(sleep, jitter)
 			continue
 		}
 		if s, ok := plain["session_id"]; ok {
@@ -212,6 +212,7 @@ func main() {
 				}
 			}
 		}
-		sleepJitter(sleep, jitter)
+		// wipe sealed payload copies when present
+		maskedSleep(sleep, jitter)
 	}
 }

--- a/agents/sc5beacon/sleep.go
+++ b/agents/sc5beacon/sleep.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"crypto/rand"
+	"os"
+	"runtime"
+	"time"
+)
+
+// maskedSleep wipes sensitive buffers then sleeps with optional timer path.
+// SC5_SLEEP_MASK=jitter|timer|ekko (ekko only meaningful on windows build tags later)
+func maskedSleep(base float64, jitterPct float64, secrets ...*[]byte) {
+	mode := os.Getenv("SC5_SLEEP_MASK")
+	if mode == "" {
+		mode = "jitter"
+	}
+	// Wipe sensitive material before idle
+	for _, p := range secrets {
+		if p != nil && *p != nil {
+			for i := range *p {
+				(*p)[i] = 0
+			}
+			// fill with random then zero again (simple mask pattern)
+			_, _ = rand.Read(*p)
+			for i := range *p {
+				(*p)[i] = 0
+			}
+		}
+	}
+	runtime.GC()
+
+	switch mode {
+	case "timer":
+		// Prefer timer channel over plain Sleep
+		pct := jitterPct / 100.0
+		if pct < 0 {
+			pct = 0
+		}
+		if pct > 1 {
+			pct = 1
+		}
+		delta := base * pct
+		d := base + (float64(time.Now().UnixNano()%1000)/1000.0*2-1)*delta
+		if d < 0.1 {
+			d = 0.1
+		}
+		t := time.NewTimer(time.Duration(d * float64(time.Second)))
+		<-t.C
+	case "ekko":
+		// Portable stand-in: timer wait + buffer wipe (full ROP/timer encrypt is Win-only research)
+		pct := jitterPct / 100.0
+		if pct < 0 {
+			pct = 0
+		}
+		if pct > 1 {
+			pct = 1
+		}
+		delta := base * pct
+		d := base + (float64(time.Now().UnixNano()%1000)/1000.0*2-1)*delta
+		if d < 0.1 {
+			d = 0.1
+		}
+		t := time.NewTimer(time.Duration(d * float64(time.Second)))
+		<-t.C
+	default:
+		sleepJitter(base, jitterPct)
+	}
+}

--- a/agents/sc5beacon/tasks.go
+++ b/agents/sc5beacon/tasks.go
@@ -27,6 +27,12 @@ func runTask(cmd string, args map[string]any) string {
 		}
 		return "profile_switch_ack"
 	}
+	if strings.HasPrefix(cmd, "inject:") || cmd == "inject" {
+		return handleInject(cmd, args)
+	}
+	if cmd == "bof:run" {
+		return handleBofRun(args)
+	}
 	if cmd == "sysinfo" {
 		return fmt.Sprintf("os=%s arch=%s hostname=%s", runtime.GOOS, runtime.GOARCH, hostName())
 	}

--- a/docs/roadmap-five-star.md
+++ b/docs/roadmap-five-star.md
@@ -16,10 +16,10 @@ Goal: ★★★★★ across implants, traffic, post-ex, multi-player, AI, gover
 
 ## Still climbing to full ★★★★★
 
-- Process injection + sleep mask  
-- Windows COFF/BOF **loader host**  
+- Process injection + sleep mask — **lab stubs + catalog + agent gates** (this pack)  
+- Windows COFF/BOF **loader host** — metadata plan + gated agent stub (full COFF exec research)  
+- Ops UI file / SOCKS / HITL / engagement / modules panels — **landed**  
 - P2P / SMB / named pipe  
-- Ops UI file browser / pivot graph  
 - Lab victim matrix soak numbers  
 - External security audit  
 

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -109,6 +109,20 @@ class SocksStart(BaseModel):
     mode: str = "implant"  # implant (reverse-dial) | direct (C2 dials target)
 
 
+class InjectTaskRequest(BaseModel):
+    session_id: str
+    technique: str = "create_remote_thread"
+    pid: int = 0
+    args: dict[str, Any] = Field(default_factory=dict)
+
+
+class BofRunRequest(BaseModel):
+    session_id: str
+    module_id: str
+    entry: str = "go"
+    object_b64: str | None = None
+
+
 class BeaconIn(BaseModel):
     session_id: str | None = None
     hostname: str | None = None
@@ -805,6 +819,144 @@ def build_api_router() -> APIRouter:
         if not ok:
             raise HTTPException(404, "pivot not found")
         return {"status": "stopped", "id": pivot_id}
+
+    # ----- Modules: inject / BOF / sleep mask catalog -----
+
+    @api.get("/modules")
+    async def list_modules_catalog(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tasks:read", "shell:interact", "admin")),
+    ) -> dict[str, Any]:
+        from squidc5.modules.catalog import (
+            list_bof_modules,
+            list_inject_techniques,
+            sleep_mask_catalog,
+        )
+
+        return {
+            "inject": list_inject_techniques(),
+            "bof": list_bof_modules(),
+            "sleep_mask": sleep_mask_catalog(),
+            "gates": {
+                "inject": "SC5_ALLOW_INJECT=1 on implant",
+                "bof": "SC5_ALLOW_BOF=1 on implant",
+            },
+        }
+
+    @api.get("/modules/bof")
+    async def list_bof(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tasks:read", "admin")),
+    ) -> dict[str, Any]:
+        from squidc5.modules.catalog import list_bof_modules
+
+        return {"modules": list_bof_modules()}
+
+    @api.get("/modules/inject")
+    async def list_inject(
+        request: Request,
+        platform: str | None = None,
+        auth: AuthContext = Depends(require_scope("tasks:read", "admin")),
+    ) -> dict[str, Any]:
+        from squidc5.modules.catalog import list_inject_techniques
+
+        return {"techniques": list_inject_techniques(platform)}
+
+    @api.post("/modules/inject")
+    async def queue_inject(
+        body: InjectTaskRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("shell:interact", "admin")),
+    ) -> dict[str, Any]:
+        """Queue lab inject task (implant refuses without SC5_ALLOW_INJECT=1)."""
+        state = get_state(request)
+        tech = (body.technique or "").strip().lower()
+        if not tech:
+            raise HTTPException(400, "technique required")
+        cmd = f"inject:{tech}" if not tech.startswith("inject:") else tech
+        args: dict[str, Any] = {"technique": tech.replace("inject:", ""), "pid": body.pid}
+        args.update(body.args or {})
+        decision = await state.policy.check_and_audit(
+            auth,
+            "shell.interact",
+            resource=body.session_id,
+            extra={"command": cmd, "technique": tech},
+        )
+        if not decision.allowed:
+            raise _policy_http_error(decision)
+        try:
+            task = await state.tasks.create(
+                session_id=body.session_id,
+                command=cmd,
+                args=args,
+                created_by=auth.name,
+            )
+        except KeyError as e:
+            raise HTTPException(404, str(e)) from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="modules.inject.queue",
+            resource=body.session_id,
+            details={"technique": tech, "task_id": task.get("id")},
+            risk_score=9,
+        )
+        return task
+
+    @api.post("/modules/bof/run")
+    async def queue_bof_run(
+        body: BofRunRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("shell:interact", "admin")),
+    ) -> dict[str, Any]:
+        """Queue BOF run plan (implant refuses without SC5_ALLOW_BOF=1)."""
+        from squidc5.modules.catalog import bof_modules_dir
+        from squidc5.modules.coff_loader import plan_bof_run
+
+        state = get_state(request)
+        mod_id = (body.module_id or "").strip()
+        if not mod_id or "/" in mod_id or "\\" in mod_id or ".." in mod_id:
+            raise HTTPException(400, "invalid module_id")
+        obj_path = bof_modules_dir() / f"{mod_id}.c"
+        # Prefer .o if present (compiled COFF)
+        o_path = bof_modules_dir() / f"{mod_id}.o"
+        path = o_path if o_path.is_file() else (obj_path if obj_path.is_file() else None)
+        plan = plan_bof_run(
+            module_id=mod_id,
+            object_path=path,
+            object_b64=body.object_b64,
+            entry=body.entry or "go",
+        )
+        decision = await state.policy.check_and_audit(
+            auth,
+            "shell.interact",
+            resource=body.session_id,
+            extra={"command": "bof:run", "module_id": mod_id},
+        )
+        if not decision.allowed:
+            raise _policy_http_error(decision)
+        try:
+            task = await state.tasks.create(
+                session_id=body.session_id,
+                command=plan["command"],
+                args=plan["args"],
+                created_by=auth.name,
+            )
+        except KeyError as e:
+            raise HTTPException(404, str(e)) from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="modules.bof.run",
+            resource=body.session_id,
+            details={"module_id": mod_id, "task_id": task.get("id")},
+            risk_score=9,
+        )
+        return task
 
     # ----- Shell interact -----
 

--- a/src/squidc5/modules/__init__.py
+++ b/src/squidc5/modules/__init__.py
@@ -1,0 +1,3 @@
+from squidc5.modules.catalog import list_bof_modules, list_inject_techniques, sleep_mask_catalog
+
+__all__ = ["list_bof_modules", "list_inject_techniques", "sleep_mask_catalog"]

--- a/src/squidc5/modules/catalog.py
+++ b/src/squidc5/modules/catalog.py
@@ -1,0 +1,84 @@
+"""Official post-ex / BOF / inject module catalog (authorized lab only)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Techniques are named for operator planning; agent enforces SC5_ALLOW_INJECT=1
+INJECT_TECHNIQUES = [
+    {
+        "id": "create_remote_thread",
+        "platforms": ["windows"],
+        "risk": "high",
+        "description": "Classic CreateRemoteThread injection (lab only)",
+        "requires_env": "SC5_ALLOW_INJECT=1",
+    },
+    {
+        "id": "apc_queue",
+        "platforms": ["windows"],
+        "risk": "high",
+        "description": "QueueUserAPC-style injection (lab only)",
+        "requires_env": "SC5_ALLOW_INJECT=1",
+    },
+    {
+        "id": "process_vm_write",
+        "platforms": ["linux"],
+        "risk": "high",
+        "description": "process_vm_writev self/remote write lab stub",
+        "requires_env": "SC5_ALLOW_INJECT=1",
+    },
+]
+
+SLEEP_MASK_MODES = [
+    {
+        "id": "jitter_only",
+        "description": "Sleep with jitter; wipe sensitive buffers before sleep",
+    },
+    {
+        "id": "timer_wait",
+        "description": "Wait via timer channel instead of plain Sleep (cross-platform)",
+    },
+    {
+        "id": "ekko_style",
+        "platforms": ["windows"],
+        "description": "Windows timer-stack encrypt sleep pattern (lab research mode)",
+        "requires_env": "SC5_SLEEP_MASK=ekko",
+    },
+]
+
+
+def bof_modules_dir() -> Path:
+    # repo root / modules / bof
+    return Path(__file__).resolve().parents[3] / "modules" / "bof"
+
+
+def list_bof_modules() -> list[dict[str, Any]]:
+    root = bof_modules_dir()
+    out: list[dict[str, Any]] = []
+    if not root.is_dir():
+        return out
+    for p in sorted(root.glob("*.c")):
+        out.append(
+            {
+                "id": p.stem,
+                "name": p.stem,
+                "path": str(p.relative_to(root.parent.parent)) if root.parent.parent.exists() else p.name,
+                "source": p.name,
+                "entry": "go",
+                "platforms": ["windows"],
+                "description": f"BOF-style source {p.name} (compile with mingw; load via bof:run)",
+            }
+        )
+    return out
+
+
+def list_inject_techniques(platform: str | None = None) -> list[dict[str, Any]]:
+    if not platform:
+        return list(INJECT_TECHNIQUES)
+    pl = platform.lower()
+    return [t for t in INJECT_TECHNIQUES if pl in t.get("platforms", []) or not t.get("platforms")]
+
+
+def sleep_mask_catalog() -> list[dict[str, Any]]:
+    return list(SLEEP_MASK_MODES)

--- a/src/squidc5/modules/coff_loader.py
+++ b/src/squidc5/modules/coff_loader.py
@@ -1,0 +1,77 @@
+"""Minimal COFF/BOF metadata loader (lab). Does not execute untrusted code in CI.
+
+Full Windows COFF execution runs only inside sc5beacon when SC5_ALLOW_BOF=1.
+This module validates object headers and returns a run plan for the agent.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+from typing import Any
+
+# COFF file header (IMAGE_FILE_HEADER) — 20 bytes
+# Machine, NumberOfSections, TimeDateStamp, PointerToSymbolTable,
+# NumberOfSymbols, SizeOfOptionalHeader, Characteristics
+
+
+def parse_coff_header(data: bytes) -> dict[str, Any]:
+    if len(data) < 20:
+        raise ValueError("COFF too small")
+    (
+        machine,
+        nsections,
+        ts,
+        symptr,
+        nsyms,
+        opt_sz,
+        chars,
+    ) = struct.unpack_from("<HHIIIHH", data, 0)
+    machines = {
+        0x14C: "i386",
+        0x8664: "amd64",
+        0x1C0: "arm",
+        0xAA64: "arm64",
+    }
+    return {
+        "machine": hex(machine),
+        "arch": machines.get(machine, "unknown"),
+        "sections": nsections,
+        "symbols": nsyms,
+        "characteristics": hex(chars),
+        "timestamp": ts,
+        "symtab_ptr": symptr,
+        "optional_header_size": opt_sz,
+        "valid_header": True,
+    }
+
+
+def plan_bof_run(
+    *,
+    module_id: str,
+    object_path: Path | None = None,
+    object_b64: str | None = None,
+    entry: str = "go",
+) -> dict[str, Any]:
+    """Build agent task args for bof:run (agent performs load when allowed)."""
+    meta: dict[str, Any] = {
+        "module_id": module_id,
+        "entry": entry,
+        "requires_env": "SC5_ALLOW_BOF=1",
+        "note": "Authorized lab only — agent refuses without SC5_ALLOW_BOF",
+    }
+    if object_path and object_path.is_file():
+        raw = object_path.read_bytes()
+        try:
+            meta["coff"] = parse_coff_header(raw)
+        except ValueError as e:
+            meta["coff_error"] = str(e)
+        meta["size"] = len(raw)
+        meta["sha256_prefix"] = __import__("hashlib").sha256(raw).hexdigest()[:16]
+    if object_b64:
+        meta["object_b64"] = object_b64
+        meta["has_payload"] = True
+    return {
+        "command": "bof:run",
+        "args": meta,
+    }

--- a/tests/test_modules_inject_bof.py
+++ b/tests/test_modules_inject_bof.py
@@ -1,0 +1,117 @@
+"""Modules catalog, inject/BOF task queue, COFF header parse."""
+
+from __future__ import annotations
+
+import struct
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+from squidc5.modules.catalog import list_bof_modules, list_inject_techniques, sleep_mask_catalog
+from squidc5.modules.coff_loader import parse_coff_header, plan_bof_run
+
+ADMIN = "sc5_test_admin_token_bootstrap_modinj01"
+
+
+def test_catalog_lists():
+    inj = list_inject_techniques()
+    assert any(t["id"] == "create_remote_thread" for t in inj)
+    assert sleep_mask_catalog()
+    bofs = list_bof_modules()
+    assert any(m["id"] == "whoami" for m in bofs)
+
+
+def test_coff_header_amd64():
+    # Minimal IMAGE_FILE_HEADER: Machine=0x8664, 1 section, rest zeros
+    hdr = struct.pack("<HHIIIHH", 0x8664, 1, 0, 0, 0, 0, 0)
+    meta = parse_coff_header(hdr + b"\x00" * 40)
+    assert meta["arch"] == "amd64"
+    assert meta["sections"] == 1
+    assert meta["valid_header"] is True
+
+
+def test_plan_bof_run_metadata():
+    plan = plan_bof_run(module_id="whoami")
+    assert plan["command"] == "bof:run"
+    assert plan["args"]["module_id"] == "whoami"
+    assert "SC5_ALLOW_BOF" in plan["args"]["requires_env"]
+
+
+@pytest.mark.asyncio
+async def test_modules_api_and_queue(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            cat = await client.get("/api/v1/modules", headers=h)
+            assert cat.status_code == 200, cat.text
+            body = cat.json()
+            assert "inject" in body and "bof" in body and "sleep_mask" in body
+
+            b = await client.post("/api/v1/implant/beacon", json={"hostname": "mod-host"})
+            assert b.status_code == 200
+            sid = b.json()["session_id"]
+
+            inj = await client.post(
+                "/api/v1/modules/inject",
+                headers=h,
+                json={"session_id": sid, "technique": "create_remote_thread", "pid": 1},
+            )
+            assert inj.status_code == 200, inj.text
+            assert inj.json()["command"].startswith("inject:")
+
+            bof = await client.post(
+                "/api/v1/modules/bof/run",
+                headers=h,
+                json={"session_id": sid, "module_id": "whoami"},
+            )
+            assert bof.status_code == 200, bof.text
+            assert bof.json()["command"] == "bof:run"
+
+            bad = await client.post(
+                "/api/v1/modules/bof/run",
+                headers=h,
+                json={"session_id": sid, "module_id": "../etc/passwd"},
+            )
+            assert bad.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_ops_admin_has_new_panels(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d2",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=1000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.get("/api/v1/ops/admin.js", headers=h)
+            assert r.status_code == 200
+            js = r.text
+            for marker in (
+                "filesPanel",
+                "socksPanel",
+                "modulesPanel",
+                "hitlPanel",
+                "engagementPanel",
+                "/api/v1/modules",
+            ):
+                assert marker in js, marker

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -368,6 +368,116 @@
     `, true, "c2-profiles"));
   }
 
+  // ----- File ops -----
+  if (can("shell:interact")) {
+    parts.push(panel("filesPanel", "📁 File ops", `
+      ${hint("Structured file list/read/write/delete tasks on a beacon session. Write may require HITL. Implant executes <code>file:*</code> commands.", "file-ops")}
+      <label for="fileSession">Session id</label>
+      <input id="fileSession" placeholder="beacon session id" autocomplete="off" />
+      <label for="fileOp">Op</label>
+      <select id="fileOp">
+        <option value="list">list</option>
+        <option value="read">read</option>
+        <option value="write">write</option>
+        <option value="delete">delete</option>
+      </select>
+      <label for="filePath">Path</label>
+      <input id="filePath" placeholder="/tmp or C:\\\\temp" autocomplete="off" />
+      <label for="fileContent">Content (write)</label>
+      <textarea id="fileContent" placeholder="optional text" style="min-height:60px"></textarea>
+      <div class="row">
+        <button type="button" class="primary" id="fileOpBtn">Queue file op</button>
+      </div>
+      <div class="outbox empty-out" id="fileOut" style="margin-top:8px">—</div>
+    `, false, "file-ops"));
+  }
+
+  // ----- SOCKS pivot -----
+  if (can("shell:interact")) {
+    parts.push(panel("socksPanel", "🕸 SOCKS pivot", `
+      ${hint("Start a SOCKS5 listener bridged through an implant (reverse-dial) or direct mode. List/stop existing pivots.", "socks-pivot")}
+      <label for="socksSession">Session id</label>
+      <input id="socksSession" placeholder="beacon session id" autocomplete="off" />
+      <label for="socksHost">Listen host</label>
+      <input id="socksHost" value="127.0.0.1" autocomplete="off" />
+      <label for="socksPort">Listen port (0=ephemeral)</label>
+      <input id="socksPort" type="number" value="0" autocomplete="off" />
+      <label for="socksMode">Mode</label>
+      <select id="socksMode">
+        <option value="implant">implant (reverse-dial)</option>
+        <option value="direct">direct</option>
+      </select>
+      <div class="row">
+        <button type="button" class="primary" id="socksStartBtn">Start</button>
+        <button type="button" id="socksListBtn">List</button>
+      </div>
+      <label for="socksStopId">Stop pivot id</label>
+      <input id="socksStopId" placeholder="pivot id" autocomplete="off" />
+      <div class="row">
+        <button type="button" class="danger" id="socksStopBtn">Stop</button>
+      </div>
+      <div class="outbox empty-out" id="socksOut" style="margin-top:8px">—</div>
+    `, false, "socks-pivot"));
+  }
+
+  // ----- Modules inject / BOF -----
+  if (can("shell:interact") || can("tasks:read")) {
+    parts.push(panel("modulesPanel", "🧬 Inject / BOF / sleep", `
+      ${hint("Lab catalog for inject techniques, BOF modules, sleep-mask modes. Queue inject/BOF only on authorized targets; implant requires <code>SC5_ALLOW_INJECT=1</code> / <code>SC5_ALLOW_BOF=1</code>.", "modules")}
+      <div class="row">
+        <button type="button" id="modCatalogBtn">Load catalog</button>
+      </div>
+      <label for="modSession">Session id</label>
+      <input id="modSession" placeholder="beacon session id" autocomplete="off" />
+      <label for="modTech">Inject technique</label>
+      <input id="modTech" placeholder="create_remote_thread" autocomplete="off" />
+      <label for="modPid">PID</label>
+      <input id="modPid" type="number" value="0" autocomplete="off" />
+      <div class="row">
+        ${can("shell:interact") ? '<button type="button" class="primary" id="modInjectBtn">Queue inject</button>' : ""}
+      </div>
+      <label for="modBofId">BOF module id</label>
+      <input id="modBofId" placeholder="whoami" autocomplete="off" />
+      <div class="row">
+        ${can("shell:interact") ? '<button type="button" id="modBofBtn">Queue bof:run</button>' : ""}
+      </div>
+      <div class="outbox empty-out" id="modOut" style="margin-top:8px">—</div>
+    `, false, "modules"));
+  }
+
+  // ----- HITL queue -----
+  if (can("policy:manage") || can("admin")) {
+    parts.push(panel("hitlPanel", "✋ HITL queue", `
+      ${hint("Human-in-the-loop approvals for high-risk actions. List pending requests; approve or deny as admin.", "hitl")}
+      <div class="row">
+        <button type="button" id="hitlListBtn">List pending</button>
+      </div>
+      <label for="hitlId">Request id</label>
+      <input id="hitlId" placeholder="hitl request id" autocomplete="off" />
+      <div class="row">
+        ${can("admin") ? '<button type="button" class="primary" id="hitlApproveBtn">Approve</button>' : ""}
+        ${can("admin") ? '<button type="button" class="danger" id="hitlDenyBtn">Deny</button>' : ""}
+      </div>
+      <div class="outbox empty-out" id="hitlOut" style="margin-top:8px">—</div>
+    `, false, "hitl"));
+  }
+
+  // ----- Engagement ROE -----
+  if (can("policy:manage") || can("admin")) {
+    parts.push(panel("engagementPanel", "🎯 Engagement ROE", `
+      ${hint("Rules of engagement: allowed hosts/CIDRs, kill date, working hours. Get current policy; admins can PATCH JSON fields.", "engagement")}
+      <div class="row">
+        <button type="button" id="engGetBtn">Get engagement</button>
+      </div>
+      <label for="engJson">Update JSON (admin)</label>
+      <textarea id="engJson" placeholder='{"allowed_cidrs":["10.0.0.0/8"]}' style="min-height:80px"></textarea>
+      <div class="row">
+        ${can("admin") ? '<button type="button" class="primary" id="engSetBtn">Save engagement</button>' : ""}
+      </div>
+      <div class="outbox empty-out" id="engOut" style="margin-top:8px">—</div>
+    `, false, "engagement"));
+  }
+
   // ----- Feature toggles (admin) -----
   if (can("admin") || can("policy:manage")) {
     parts.push(panel("featuresPanel", "🎛 Feature toggles", `
@@ -1176,6 +1286,152 @@
   }
   if ($("chatReloadBtn")) {
     $("chatReloadBtn").onclick = () => loadChat().catch((e) => showError(String(e.message || e)));
+  }
+
+  // File ops
+  if ($("fileOpBtn")) {
+    $("fileOpBtn").onclick = async () => {
+      const session_id = ($("fileSession").value || "").trim();
+      const op = ($("fileOp").value || "list").trim();
+      const path = ($("filePath").value || "").trim();
+      if (!session_id) return showError("Session id required");
+      const body = { session_id, op, path };
+      if (op === "write") body.content = $("fileContent").value || "";
+      try {
+        const r = await api("POST", "/api/v1/files/op", body);
+        setOut("fileOut", JSON.stringify(r, null, 2), false);
+        showOk("File op queued");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+
+  // SOCKS
+  if ($("socksStartBtn")) {
+    $("socksStartBtn").onclick = async () => {
+      const session_id = ($("socksSession").value || "").trim();
+      if (!session_id) return showError("Session id required");
+      try {
+        const r = await api("POST", "/api/v1/pivot/socks", {
+          session_id,
+          listen_host: ($("socksHost").value || "127.0.0.1").trim(),
+          listen_port: Number($("socksPort").value || 0),
+          mode: ($("socksMode").value || "implant"),
+        });
+        setOut("socksOut", JSON.stringify(r, null, 2), false);
+        showOk("SOCKS started");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("socksListBtn")) {
+    $("socksListBtn").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/pivot/socks");
+        setOut("socksOut", JSON.stringify(r, null, 2), false);
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("socksStopBtn")) {
+    $("socksStopBtn").onclick = async () => {
+      const id = ($("socksStopId").value || "").trim();
+      if (!id) return showError("Pivot id required");
+      try {
+        const r = await api("DELETE", `/api/v1/pivot/socks/${encodeURIComponent(id)}`);
+        setOut("socksOut", JSON.stringify(r, null, 2), false);
+        showOk("Stopped");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+
+  // Modules
+  if ($("modCatalogBtn")) {
+    $("modCatalogBtn").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/modules");
+        setOut("modOut", JSON.stringify(r, null, 2), false);
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("modInjectBtn")) {
+    $("modInjectBtn").onclick = async () => {
+      const session_id = ($("modSession").value || "").trim();
+      if (!session_id) return showError("Session id required");
+      try {
+        const r = await api("POST", "/api/v1/modules/inject", {
+          session_id,
+          technique: ($("modTech").value || "create_remote_thread").trim(),
+          pid: Number($("modPid").value || 0),
+        });
+        setOut("modOut", JSON.stringify(r, null, 2), false);
+        showOk("Inject task queued");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("modBofBtn")) {
+    $("modBofBtn").onclick = async () => {
+      const session_id = ($("modSession").value || "").trim();
+      const module_id = ($("modBofId").value || "").trim();
+      if (!session_id || !module_id) return showError("Session and module id required");
+      try {
+        const r = await api("POST", "/api/v1/modules/bof/run", { session_id, module_id });
+        setOut("modOut", JSON.stringify(r, null, 2), false);
+        showOk("BOF task queued");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+
+  // HITL
+  if ($("hitlListBtn")) {
+    $("hitlListBtn").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/policy/hitl?status=pending");
+        setOut("hitlOut", JSON.stringify(r, null, 2), false);
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("hitlApproveBtn")) {
+    $("hitlApproveBtn").onclick = async () => {
+      const id = ($("hitlId").value || "").trim();
+      if (!id) return showError("Request id required");
+      try {
+        const r = await api("POST", `/api/v1/policy/hitl/${encodeURIComponent(id)}/approve`);
+        setOut("hitlOut", JSON.stringify(r, null, 2), false);
+        showOk("Approved");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("hitlDenyBtn")) {
+    $("hitlDenyBtn").onclick = async () => {
+      const id = ($("hitlId").value || "").trim();
+      if (!id) return showError("Request id required");
+      try {
+        const r = await api("POST", `/api/v1/policy/hitl/${encodeURIComponent(id)}/deny`);
+        setOut("hitlOut", JSON.stringify(r, null, 2), false);
+        showOk("Denied");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+
+  // Engagement
+  if ($("engGetBtn")) {
+    $("engGetBtn").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/engagement");
+        setOut("engOut", JSON.stringify(r, null, 2), false);
+        if ($("engJson") && !$("engJson").value) $("engJson").value = JSON.stringify(r, null, 2);
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+  if ($("engSetBtn")) {
+    $("engSetBtn").onclick = async () => {
+      let body = {};
+      try { body = JSON.parse($("engJson").value || "{}"); }
+      catch (_) { return showError("Invalid JSON"); }
+      try {
+        const r = await api("PUT", "/api/v1/engagement", body);
+        setOut("engOut", JSON.stringify(r, null, 2), false);
+        showOk("Engagement saved");
+      } catch (e) { showError(String(e.message || e)); }
+    };
   }
 
   // Bootstrap data for panels present

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -244,7 +244,12 @@
     #profilesPanel > .panel-body,
     #featuresPanel > .panel-body,
     #policyPanel > .panel-body,
-    #mcpPanel > .panel-body {
+    #mcpPanel > .panel-body,
+    #filesPanel > .panel-body,
+    #socksPanel > .panel-body,
+    #modulesPanel > .panel-body,
+    #hitlPanel > .panel-body,
+    #engagementPanel > .panel-body {
       padding-bottom: 40px;
     }
     details.panel > .panel-body.scroll-focus {


### PR DESCRIPTION
## Summary
- **Build 1:** Sleep mask modes in sc5beacon (`SC5_SLEEP_MASK`); lab-gated inject techniques (`SC5_ALLOW_INJECT=1`) with catalog + API queue
- **Build 2:** BOF module catalog, minimal COFF header parser, `bof:run` plan/queue (`SC5_ALLOW_BOF=1` on implant)
- **Build 3:** Ops UI panels — File ops, SOCKS pivot, Inject/BOF/sleep catalog, HITL queue, Engagement ROE

## APIs
- `GET /api/v1/modules` — inject + bof + sleep_mask catalog
- `POST /api/v1/modules/inject` — queue inject task
- `POST /api/v1/modules/bof/run` — queue bof:run plan

## Security
- Inject/BOF are **no-op lab stubs** on the agent unless env gates set
- Path traversal rejected on module_id
- High-risk audit events for queue actions
- No real process injection in default builds

## Test plan
- [x] `pytest tests/test_modules_inject_bof.py`
- [x] ruff on new modules
- [ ] CI + SquidGate green