### PR TITLE
fix(ops): LLM providers, model picker, xAI /v1, admin layout

### DIFF
--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -554,16 +554,17 @@ class AdminAI:
         raw_base = (base_url or "").strip()
         prov = (provider or "").strip().lower()
         if llm_id:
+            # Never mix stored secrets with caller-supplied base_url (key exfil).
             row = await self.db.get_llm(llm_id)
             if not row:
                 raise ValueError("LLM not found")
-            raw_base = raw_base or (row.get("base_url") or "")
-            prov = prov or str(row.get("provider") or "")
+            raw_base = (row.get("base_url") or "").strip()
+            prov = str(row.get("provider") or "")
             raw_key = row.get("api_key_enc") or ""
             if self.secrets is not None and raw_key:
                 key = self.secrets.decrypt(raw_key) or ""
             else:
-                key = raw_key or key
+                key = raw_key or ""
         if not raw_base:
             raise ValueError("base_url required")
         base = validate_llm_base_url(raw_base, allow_private=False)

--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -41,6 +41,64 @@ INJECTION_MARKERS = re.compile(
 )
 
 
+# Hosts / providers that need /v1 when path was stripped by older configs
+_PROVIDER_V1 = frozenset(
+    {
+        "xai",
+        "openai",
+        "groq",
+        "together",
+        "openrouter",
+        "deepseek",
+        "mistral",
+        "fireworks",
+        "ollama",
+        "lmstudio",
+        "azure",
+        "custom",
+    }
+)
+_HOST_V1 = (
+    "api.x.ai",
+    "api.openai.com",
+    "api.groq.com",
+    "api.together.xyz",
+    "openrouter.ai",
+    "api.deepseek.com",
+    "api.mistral.ai",
+    "api.fireworks.ai",
+)
+
+
+def _ensure_openai_compat_root(base: str, *, provider: str = "") -> str:
+    """Ensure OpenAI-compatible API root (…/v1) when path is missing.
+
+    Fixes legacy rows stored as https://api.x.ai (path stripped) which 404 on
+    /chat/completions without /v1.
+    """
+    b = (base or "").rstrip("/")
+    if not b:
+        return b
+    from urllib.parse import urlparse
+
+    p = urlparse(b)
+    path = (p.path or "").rstrip("/")
+    if path and path != "/":
+        return b
+    prov = (provider or "").lower().strip()
+    host = (p.hostname or "").lower()
+    needs = prov in _PROVIDER_V1 or any(host == h or host.endswith("." + h) for h in _HOST_V1)
+    # loopback lab endpoints (ollama/lmstudio) also use /v1 openai shim
+    if host in ("127.0.0.1", "localhost", "::1"):
+        needs = True
+    # perplexity uses root without /v1
+    if host.endswith("perplexity.ai") or prov == "perplexity":
+        needs = False
+    if needs:
+        return b + "/v1"
+    return b
+
+
 def sanitize_untrusted(text: str, max_chars: int = 512) -> str:
     """Isolate untrusted input — never free-form inject into system reasoning."""
     if not text:
@@ -433,6 +491,7 @@ class AdminAI:
             base = validate_llm_base_url(raw_base, allow_private=False)
         except ValueError as e:
             raise PermissionError(f"LLM base_url blocked: {e}") from e
+        base = _ensure_openai_compat_root(base, provider=str(llm.get("provider") or ""))
         model = llm["model"]
         raw_key = llm.get("api_key_enc") or ""
         if self.secrets is not None and raw_key:
@@ -479,6 +538,55 @@ class AdminAI:
             return json.loads(content)
         except json.JSONDecodeError:
             return {"raw": content[:2000]}
+
+    async def list_remote_models(
+        self,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        provider: str | None = None,
+        llm_id: str | None = None,
+    ) -> list[str]:
+        """Fetch OpenAI-compatible /models (server-side; SSRF-guarded)."""
+        from squidc5.security.ssrf import validate_llm_base_url
+
+        key = (api_key or "").strip()
+        raw_base = (base_url or "").strip()
+        prov = (provider or "").strip().lower()
+        if llm_id:
+            row = await self.db.get_llm(llm_id)
+            if not row:
+                raise ValueError("LLM not found")
+            raw_base = raw_base or (row.get("base_url") or "")
+            prov = prov or str(row.get("provider") or "")
+            raw_key = row.get("api_key_enc") or ""
+            if self.secrets is not None and raw_key:
+                key = self.secrets.decrypt(raw_key) or ""
+            else:
+                key = raw_key or key
+        if not raw_base:
+            raise ValueError("base_url required")
+        base = validate_llm_base_url(raw_base, allow_private=False)
+        base = _ensure_openai_compat_root(base, provider=prov)
+        headers: dict[str, str] = {}
+        if key:
+            headers["Authorization"] = f"Bearer {key}"
+        url = f"{base}/models"
+        async with httpx.AsyncClient(timeout=30.0, follow_redirects=False) as client:
+            resp = await client.get(url, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+        ids: list[str] = []
+        for item in data.get("data") or []:
+            mid = item.get("id") if isinstance(item, dict) else None
+            if mid:
+                ids.append(str(mid))
+        # Ollama native fallback shape
+        if not ids and isinstance(data.get("models"), list):
+            for item in data["models"]:
+                if isinstance(item, dict) and item.get("name"):
+                    ids.append(str(item["name"]))
+        return sorted(set(ids), key=str.lower)
 
     def _offline_fallback(self, capability: str, safe_data: str) -> dict[str, Any]:
         if capability == "payload_template":

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -1620,7 +1620,7 @@ def build_api_router() -> APIRouter:
     async def list_llm_models(
         body: LLMModelsRequest,
         request: Request,
-        auth: AuthContext = Depends(require_scope("llm:manage", "admin", "ai:use")),
+        auth: AuthContext = Depends(require_scope("llm:manage", "admin")),
     ) -> dict[str, Any]:
         """List models from an OpenAI-compatible provider (SSRF-guarded proxy)."""
         state = get_state(request)

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -83,6 +83,15 @@ class LLMConfig(BaseModel):
     capabilities: list[str] | None = None
 
 
+class LLMModelsRequest(BaseModel):
+    """Probe OpenAI-compatible /models (key never logged)."""
+
+    base_url: str | None = None
+    api_key: str | None = None
+    provider: str | None = None
+    llm_id: str | None = None
+
+
 class AIRunRequest(BaseModel):
     capability: str
     user_data: str = ""
@@ -1606,6 +1615,37 @@ def build_api_router() -> APIRouter:
             risk_score=4,
         )
         return {"id": lid, "name": body.name, "model": body.model}
+
+    @api.post("/llm/models")
+    async def list_llm_models(
+        body: LLMModelsRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("llm:manage", "admin", "ai:use")),
+    ) -> dict[str, Any]:
+        """List models from an OpenAI-compatible provider (SSRF-guarded proxy)."""
+        state = get_state(request)
+        try:
+            models = await state.admin_ai.list_remote_models(
+                base_url=body.base_url,
+                api_key=body.api_key,
+                provider=body.provider,
+                llm_id=body.llm_id,
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        except PermissionError as e:
+            raise HTTPException(400, str(e)) from e
+        except Exception as e:
+            raise HTTPException(502, f"Provider models unavailable: {e}") from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="llm.models_list",
+            resource=body.llm_id or (body.base_url or "")[:80],
+            details={"count": len(models), "provider": body.provider},
+            risk_score=2,
+        )
+        return {"models": models}
 
     @api.get("/ai/status")
     async def ai_status(

--- a/src/squidc5/security/ssrf.py
+++ b/src/squidc5/security/ssrf.py
@@ -3,18 +3,28 @@
 from __future__ import annotations
 
 import ipaddress
+import re
 import socket
 from urllib.parse import urlparse
 
+# Allow only simple API path prefixes (e.g. /v1, /openai/v1)
+_SAFE_PATH = re.compile(r"^(/[A-Za-z0-9._-]+)+$")
+
 
 def validate_llm_base_url(url: str, *, allow_private: bool = False) -> str:
-    """Return normalized base URL or raise ValueError."""
+    """Return normalized base URL (scheme://host[:port][/path]) or raise ValueError.
+
+    Path is preserved when it is a simple API root (OpenAI-compatible /v1 etc.).
+    Query strings and fragments are rejected. Callers append /chat/completions or /models.
+    """
     u = (url or "").strip()
     if not u:
         raise ValueError("base_url required")
     p = urlparse(u)
     if p.scheme not in ("https", "http"):
         raise ValueError("base_url scheme must be http or https")
+    if p.query or p.fragment or p.username or p.password:
+        raise ValueError("base_url must not include credentials, query, or fragment")
     host = p.hostname
     if not host:
         raise ValueError("base_url host required")
@@ -29,9 +39,16 @@ def validate_llm_base_url(url: str, *, allow_private: bool = False) -> str:
     elif not allow_private and loopback and p.scheme != "http":
         # https://localhost still blocked (avoid confusing TLS-to-loopback)
         raise ValueError("base_url host not allowed")
-    # strip path noise; callers append /chat/completions
+
+    path = (p.path or "").rstrip("/")
+    if path in ("", "/"):
+        path = ""
+    elif not _SAFE_PATH.fullmatch(path):
+        raise ValueError("base_url path not allowed")
+
     port = f":{p.port}" if p.port else ""
-    return f"{p.scheme}://{host_l if loopback else host}{port}"
+    host_out = host_l if loopback else host
+    return f"{p.scheme}://{host_out}{port}{path}"
 
 
 def _assert_public_host(host: str) -> None:

--- a/tests/test_security_hardening.py
+++ b/tests/test_security_hardening.py
@@ -41,11 +41,26 @@ def test_ssrf_blocks_metadata_and_private():
     with pytest.raises(ValueError):
         validate_llm_base_url("https://127.0.0.1/v1")  # loopback only via http lab
     ok = validate_llm_base_url("https://api.openai.com/v1")
-    assert ok.startswith("https://")
+    assert ok == "https://api.openai.com/v1"
+    xai = validate_llm_base_url("https://api.x.ai/v1")
+    assert xai == "https://api.x.ai/v1"
     lab = validate_llm_base_url("http://127.0.0.1:11434/v1")
-    assert lab == "http://127.0.0.1:11434"
+    assert lab == "http://127.0.0.1:11434/v1"
     lab2 = validate_llm_base_url("http://localhost:11434/v1")
-    assert lab2 == "http://localhost:11434"
+    assert lab2 == "http://localhost:11434/v1"
+    with pytest.raises(ValueError):
+        validate_llm_base_url("https://api.openai.com/v1?x=1")
+
+
+def test_ensure_openai_compat_root_fixes_xai_path():
+    from squidc5.ai.admin_ai import _ensure_openai_compat_root
+
+    assert _ensure_openai_compat_root("https://api.x.ai", provider="xai") == "https://api.x.ai/v1"
+    assert _ensure_openai_compat_root("https://api.x.ai/v1", provider="xai") == "https://api.x.ai/v1"
+    assert (
+        _ensure_openai_compat_root("https://api.perplexity.ai", provider="perplexity")
+        == "https://api.perplexity.ai"
+    )
 
 
 def test_stage2_host_injection_blocked():
@@ -260,6 +275,12 @@ async def test_llm_ssrf_on_configure(tmp_path):
                 },
             )
             assert bad.status_code in (400, 500, 422) or bad.status_code >= 400
+            bad_models = await client.post(
+                "/api/v1/llm/models",
+                headers=h,
+                json={"base_url": "http://169.254.169.254/", "api_key": "k"},
+            )
+            assert bad_models.status_code >= 400
 
 
 @pytest.mark.asyncio

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -110,25 +110,58 @@
     "anomaly_explain", "profile_mutate", "implant_build_plan", "phishing_asset", "doc_generate",
   ];
 
+  /** OpenAI-compatible providers (chat/completions + /models) */
+  const LLM_PROVIDERS = [
+    { id: "xai", label: "xAI (Grok)", base: "https://api.x.ai/v1", model: "grok-3", needKey: true },
+    { id: "openai", label: "OpenAI", base: "https://api.openai.com/v1", model: "gpt-4o-mini", needKey: true },
+    { id: "groq", label: "Groq", base: "https://api.groq.com/openai/v1", model: "llama-3.3-70b-versatile", needKey: true },
+    { id: "openrouter", label: "OpenRouter", base: "https://openrouter.ai/api/v1", model: "openai/gpt-4o-mini", needKey: true },
+    { id: "together", label: "Together AI", base: "https://api.together.xyz/v1", model: "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", needKey: true },
+    { id: "deepseek", label: "DeepSeek", base: "https://api.deepseek.com/v1", model: "deepseek-chat", needKey: true },
+    { id: "mistral", label: "Mistral", base: "https://api.mistral.ai/v1", model: "mistral-small-latest", needKey: true },
+    { id: "fireworks", label: "Fireworks", base: "https://api.fireworks.ai/inference/v1", model: "accounts/fireworks/models/llama-v3p1-8b-instruct", needKey: true },
+    { id: "perplexity", label: "Perplexity", base: "https://api.perplexity.ai", model: "sonar", needKey: true },
+    { id: "gemini", label: "Google Gemini (OpenAI compat)", base: "https://generativelanguage.googleapis.com/v1beta/openai", model: "gemini-2.0-flash", needKey: true },
+    { id: "ollama", label: "Ollama (localhost)", base: "http://127.0.0.1:11434/v1", model: "llama3.2", needKey: false },
+    { id: "lmstudio", label: "LM Studio (localhost)", base: "http://127.0.0.1:1234/v1", model: "local-model", needKey: false },
+    { id: "custom", label: "Custom OpenAI-compatible", base: "", model: "", needKey: true },
+  ];
+  const LLM_PROVIDER_MAP = Object.fromEntries(LLM_PROVIDERS.map((p) => [p.id, p]));
+
   function llmFormHtml(prefix) {
     const canSave = can("llm:manage") || can("admin");
+    const opts = LLM_PROVIDERS.map((p) =>
+      `<option value="${esc(p.id)}">${esc(p.label)}</option>`
+    ).join("");
     return `
-      <p class="muted" style="font-size:0.78rem;margin:0 0 8px">API keys encrypted at rest; never returned by API. xAI / OpenAI / local Ollama.</p>
-      <div class="form-grid">
-        <div><label>Name</label><input id="${prefix}Name" placeholder="grok-prod" /></div>
+      <p class="muted" style="font-size:0.78rem;margin:0 0 10px">
+        OpenAI-compatible providers. Keys encrypted at rest and never returned by the API.
+        Paste a key to load live models from the provider.
+      </p>
+      <div class="form-grid llm-form-grid">
+        <div><label>Connection name</label><input id="${prefix}Name" placeholder="grok-prod" /></div>
         <div><label>Provider</label>
-          <select id="${prefix}Provider">
-            <option value="xai">xAI (Grok)</option>
-            <option value="openai">OpenAI-compatible</option>
-            <option value="ollama">Ollama (localhost)</option>
-          </select>
+          <select id="${prefix}Provider">${opts}</select>
         </div>
-        <div class="full"><label>Model</label><input id="${prefix}Model" placeholder="grok-3" value="grok-3" /></div>
         <div class="full"><label>Base URL</label>
           <input id="${prefix}Base" placeholder="https://api.x.ai/v1" value="https://api.x.ai/v1" />
         </div>
         <div class="full"><label>API key</label>
           <input id="${prefix}Key" type="password" placeholder="xai-… / sk-… (never shown again)" autocomplete="off" />
+        </div>
+        <div class="full" id="${prefix}ModelWrap">
+          <label>Model</label>
+          <select id="${prefix}ModelSel" disabled>
+            <option value="">Paste API key to load models…</option>
+          </select>
+          <input id="${prefix}Model" class="hidden" placeholder="custom-model-id" />
+          <label class="chk-inline" style="margin-top:8px;text-transform:none;letter-spacing:0;font-size:0.78rem;color:var(--text);font-weight:500">
+            <input type="checkbox" id="${prefix}ModelOverride" /> Override — type model name manually
+          </label>
+          <div class="row" style="margin-top:6px">
+            <button type="button" id="${prefix}FetchModels" disabled>Refresh models</button>
+            <span class="muted" id="${prefix}ModelHint" style="font-size:0.72rem"></span>
+          </div>
         </div>
       </div>
       <div class="row">
@@ -138,28 +171,122 @@
       <div class="outbox empty" id="${prefix}Out">—</div>`;
   }
   function bindLlmForm(prefix) {
-    if (el(prefix + "Provider")) el(prefix + "Provider").onchange = () => {
-      const p = el(prefix + "Provider").value;
-      if (p === "xai") {
-        el(prefix + "Base").value = "https://api.x.ai/v1";
-        if (!el(prefix + "Model").value || el(prefix + "Model").value === "gpt-4o-mini") el(prefix + "Model").value = "grok-3";
-      } else if (p === "openai") {
-        el(prefix + "Base").value = "https://api.openai.com/v1";
-        if (!el(prefix + "Model").value || el(prefix + "Model").value === "grok-3") el(prefix + "Model").value = "gpt-4o-mini";
-      } else if (p === "ollama") {
-        el(prefix + "Base").value = "http://127.0.0.1:11434/v1";
-        el(prefix + "Model").value = el(prefix + "Model").value || "llama3.2";
+    const applyProvider = () => {
+      const id = el(prefix + "Provider")?.value || "xai";
+      const p = LLM_PROVIDER_MAP[id] || LLM_PROVIDER_MAP.custom;
+      if (p.base) el(prefix + "Base").value = p.base;
+      if (p.model && !el(prefix + "ModelOverride")?.checked) {
+        const sel = el(prefix + "ModelSel");
+        const custom = el(prefix + "Model");
+        if (sel && !sel.disabled && [...sel.options].some((o) => o.value === p.model)) {
+          sel.value = p.model;
+        } else if (custom) {
+          custom.value = p.model;
+        } else if (sel) {
+          // seed single default option until fetch
+          sel.innerHTML = `<option value="${esc(p.model)}">${esc(p.model)}</option>`;
+          sel.value = p.model;
+        }
+      }
+      updateModelUi();
+    };
+    const updateModelUi = () => {
+      const override = !!(el(prefix + "ModelOverride") && el(prefix + "ModelOverride").checked);
+      const sel = el(prefix + "ModelSel");
+      const inp = el(prefix + "Model");
+      const key = (el(prefix + "Key")?.value || "").trim();
+      const prov = el(prefix + "Provider")?.value || "";
+      const needKey = (LLM_PROVIDER_MAP[prov] || {}).needKey !== false;
+      const canFetch = !needKey || key.length > 0;
+      if (sel) {
+        sel.classList.toggle("hidden", override);
+        sel.disabled = override || (!canFetch && sel.options.length <= 1 && !sel.value);
+      }
+      if (inp) {
+        inp.classList.toggle("hidden", !override);
+        if (override && sel && sel.value && !inp.value) inp.value = sel.value;
+      }
+      if (el(prefix + "FetchModels")) el(prefix + "FetchModels").disabled = !canFetch;
+    };
+    const currentModel = () => {
+      if (el(prefix + "ModelOverride")?.checked) return (el(prefix + "Model")?.value || "").trim();
+      return (el(prefix + "ModelSel")?.value || el(prefix + "Model")?.value || "").trim();
+    };
+    const fetchModels = async () => {
+      const hint = el(prefix + "ModelHint");
+      const sel = el(prefix + "ModelSel");
+      try {
+        if (hint) hint.textContent = "Loading models…";
+        const body = {
+          base_url: (el(prefix + "Base")?.value || "").trim() || null,
+          api_key: (el(prefix + "Key")?.value || "").trim() || null,
+          provider: el(prefix + "Provider")?.value || null,
+        };
+        const r = await api("POST", "/api/v1/llm/models", body);
+        const models = r.models || [];
+        if (!sel) return;
+        const prev = currentModel();
+        if (!models.length) {
+          sel.innerHTML = `<option value="">(no models returned)</option>`;
+          sel.disabled = true;
+          if (hint) hint.textContent = "No models — use override";
+          return;
+        }
+        sel.innerHTML = models.map((m) =>
+          `<option value="${esc(m)}">${esc(m)}</option>`
+        ).join("");
+        sel.disabled = false;
+        if (prev && models.includes(prev)) sel.value = prev;
+        else {
+          const def = (LLM_PROVIDER_MAP[el(prefix + "Provider")?.value] || {}).model;
+          if (def && models.includes(def)) sel.value = def;
+        }
+        if (hint) hint.textContent = models.length + " model(s)";
+        updateModelUi();
+      } catch (e) {
+        if (hint) hint.textContent = "Fetch failed — use override";
+        showError(String(e.message || e));
+        // enable override path
+        if (el(prefix + "ModelOverride")) {
+          el(prefix + "ModelOverride").checked = true;
+          updateModelUi();
+          const p = LLM_PROVIDER_MAP[el(prefix + "Provider")?.value] || {};
+          if (el(prefix + "Model") && !el(prefix + "Model").value) el(prefix + "Model").value = p.model || "";
+        }
       }
     };
+    if (el(prefix + "Provider")) {
+      el(prefix + "Provider").onchange = () => {
+        applyProvider();
+        const key = (el(prefix + "Key")?.value || "").trim();
+        const prov = el(prefix + "Provider").value;
+        if (key || (LLM_PROVIDER_MAP[prov] || {}).needKey === false) fetchModels();
+      };
+    }
+    if (el(prefix + "Key")) {
+      let t = null;
+      el(prefix + "Key").oninput = () => {
+        updateModelUi();
+        clearTimeout(t);
+        t = setTimeout(() => {
+          const key = (el(prefix + "Key")?.value || "").trim();
+          if (key.length >= 8) fetchModels();
+        }, 600);
+      };
+    }
+    if (el(prefix + "ModelOverride")) el(prefix + "ModelOverride").onchange = updateModelUi;
+    if (el(prefix + "FetchModels")) el(prefix + "FetchModels").onclick = () => fetchModels();
     if (el(prefix + "Save")) el(prefix + "Save").onclick = async () => {
       try {
         const name = (el(prefix + "Name").value || "").trim();
-        const model = (el(prefix + "Model").value || "").trim();
+        const model = currentModel();
         const base_url = (el(prefix + "Base").value || "").trim();
         const api_key = (el(prefix + "Key").value || "").trim();
         const provider = el(prefix + "Provider").value || "openai";
+        const needKey = (LLM_PROVIDER_MAP[provider] || {}).needKey !== false;
         if (!name || !model) return showError("Name and model required");
-        if (!api_key && provider !== "ollama") return showError("API key required (except local Ollama)");
+        if (!api_key && needKey) return showError("API key required for this provider");
+        if (!base_url) return showError("Base URL required");
         const body = {
           name, provider, model,
           base_url: base_url || null,
@@ -170,7 +297,9 @@
         el(prefix + "Out").textContent = JSON.stringify(r, null, 2);
         el(prefix + "Out").classList.remove("empty");
         if (el(prefix + "Key")) el(prefix + "Key").value = "";
+        updateModelUi();
         showOk("LLM saved (key encrypted at rest)");
+        if (window.__SC5_refreshLlms) window.__SC5_refreshLlms();
       } catch (e) { showError(String(e.message || e)); }
     };
     if (el(prefix + "List")) el(prefix + "List").onclick = async () => {
@@ -180,6 +309,37 @@
         el(prefix + "Out").classList.remove("empty");
       } catch (e) { showError(String(e.message || e)); }
     };
+    // defaults
+    if (el(prefix + "Provider") && !el(prefix + "Provider").dataset.bound) {
+      el(prefix + "Provider").value = "xai";
+      applyProvider();
+      el(prefix + "Provider").dataset.bound = "1";
+    }
+    updateModelUi();
+  }
+
+  async function loadSavedLlms() {
+    try {
+      return await api("GET", "/api/v1/llm") || [];
+    } catch (_) {
+      return [];
+    }
+  }
+  function fillLlmSelect(sel, llms, selected) {
+    if (!sel) return;
+    const list = Array.isArray(llms) ? llms : [];
+    if (!list.length) {
+      sel.innerHTML = `<option value="">(no LLM configured — use Configure panel)</option>`;
+      sel.disabled = true;
+      return;
+    }
+    sel.disabled = false;
+    sel.innerHTML = list.map((L) => {
+      const id = L.id || L.name;
+      const label = `${L.name || id} · ${L.model || "?"} · ${L.provider || "?"}`;
+      return `<option value="${esc(id)}">${esc(label)}</option>`;
+    }).join("");
+    if (selected && list.some((L) => (L.id || L.name) === selected)) sel.value = selected;
   }
 
   /* —— Context rail —— */
@@ -912,14 +1072,16 @@
       return;
     }
     root.innerHTML = `
-      <div class="form-grid">
+      <div class="form-grid ai-layout">
         <div class="work-panel">
           <div class="wp-head">Run capability</div>
           <div class="wp-body">
+            <label>LLM connection</label>
+            <select id="aiLlmPick"><option value="">Loading…</option></select>
             <label>Capability</label>
             <select id="aiCap">${AI_CAPS.map((c) => `<option value="${c}">${c}</option>`).join("")}</select>
             <label>Input (untrusted — sanitized server-side)</label>
-            <textarea id="aiData" rows="4" placeholder="Describe target, paste metrics text, ask for recon assist…"></textarea>
+            <textarea id="aiData" rows="5" placeholder="Describe target, paste metrics text, ask for recon assist…"></textarea>
             <div class="row">
               <button type="button" class="primary" id="aiRun">Run</button>
               <button type="button" id="aiStatus">AI status</button>
@@ -935,6 +1097,18 @@
       </div>
     `;
     bindLlmForm("llm");
+    const refreshPick = async () => {
+      const llms = await loadSavedLlms();
+      const prev = el("aiLlmPick")?.value || loadSel("sc5_ops_llm") || "";
+      fillLlmSelect(el("aiLlmPick"), llms, prev);
+      fillLlmSelect(el("aiLlmGlobal"), llms, prev);
+    };
+    window.__SC5_refreshLlms = refreshPick;
+    refreshPick();
+    if (el("aiLlmPick")) el("aiLlmPick").onchange = () => {
+      saveSel("sc5_ops_llm", el("aiLlmPick").value || "");
+      if (el("aiLlmGlobal") && el("aiLlmPick").value) el("aiLlmGlobal").value = el("aiLlmPick").value;
+    };
     if (el("aiRun")) el("aiRun").onclick = () => runAi(el("aiCap").value, el("aiData").value, "aiOut");
     if (el("aiStatus")) el("aiStatus").onclick = async () => {
       try {
@@ -949,16 +1123,22 @@
 
   async function runAi(capability, user_data, outId) {
     try {
-      const r = await api("POST", "/api/v1/ai/run", {
+      const llm_id = (el("aiLlmPick") && el("aiLlmPick").value)
+        || (el("aiLlmGlobal") && el("aiLlmGlobal").value)
+        || loadSel("sc5_ops_llm")
+        || null;
+      const body = {
         capability: capability || "recon_assist",
         user_data: user_data || "",
-      });
+      };
+      if (llm_id) body.llm_id = llm_id;
+      const r = await api("POST", "/api/v1/ai/run", body);
       const text = typeof r === "string" ? r : JSON.stringify(r, null, 2);
       if (outId && el(outId)) {
         el(outId).textContent = text;
         el(outId).classList.remove("empty");
       }
-      appendAiChat("user", `[${capability}] ${user_data || "(empty)"}`);
+      appendAiChat("user", `[${capability}${llm_id ? " · " + llm_id.slice(0, 10) : ""}] ${user_data || "(empty)"}`);
       appendAiChat("bot", text);
       showOk("AI complete");
       return r;
@@ -1012,6 +1192,14 @@
       });
       sel.value = "recon_assist";
     }
+    // LLM picker in drawer
+    loadSavedLlms().then((llms) => {
+      fillLlmSelect(el("aiLlmGlobal"), llms, loadSel("sc5_ops_llm") || "");
+    });
+    if (el("aiLlmGlobal")) el("aiLlmGlobal").onchange = () => {
+      saveSel("sc5_ops_llm", el("aiLlmGlobal").value || "");
+      if (el("aiLlmPick") && el("aiLlmGlobal").value) el("aiLlmPick").value = el("aiLlmGlobal").value;
+    };
     fab.onclick = () => openAiDrawer();
     if (el("aiDrawerClose")) el("aiDrawerClose").onclick = () => openAiDrawer(false);
     if (el("aiSendGlobal")) el("aiSendGlobal").onclick = async () => {
@@ -1047,41 +1235,43 @@
       "tokens:manage", "llm:manage", "policy:manage", "plugins:manage", "admin",
     ];
     root.innerHTML = `
-      <div class="form-grid">
-        <div class="work-panel">
-          <div class="wp-head">Mint token</div>
-          <div class="wp-body">
-            <label>Name</label><input id="adName" placeholder="operator-1" />
-            <label>Scopes</label>
-            <div class="row" style="margin:4px 0">
-              <button type="button" id="adScopeOp">Operator preset</button>
-              <button type="button" id="adScopeNone">Clear</button>
-              <button type="button" id="adScopeAll">All non-admin</button>
+      <div class="admin-stack">
+        <div class="admin-row">
+          <div class="work-panel">
+            <div class="wp-head">Mint token</div>
+            <div class="wp-body">
+              <label>Name</label><input id="adName" placeholder="operator-1" />
+              <label>Scopes</label>
+              <div class="row" style="margin:4px 0">
+                <button type="button" id="adScopeOp">Operator preset</button>
+                <button type="button" id="adScopeNone">Clear</button>
+                <button type="button" id="adScopeAll">All non-admin</button>
+              </div>
+              <div class="scope-grid" id="adScopeGrid">
+                ${allScopes.map((s) => `
+                  <label><input type="checkbox" class="ad-scope" value="${esc(s)}"
+                    ${defaultScopes.has(s) ? "checked" : ""}
+                    ${s === "admin" && !can("admin") ? "disabled" : ""} /> ${esc(s)}</label>
+                `).join("")}
+              </div>
+              <div class="row"><button type="button" class="primary" id="adMint">Mint</button></div>
+              <div class="outbox empty" id="adMintOut">Token shown once</div>
             </div>
-            <div class="scope-grid" id="adScopeGrid">
-              ${allScopes.map((s) => `
-                <label><input type="checkbox" class="ad-scope" value="${esc(s)}"
-                  ${defaultScopes.has(s) ? "checked" : ""}
-                  ${s === "admin" && !can("admin") ? "disabled" : ""} /> ${esc(s)}</label>
-              `).join("")}
-            </div>
-            <div class="row"><button type="button" class="primary" id="adMint">Mint</button></div>
-            <div class="outbox empty" id="adMintOut">Token shown once</div>
           </div>
-        </div>
-        <div class="work-panel">
-          <div class="wp-head">Policy / features</div>
-          <div class="wp-body">
-            <div class="row">
-              <button type="button" id="adPolGet">Get policy</button>
-              <button type="button" id="adFeat">Features</button>
-              <button type="button" id="adTokList">List tokens</button>
+          <div class="work-panel">
+            <div class="wp-head">Policy / features</div>
+            <div class="wp-body">
+              <div class="row">
+                <button type="button" id="adPolGet">Get policy</button>
+                <button type="button" id="adFeat">Features</button>
+                <button type="button" id="adTokList">List tokens</button>
+              </div>
+              <div class="outbox empty" id="adOut" style="max-height:min(420px,50vh);flex:1">—</div>
             </div>
-            <div class="outbox empty" id="adOut" style="max-height:360px;flex:1">—</div>
           </div>
         </div>
         ${(can("llm:manage") || can("admin")) ? `
-        <div class="work-panel full">
+        <div class="work-panel admin-llm">
           <div class="wp-head">Configure LLM (BYO)</div>
           <div class="wp-body">${llmFormHtml("adLlm")}</div>
         </div>` : ""}

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -81,6 +81,21 @@
         "bottom bottom";
     }
     .app.no-ctx .ctx { display: none; }
+    .app.no-bottom {
+      grid-template-rows: var(--top-h) 1fr;
+      --bottom-h: 0px;
+    }
+    .app.no-bottom {
+      grid-template-areas:
+        "top top top"
+        "side main ctx";
+    }
+    .app.no-bottom.no-ctx {
+      grid-template-areas:
+        "top top"
+        "side main";
+    }
+    .app.no-bottom .bottom { display: none; }
 
     /* Top bar */
     .top {
@@ -288,6 +303,25 @@
 
     .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 0 12px; }
     .form-grid .full { grid-column: 1 / -1; }
+    .llm-form-grid { gap: 10px 16px; }
+    .chk-inline { display: flex; align-items: center; gap: 8px; cursor: pointer; }
+    .chk-inline input { width: auto; margin: 0; }
+    .admin-stack {
+      display: flex; flex-direction: column; gap: 16px;
+      height: 100%; min-height: 0; overflow: auto; padding: 4px 2px 16px;
+    }
+    .admin-row {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 16px;
+      align-items: stretch;
+    }
+    .admin-stack .work-panel {
+      height: auto; min-height: 0; display: flex; flex-direction: column;
+    }
+    .admin-stack .work-panel .wp-body { flex: 1; }
+    .admin-stack .admin-llm { flex: 0 0 auto; }
+    .admin-stack .scope-grid { max-height: 280px; }
+    .admin-stack .llm-form-grid { max-width: 720px; }
+    .view.active > .admin-stack { flex: 1 1 auto; min-height: 0; }
     .row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; align-items: center; }
     .outbox {
       background: #08080c; border: 1px solid var(--border); border-radius: 6px;
@@ -467,6 +501,7 @@
         grid-template-columns: 1fr;
       }
       .view.active > .form-grid > .work-panel { height: auto; min-height: 200px; }
+      .admin-row { grid-template-columns: 1fr; }
       .stats { grid-template-columns: repeat(2, 1fr); }
       .scope-grid { grid-template-columns: 1fr 1fr; max-height: 180px; }
       button, .nav-item, input, select, textarea { font-size: 16px; } /* prevent iOS zoom */
@@ -564,6 +599,7 @@
       </div>
       <div class="ai-drawer-body" id="aiChatLog"></div>
       <div class="ai-drawer-foot">
+        <select id="aiLlmGlobal" title="LLM connection"></select>
         <select id="aiCapGlobal" title="Capability"></select>
         <textarea id="aiPromptGlobal" rows="2" placeholder="Ask the sandboxed Admin AI…"></textarea>
         <button type="button" class="primary" id="aiSendGlobal">Send</button>
@@ -734,6 +770,14 @@
     document.querySelectorAll(".view").forEach((v) => {
       v.classList.toggle("active", v.id === "view-" + name);
     });
+    const app = document.querySelector(".app");
+    if (app) {
+      // Admin: full width — hide session context + bottom event/output panes
+      const focusAdmin = name === "admin";
+      const focusWide = name === "admin" || name === "ai";
+      app.classList.toggle("no-ctx", focusWide);
+      app.classList.toggle("no-bottom", focusAdmin);
+    }
     const meta = VIEWS[name] || VIEWS.dashboard;
     $("viewTitle").textContent = meta.title;
     $("viewSub").textContent = meta.sub;


### PR DESCRIPTION
## Summary
- **Bugfix**: Admin AI called `https://api.x.ai/chat/completions` (404) because SSRF stripped `/v1`. Path is now preserved; legacy pathless bases get `/v1` restored for known providers.
- **Providers**: Full OpenAI-compatible dropdown (xAI, OpenAI, Groq, OpenRouter, Together, DeepSeek, Mistral, Fireworks, Perplexity, Gemini compat, Ollama, LM Studio, custom) with auto base URL.
- **Models**: Paste API key → server `POST /api/v1/llm/models` loads live model list; override checkbox for manual model name.
- **Multi-LLM**: AI page + floating drawer select among configured connections (`llm_id`).
- **Admin layout**: Hide session context + bottom event/output panes; roomier stacked panels.

## Test plan
- [x] pytest security/llm encryption/privacy (24+)
- [ ] Re-save xAI LLM (or rely on path fix) → Run recon_assist → no 404
- [ ] Paste key → model dropdown fills
- [ ] Admin page: full width, no ctx/bottom clutter
- [ ] Two LLMs saved → switch on AI page