### PR TITLE
fix(ops): mobile, scopes UI, listener fill, pending tasks

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -58,6 +58,11 @@ class TaskCreate(BaseModel):
     hitl_request_id: str | None = None
 
 
+class TaskUpdate(BaseModel):
+    command: str | None = None
+    args: dict[str, Any] | None = None
+
+
 class PayloadRequest(BaseModel):
     template: str
     host: str
@@ -533,10 +538,11 @@ def build_api_router() -> APIRouter:
     async def list_tasks(
         request: Request,
         session_id: str | None = None,
+        status: str | None = None,
         auth: AuthContext = Depends(require_scope("tasks:read", "admin")),
     ) -> list[dict[str, Any]]:
         state = get_state(request)
-        return await state.tasks.list(session_id=session_id)
+        return await state.tasks.list(session_id=session_id, status=status)
 
     @api.post("/tasks")
     async def create_task(
@@ -587,6 +593,71 @@ def build_api_router() -> APIRouter:
         if not t:
             raise HTTPException(404, "task not found")
         return t
+
+    @api.post("/tasks/{task_id}/cancel")
+    async def cancel_task(
+        task_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tasks:write", "admin")),
+    ) -> dict[str, Any]:
+        """Cancel a pending task (not yet picked up by implant)."""
+        state = get_state(request)
+        try:
+            t = await state.tasks.get(task_id)
+            if not t:
+                raise HTTPException(404, "task not found")
+            if not auth.has_scope("admin"):
+                await state.teams.assert_write_access(
+                    t["session_id"], auth.name, is_admin=False
+                )
+            out = await state.tasks.cancel(task_id)
+        except KeyError as e:
+            raise HTTPException(404, str(e)) from e
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="tasks.cancel",
+            resource=task_id,
+            risk_score=3,
+        )
+        return out
+
+    @api.patch("/tasks/{task_id}")
+    async def update_task(
+        task_id: str,
+        body: TaskUpdate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tasks:write", "admin")),
+    ) -> dict[str, Any]:
+        """Modify command/args on a pending task only."""
+        state = get_state(request)
+        if body.command is None and body.args is None:
+            raise HTTPException(400, "command or args required")
+        try:
+            t = await state.tasks.get(task_id)
+            if not t:
+                raise HTTPException(404, "task not found")
+            if not auth.has_scope("admin"):
+                await state.teams.assert_write_access(
+                    t["session_id"], auth.name, is_admin=False
+                )
+            out = await state.tasks.update_pending(
+                task_id, command=body.command, args=body.args
+            )
+        except KeyError as e:
+            raise HTTPException(404, str(e)) from e
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="tasks.update",
+            resource=task_id,
+            risk_score=3,
+        )
+        return out
 
     # ----- Listeners -----
 

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -541,7 +541,22 @@ def build_api_router() -> APIRouter:
         status: str | None = None,
         auth: AuthContext = Depends(require_scope("tasks:read", "admin")),
     ) -> list[dict[str, Any]]:
+        """List tasks. Non-admins must pass session_id (no global enumeration)."""
         state = get_state(request)
+        if not auth.has_scope("admin"):
+            if not session_id:
+                raise HTTPException(
+                    400, "session_id required (non-admin cannot list all tasks)"
+                )
+            # read path: allow if not claim-locked against this actor
+            try:
+                await state.teams.assert_write_access(
+                    session_id, auth.name, is_admin=False
+                )
+            except KeyError as e:
+                raise HTTPException(404, str(e)) from e
+            except PermissionError as e:
+                raise HTTPException(403, str(e)) from e
         return await state.tasks.list(session_id=session_id, status=status)
 
     @api.post("/tasks")

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -324,13 +324,55 @@ class Database:
     async def get_task(self, task_id: str) -> dict[str, Any] | None:
         return await self.fetchone("SELECT * FROM tasks WHERE id = ?", (task_id,))
 
-    async def list_tasks(self, session_id: str | None = None) -> list[dict[str, Any]]:
+    async def cancel_task(self, task_id: str) -> bool:
+        """Cancel a pending task only (not running/completed)."""
+        cur = await self.execute(
+            """UPDATE tasks SET status = 'cancelled', completed_at = ?, result = COALESCE(result, '')
+               WHERE id = ? AND status = 'pending'""",
+            (_now(), task_id),
+        )
+        return cur.rowcount > 0
+
+    async def update_pending_task(
+        self,
+        task_id: str,
+        *,
+        command: str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> bool:
+        """Modify command/args on a pending task only."""
+        row = await self.get_task(task_id)
+        if not row or row.get("status") != "pending":
+            return False
+        new_cmd = command if command is not None else row.get("command")
+        if args is not None:
+            new_args = json.dumps(args)
+        else:
+            existing = row.get("args")
+            new_args = existing if isinstance(existing, str) else json.dumps(existing or {})
+        cur = await self.execute(
+            """UPDATE tasks SET command = ?, args = ? WHERE id = ? AND status = 'pending'""",
+            (new_cmd, new_args, task_id),
+        )
+        return cur.rowcount > 0
+
+    async def list_tasks(
+        self, session_id: str | None = None, *, status: str | None = None
+    ) -> list[dict[str, Any]]:
+        clauses: list[str] = []
+        params: list[Any] = []
         if session_id:
-            return await self.fetchall(
-                "SELECT * FROM tasks WHERE session_id = ? ORDER BY created_at DESC",
-                (session_id,),
-            )
-        return await self.fetchall("SELECT * FROM tasks ORDER BY created_at DESC LIMIT 200")
+            clauses.append("session_id = ?")
+            params.append(session_id)
+        if status:
+            clauses.append("status = ?")
+            params.append(status)
+        where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+        params.append(200)
+        return await self.fetchall(
+            f"SELECT * FROM tasks {where} ORDER BY created_at DESC LIMIT ?",
+            tuple(params),
+        )
 
     async def complete_task(
         self,

--- a/src/squidc5/tasking/manager.py
+++ b/src/squidc5/tasking/manager.py
@@ -78,12 +78,37 @@ class TaskManager:
         row = await self.db.get_task(task_id)
         return self._norm(row) if row else None
 
-    async def list(self, session_id: str | None = None) -> list[dict[str, Any]]:
-        return [self._norm(r) for r in await self.db.list_tasks(session_id)]
+    async def list(
+        self, session_id: str | None = None, *, status: str | None = None
+    ) -> list[dict[str, Any]]:
+        return [self._norm(r) for r in await self.db.list_tasks(session_id, status=status)]
 
     async def poll(self, session_id: str) -> dict[str, Any] | None:
         row = await self.db.next_pending_task(session_id)
         return self._norm(row) if row else None
+
+    async def cancel(self, task_id: str) -> dict[str, Any]:
+        ok = await self.db.cancel_task(task_id)
+        if not ok:
+            raise KeyError("task not found or not pending")
+        await self.metrics.incr("tasks.cancelled")
+        await self.metrics.emit("task.cancelled", {"id": task_id})
+        row = await self.db.get_task(task_id)
+        return self._norm(row)  # type: ignore[arg-type]
+
+    async def update_pending(
+        self,
+        task_id: str,
+        *,
+        command: str | None = None,
+        args: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        ok = await self.db.update_pending_task(task_id, command=command, args=args)
+        if not ok:
+            raise KeyError("task not found or not pending")
+        await self.metrics.emit("task.updated", {"id": task_id})
+        row = await self.db.get_task(task_id)
+        return self._norm(row)  # type: ignore[arg-type]
 
     async def complete(
         self,

--- a/tests/test_task_cancel_update.py
+++ b/tests/test_task_cancel_update.py
@@ -39,8 +39,10 @@ async def test_cancel_and_patch_pending_task(tmp_path):
             tid = t.json()["id"]
             assert t.json()["status"] == "pending"
 
-            # list pending
-            lst = await client.get("/api/v1/tasks?status=pending", headers=h)
+            # list pending for session
+            lst = await client.get(
+                f"/api/v1/tasks?session_id={sid}&status=pending", headers=h
+            )
             assert lst.status_code == 200
             assert any(x["id"] == tid for x in lst.json())
 

--- a/tests/test_task_cancel_update.py
+++ b/tests/test_task_cancel_update.py
@@ -1,0 +1,72 @@
+"""Pending task cancel and modify APIs."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_tskcanc01"
+
+
+@pytest.mark.asyncio
+async def test_cancel_and_patch_pending_task(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        implant_require_auth=False,
+        rate_limit_per_minute=2000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            b = await client.post("/api/v1/implant/beacon", json={"hostname": "t1"})
+            assert b.status_code == 200
+            sid = b.json()["session_id"]
+            t = await client.post(
+                "/api/v1/tasks",
+                headers=h,
+                json={"session_id": sid, "command": "whoami"},
+            )
+            assert t.status_code == 200, t.text
+            tid = t.json()["id"]
+            assert t.json()["status"] == "pending"
+
+            # list pending
+            lst = await client.get("/api/v1/tasks?status=pending", headers=h)
+            assert lst.status_code == 200
+            assert any(x["id"] == tid for x in lst.json())
+
+            # patch command
+            p = await client.patch(
+                f"/api/v1/tasks/{tid}",
+                headers=h,
+                json={"command": "id"},
+            )
+            assert p.status_code == 200, p.text
+            assert p.json()["command"] == "id"
+            assert p.json()["status"] == "pending"
+
+            # cancel
+            c = await client.post(f"/api/v1/tasks/{tid}/cancel", headers=h)
+            assert c.status_code == 200, c.text
+            assert c.json()["status"] == "cancelled"
+
+            # cannot cancel again
+            c2 = await client.post(f"/api/v1/tasks/{tid}/cancel", headers=h)
+            assert c2.status_code == 404
+
+            # cannot patch cancelled
+            p2 = await client.patch(
+                f"/api/v1/tasks/{tid}",
+                headers=h,
+                json={"command": "uname"},
+            )
+            assert p2.status_code == 404

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -185,6 +185,7 @@
     }
     if (el("pxSid")) el("pxSid").textContent = selectedId || "(none — pick in Sessions)";
     renderContext();
+    if (el("tskList")) loadTasksPanel();
   }
   window.__SC5_selectSession = selectSession;
 
@@ -257,6 +258,18 @@
               Shell = verified reverse shells; Tasks = beacons.
             </p>
             <div id="sesDetail" class="outbox empty" style="margin-top:12px">Select a session…</div>
+            <div class="wp-head" style="margin-top:12px;border-top:1px solid var(--border);padding-top:8px">
+              Pending tasks ${docLink("tasks")}
+            </div>
+            <div class="toolbar" style="margin-top:6px">
+              <button type="button" id="tskReload">Reload tasks</button>
+              ${can("tasks:write") ? '<button type="button" class="danger" id="tskCancel">Cancel selected</button>' : ""}
+              ${can("tasks:write") ? '<button type="button" id="tskSave">Save edit</button>' : ""}
+            </div>
+            <div id="tskList" class="lp-body" style="max-height:180px;border:1px solid var(--border);border-radius:6px;margin-top:6px"></div>
+            <label for="tskCmd">Edit command (pending only)</label>
+            <input id="tskCmd" placeholder="select a pending task" />
+            <p class="muted mono" id="tskHint" style="font-size:0.7rem;margin:4px 0 0">—</p>
           </div>
         </div>
       </div>
@@ -291,12 +304,85 @@
       }
     };
     if (el("sesRefresh")) el("sesRefresh").onclick = () => window.__SC5_refresh && window.__SC5_refresh();
+    if (el("tskReload")) el("tskReload").onclick = () => loadTasksPanel();
+    if (el("tskCancel")) el("tskCancel").onclick = () => cancelSelectedTask();
+    if (el("tskSave")) el("tskSave").onclick = () => saveSelectedTask();
     tools(`${docLink("sessions", "Sessions docs")} <button type="button" class="primary" id="toolNewShell">Focus rail</button>`);
     if (el("toolNewShell")) el("toolNewShell").onclick = () => {
       if (!selectedId) return showError("Select a session first");
       renderContext();
     };
     if (selectedId) selectSession(selectedId);
+    loadTasksPanel();
+  }
+
+  let selectedTaskId = null;
+  async function loadTasksPanel() {
+    const box = el("tskList");
+    if (!box) return;
+    if (!can("tasks:read") && !can("admin")) {
+      box.innerHTML = '<div class="muted" style="padding:8px">Need tasks:read</div>';
+      return;
+    }
+    try {
+      const q = selectedId
+        ? `/api/v1/tasks?session_id=${encodeURIComponent(selectedId)}&status=pending`
+        : "/api/v1/tasks?status=pending";
+      let tasks = await api("GET", q);
+      if (!Array.isArray(tasks)) tasks = tasks.tasks || [];
+      // also show pending for all if no session filter returned empty and we want global
+      if (!tasks.length && selectedId) {
+        const all = await api("GET", "/api/v1/tasks?status=pending");
+        tasks = Array.isArray(all) ? all.filter((t) => t.session_id === selectedId) : [];
+      }
+      if (!tasks.length) {
+        box.innerHTML = '<div class="muted" style="padding:8px">No pending tasks' +
+          (selectedId ? " for this session" : "") + "</div>";
+        selectedTaskId = null;
+        return;
+      }
+      box.innerHTML = `<table class="data"><thead><tr><th>ID</th><th>Session</th><th>Command</th><th>Status</th></tr></thead><tbody>
+        ${tasks.map((t) => `<tr data-tid="${esc(t.id)}" class="${t.id === selectedTaskId ? "selected" : ""}">
+          <td class="mono">${esc(shortId(t.id))}</td>
+          <td class="mono">${esc(shortId(t.session_id))}</td>
+          <td>${esc(t.command || "")}</td>
+          <td><span class="chip">${esc(t.status || "")}</span></td>
+        </tr>`).join("")}
+      </tbody></table>`;
+      box.querySelectorAll("tr[data-tid]").forEach((tr) => {
+        tr.onclick = () => {
+          selectedTaskId = tr.getAttribute("data-tid");
+          box.querySelectorAll("tr").forEach((x) => x.classList.remove("selected"));
+          tr.classList.add("selected");
+          const t = tasks.find((x) => x.id === selectedTaskId);
+          if (t && el("tskCmd")) el("tskCmd").value = t.command || "";
+          if (el("tskHint")) el("tskHint").textContent = t
+            ? `Editing ${t.id} (${t.status}) · session ${t.session_id}`
+            : "—";
+        };
+      });
+    } catch (e) {
+      box.innerHTML = `<div class="muted" style="padding:8px">${esc(String(e.message || e))}</div>`;
+    }
+  }
+  async function cancelSelectedTask() {
+    if (!selectedTaskId) return showError("Select a pending task");
+    try {
+      await api("POST", `/api/v1/tasks/${encodeURIComponent(selectedTaskId)}/cancel`);
+      showOk("Task cancelled");
+      selectedTaskId = null;
+      await loadTasksPanel();
+    } catch (e) { showError(String(e.message || e)); }
+  }
+  async function saveSelectedTask() {
+    if (!selectedTaskId) return showError("Select a pending task");
+    const command = (el("tskCmd") && el("tskCmd").value || "").trim();
+    if (!command) return showError("Command required");
+    try {
+      await api("PATCH", `/api/v1/tasks/${encodeURIComponent(selectedTaskId)}`, { command });
+      showOk("Task updated");
+      await loadTasksPanel();
+    } catch (e) { showError(String(e.message || e)); }
   }
 
   /* —— Listeners —— */
@@ -315,9 +401,22 @@
         saveSel("sc5_ops_lid", selectedListenerId);
         tbody.querySelectorAll("tr").forEach((x) => x.classList.remove("selected"));
         tr.classList.add("selected");
+        populateListenerForm(selectedListenerId);
       };
     });
   }
+
+  function populateListenerForm(lid) {
+    const l = (cache.listeners || []).find((x) => x.id === lid);
+    if (!l) return;
+    if (el("lisName")) el("lisName").value = l.name || "";
+    if (el("lisPort")) el("lisPort").value = l.port != null ? String(l.port) : "";
+    if (el("lisKind")) el("lisKind").value = l.kind || "reverse_shell";
+    const cfg = l.config || {};
+    if (el("lisZone")) el("lisZone").value = cfg.zone || cfg.dns_zone || "";
+    if (el("lisIdHint")) el("lisIdHint").textContent = "Selected: " + (l.id || "") + " · " + (l.status || "");
+  }
+
 
   function renderListenersView(force) {
     const root = el("view-listeners");
@@ -340,6 +439,7 @@
           <div class="wp-head">Manage ${docLink("listeners")}</div>
           <div class="wp-body">
             ${can("listeners:write") ? `
+              <p class="muted mono" id="lisIdHint" style="font-size:0.72rem;margin:0 0 6px">Select a listener to load fields</p>
               <div class="form-grid">
                 <div><label>Name</label><input id="lisName" placeholder="rev443" /></div>
                 <div><label>Port</label><input id="lisPort" type="number" placeholder="443" /></div>
@@ -355,9 +455,10 @@
               </div>
               <div class="row">
                 <button type="button" class="primary" id="lisCreate">Create + start</button>
-                <button type="button" id="lisStart">Start selected</button>
+                <button type="button" id="lisStart">Start</button>
                 <button type="button" id="lisStop">Stop</button>
                 <button type="button" class="danger" id="lisDel">Delete</button>
+                <button type="button" id="lisClear">Clear form</button>
               </div>
             ` : '<p class="muted">Read-only token</p>'}
             <div class="outbox empty" id="lisOut">—</div>
@@ -367,6 +468,7 @@
     `;
     viewBuilt.listeners = true;
     fillListenerRows(el("lisTbody"));
+    if (selectedListenerId) populateListenerForm(selectedListenerId);
     async function lisAct(fn) {
       try {
         const r = await fn();
@@ -384,6 +486,8 @@
       const config = kind === "dns" && zone ? { zone } : {};
       const created = await api("POST", "/api/v1/listeners", { name, port, kind, host: "0.0.0.0", config });
       await api("POST", `/api/v1/listeners/${created.id}/start`);
+      selectedListenerId = created.id;
+      saveSel("sc5_ops_lid", selectedListenerId);
       showOk("Listener running");
       return created;
     });
@@ -401,8 +505,21 @@
         const id = selectedListenerId;
         selectedListenerId = null;
         saveSel("sc5_ops_lid", null);
+        if (el("lisName")) el("lisName").value = "";
+        if (el("lisPort")) el("lisPort").value = "";
+        if (el("lisIdHint")) el("lisIdHint").textContent = "Select a listener to load fields";
         return api("DELETE", `/api/v1/listeners/${id}`);
       });
+    };
+    if (el("lisClear")) el("lisClear").onclick = () => {
+      selectedListenerId = null;
+      saveSel("sc5_ops_lid", null);
+      if (el("lisName")) el("lisName").value = "";
+      if (el("lisPort")) el("lisPort").value = "";
+      if (el("lisZone")) el("lisZone").value = "";
+      if (el("lisKind")) el("lisKind").value = "reverse_shell";
+      if (el("lisIdHint")) el("lisIdHint").textContent = "Select a listener to load fields";
+      document.querySelectorAll("#lisTbody tr").forEach((x) => x.classList.remove("selected"));
     };
   }
 
@@ -807,6 +924,17 @@
       root.innerHTML = '<div class="empty-state"><strong>Admin area</strong>Requires admin or manage scopes.</div>';
       return;
     }
+    const defaultScopes = new Set([
+      "sessions:read", "sessions:write", "tasks:read", "tasks:write",
+      "shell:interact", "listeners:read", "collab:use", "metrics:read",
+    ]);
+    const allScopes = [
+      "sessions:read", "sessions:write", "tasks:read", "tasks:write",
+      "listeners:read", "listeners:write", "payloads:generate", "shell:interact",
+      "metrics:read", "audit:read", "ai:use", "collab:use", "profiles:read", "profiles:write",
+      "files:read", "files:write", "oast:read", "oast:write", "mcp:connect",
+      "tokens:manage", "llm:manage", "policy:manage", "plugins:manage", "admin",
+    ];
     root.innerHTML = `
       ${featDocs("feature-toggles", "Tokens, policy engine, feature flags. High-risk — admin only where required.")}
       <div class="form-grid">
@@ -814,28 +942,54 @@
           <div class="wp-head">Mint token ${docLink("tokens")}</div>
           <div class="wp-body">
             <label>Name</label><input id="adName" placeholder="operator-1" />
-            <label>Scopes (comma)</label>
-            <input id="adScopes" value="sessions:read,sessions:write,tasks:read,tasks:write,shell:interact,listeners:read,collab:use" />
+            <label>Scopes</label>
+            <div class="row" style="margin:4px 0">
+              <button type="button" id="adScopeOp">Operator preset</button>
+              <button type="button" id="adScopeNone">Clear</button>
+              <button type="button" id="adScopeAll">All non-admin</button>
+            </div>
+            <div class="scope-grid" id="adScopeGrid">
+              ${allScopes.map((s) => `
+                <label><input type="checkbox" class="ad-scope" value="${esc(s)}"
+                  ${defaultScopes.has(s) ? "checked" : ""}
+                  ${s === "admin" && !can("admin") ? "disabled" : ""} /> ${esc(s)}</label>
+              `).join("")}
+            </div>
             <div class="row"><button type="button" class="primary" id="adMint">Mint</button></div>
             <div class="outbox empty" id="adMintOut">Token shown once</div>
           </div>
         </div>
         <div class="work-panel">
-          <div class="wp-head">Policy / features</div>
+          <div class="wp-head">Policy / features ${docLink("feature-toggles")}</div>
           <div class="wp-body">
             <div class="row">
               <button type="button" id="adPolGet">Get policy</button>
               <button type="button" id="adFeat">Features</button>
               <button type="button" id="adTokList">List tokens</button>
             </div>
-            <div class="outbox empty" id="adOut" style="max-height:360px">—</div>
+            <div class="outbox empty" id="adOut" style="max-height:360px;flex:1">—</div>
           </div>
         </div>
       </div>
     `;
+    function selectedScopes() {
+      return Array.from(document.querySelectorAll(".ad-scope:checked")).map((c) => c.value);
+    }
+    function setScopes(set) {
+      document.querySelectorAll(".ad-scope").forEach((c) => {
+        if (c.disabled) return;
+        c.checked = set.has(c.value);
+      });
+    }
+    if (el("adScopeOp")) el("adScopeOp").onclick = () => setScopes(defaultScopes);
+    if (el("adScopeNone")) el("adScopeNone").onclick = () => setScopes(new Set());
+    if (el("adScopeAll")) el("adScopeAll").onclick = () => {
+      setScopes(new Set(allScopes.filter((s) => s !== "admin" || can("admin"))));
+    };
     if (el("adMint")) el("adMint").onclick = async () => {
       try {
-        const scopes = (el("adScopes").value || "").split(",").map((s) => s.trim()).filter(Boolean);
+        const scopes = selectedScopes();
+        if (!scopes.length) return showError("Select at least one scope");
         const r = await api("POST", "/api/v1/tokens", { name: el("adName").value.trim() || "op", scopes });
         el("adMintOut").textContent = r.token || JSON.stringify(r, null, 2);
         el("adMintOut").classList.remove("empty");
@@ -875,7 +1029,10 @@
     if (data.sessions) cache.sessions = data.sessions;
     if (data.listeners) cache.listeners = data.listeners;
     // Soft update — do not wipe selection or rebuild forms
-    if (currentIs("sessions")) renderSessionsView(false);
+    if (currentIs("sessions")) {
+      renderSessionsView(false);
+      if (el("tskList")) loadTasksPanel();
+    }
     if (currentIs("listeners")) renderListenersView(false);
     if (el("pxSid")) el("pxSid").textContent = selectedId || "(none — pick in Sessions)";
     // Restore row highlights without full context rebuild if possible

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -325,19 +325,16 @@
       return;
     }
     try {
-      const q = selectedId
-        ? `/api/v1/tasks?session_id=${encodeURIComponent(selectedId)}&status=pending`
-        : "/api/v1/tasks?status=pending";
+      if (!selectedId) {
+        box.innerHTML = '<div class="muted" style="padding:8px">Select a session to list pending tasks</div>';
+        selectedTaskId = null;
+        return;
+      }
+      const q = `/api/v1/tasks?session_id=${encodeURIComponent(selectedId)}&status=pending`;
       let tasks = await api("GET", q);
       if (!Array.isArray(tasks)) tasks = tasks.tasks || [];
-      // also show pending for all if no session filter returned empty and we want global
-      if (!tasks.length && selectedId) {
-        const all = await api("GET", "/api/v1/tasks?status=pending");
-        tasks = Array.isArray(all) ? all.filter((t) => t.session_id === selectedId) : [];
-      }
       if (!tasks.length) {
-        box.innerHTML = '<div class="muted" style="padding:8px">No pending tasks' +
-          (selectedId ? " for this session" : "") + "</div>";
+        box.innerHTML = '<div class="muted" style="padding:8px">No pending tasks for this session</div>';
         selectedTaskId = null;
         return;
       }

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -158,9 +158,10 @@
     .main-body {
       flex: 1; min-height: 0; overflow: auto;
       padding: 12px 14px;
+      display: flex; flex-direction: column;
     }
-    .view { display: none; height: 100%; }
-    .view.active { display: block; }
+    .view { display: none; flex: 1; min-height: 0; }
+    .view.active { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 
     /* Context rail (session detail) */
     .ctx {
@@ -229,11 +230,12 @@
 
     .split {
       display: grid; grid-template-columns: minmax(240px, 340px) 1fr;
-      gap: 12px; height: calc(100% - 4px); min-height: 280px;
+      gap: 12px; flex: 1; min-height: 0; height: 100%;
     }
     .list-panel, .work-panel {
       background: var(--bg2); border: 1px solid var(--border); border-radius: var(--radius);
       display: flex; flex-direction: column; min-height: 0; overflow: hidden;
+      height: 100%;
     }
     .list-panel .lp-head, .work-panel .wp-head {
       padding: 8px 10px; border-bottom: 1px solid var(--border);
@@ -241,9 +243,34 @@
       color: var(--muted); display: flex; align-items: center; gap: 8px; flex-shrink: 0;
     }
     .list-panel .lp-body, .work-panel .wp-body {
-      flex: 1; overflow: auto; min-height: 0;
+      flex: 1 1 auto; overflow: auto; min-height: 0;
     }
     .work-panel .wp-body { padding: 10px 12px; }
+    .view.active {
+      display: flex; flex-direction: column; height: 100%; min-height: 0;
+    }
+    .view.active > .feat-docs { flex-shrink: 0; }
+    .view.active > .split,
+    .view.active > .form-grid,
+    .view.active > .work-panel {
+      flex: 1 1 auto; min-height: 0;
+    }
+    .view.active > .form-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+      align-content: stretch;
+    }
+    .view.active > .form-grid > .work-panel { min-height: 0; height: 100%; }
+    .scope-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+      gap: 6px; margin: 8px 0; max-height: 220px; overflow: auto;
+      padding: 8px; background: #0e0e14; border: 1px solid var(--border); border-radius: 8px;
+    }
+    .scope-grid label {
+      display: flex; align-items: center; gap: 6px; margin: 0;
+      font-size: 0.72rem; text-transform: none; letter-spacing: 0; color: var(--text);
+      font-weight: 500; cursor: pointer;
+    }
+    .scope-grid input { width: auto; margin: 0; }
 
     table.data { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
     table.data th, table.data td {
@@ -359,35 +386,86 @@
       .ai-drawer { bottom: 76px; right: 8px; left: 8px; width: auto; }
     }
 
-    /* Mobile: stack */
+    /* Mobile: stack — keep shell height, scroll main only */
     @media (max-width: 900px) {
+      :root {
+        --top-h: 52px;
+        --bottom-h: 28vh;
+        --sidebar-w: 100%;
+      }
+      body { overflow: hidden; }
       .app {
-        grid-template-rows: var(--top-h) auto 1fr minmax(120px, 28vh);
+        grid-template-rows: var(--top-h) 48px 1fr var(--bottom-h);
         grid-template-columns: 1fr;
         grid-template-areas:
           "top"
           "side"
           "main"
           "bottom";
-        overflow: auto;
+        height: 100dvh;
+        overflow: hidden;
       }
+      .top {
+        padding: 0 8px; gap: 6px; flex-wrap: nowrap;
+      }
+      .top .title { font-size: 0.85rem; }
+      .top .host { display: none; }
+      .top .sep { display: none; }
+      .top button { padding: 8px 10px; font-size: 0.75rem; min-height: 40px; }
       .side {
         flex-direction: row; border-right: 0; border-bottom: 1px solid var(--border);
-        overflow-x: auto; max-height: none;
+        overflow: hidden; max-height: 48px;
       }
       .side-nav {
-        flex-direction: row; padding: 6px; gap: 4px; overflow-x: auto;
+        flex-direction: row; padding: 4px 6px; gap: 4px;
+        overflow-x: auto; overflow-y: hidden;
+        -webkit-overflow-scrolling: touch;
+        flex: 1;
       }
-      .nav-item { white-space: nowrap; flex: 0 0 auto; padding: 8px 12px; }
+      .nav-item {
+        white-space: nowrap; flex: 0 0 auto; padding: 8px 12px;
+        min-height: 40px; font-size: 0.78rem;
+      }
       .nav-item .badge-n { display: none; }
+      .nav-item .ico { display: none; }
       .side-foot { display: none; }
       .ctx { display: none !important; }
-      .bottom { grid-template-columns: 1fr; }
-      .bottom-pane:first-child { border-right: 0; border-bottom: 1px solid var(--border); }
-      .split { grid-template-columns: 1fr; height: auto; }
-      .main-body { overflow: visible; }
-      body { overflow: auto; }
-      .app { height: auto; min-height: 100dvh; }
+      .main { min-height: 0; overflow: hidden; }
+      .main-head { padding: 8px 10px; flex-wrap: wrap; gap: 6px; }
+      .main-head h2 { font-size: 0.9rem; }
+      .main-body {
+        overflow: auto; padding: 10px;
+        -webkit-overflow-scrolling: touch;
+        min-height: 0;
+      }
+      .bottom {
+        grid-template-columns: 1fr;
+        min-height: 0;
+      }
+      .bottom-pane:first-child { border-right: 0; border-bottom: 1px solid var(--border); max-height: 50%; }
+      .bottom-pane .bp-body { font-size: 0.68rem; }
+      .split {
+        grid-template-columns: 1fr;
+        height: auto;
+        min-height: 0;
+        gap: 10px;
+      }
+      .list-panel, .work-panel {
+        height: auto;
+        min-height: 180px;
+        max-height: none;
+      }
+      .list-panel .lp-body { max-height: 40vh; }
+      .view.active { height: auto; display: block; }
+      .view.active > .form-grid {
+        grid-template-columns: 1fr;
+      }
+      .view.active > .form-grid > .work-panel { height: auto; min-height: 200px; }
+      .stats { grid-template-columns: repeat(2, 1fr); }
+      .scope-grid { grid-template-columns: 1fr 1fr; max-height: 180px; }
+      button, .nav-item, input, select, textarea { font-size: 16px; } /* prevent iOS zoom */
+      input, select, textarea { padding: 10px; min-height: 42px; }
+      label { margin-top: 10px; }
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- **Mobile layout** — app shell stays 100dvh; scroll main only; larger touch targets; horizontal nav
- **Full-height panels** — split/list/work panels flex to fill available space
- **Mint scopes** — checkbox grid + Operator/Clear/All presets (no comma string)
- **Listeners** — selecting a row loads name/port/kind/zone into Manage
- **Tasks** — pending queue on Sessions; cancel + edit command before implant pickup
  - \`POST /api/v1/tasks/{id}/cancel\`
  - \`PATCH /api/v1/tasks/{id}\`

## Test plan
- [x] pytest 275
- [ ] Phone: nav + sessions usable
- [ ] Desktop: select listener → fields fill; cancel pending task