### PR TITLE
feat(ai): operator chat with railed C5 tools

### DIFF
--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -589,6 +589,260 @@ class AdminAI:
                     ids.append(str(item["name"]))
         return sorted(set(ids), key=str.lower)
 
+    async def chat(
+        self,
+        *,
+        message: str,
+        history: list[dict[str, str]] | None = None,
+        actor: str = "admin",
+        llm_id: str | None = None,
+        state: Any = None,
+        auth: Any = None,
+        max_rounds: int = 6,
+    ) -> dict[str, Any]:
+        """Multi-turn operator chat with allow-listed C5 tool calling.
+
+        Rails: fixed tool catalog, policy/scopes per tool, sanitized I/O,
+        bounded rounds (no open-ended autonomous agent).
+        """
+        import time as _time
+
+        from squidc5.ai.ops_tools import (
+            CHAT_SYSTEM_PROMPT,
+            OPENAI_TOOLS,
+            execute_ops_tool,
+            offline_chat_intent,
+            sanitize_tool_payload,
+        )
+
+        if state is None or auth is None:
+            raise ValueError("chat requires app state and auth context")
+
+        rules = await self.policy.get_rules()
+        admin_ai_rules = rules.get("admin_ai") or {}
+        if not admin_ai_rules.get("sandbox", True):
+            raise RuntimeError("Admin AI sandbox disabled — refusing to run")
+
+        max_chars = int(admin_ai_rules.get("max_untrusted_chars", 4000))
+        max_chars = max(512, min(max_chars, 8000))
+        max_rounds = max(1, min(int(max_rounds or 6), 8))
+        max_tools = 12
+
+        safe_msg = sanitize_untrusted(message or "", max_chars=max_chars)
+        if not safe_msg.strip():
+            raise ValueError("message required")
+
+        t0 = _time.time()
+        self._busy = True
+        self._last.update(
+            {
+                "status": "running",
+                "capability": "chat",
+                "actor": actor,
+                "ok": None,
+                "error": None,
+                "ts": t0,
+                "input_len": len(message or ""),
+                "sanitized_len": len(safe_msg),
+                "result_preview": None,
+            }
+        )
+        await self.db.audit(
+            actor=actor,
+            actor_type="admin_ai",
+            action="ai.admin.chat",
+            details={"input_len": len(message or ""), "history_len": len(history or [])},
+            risk_score=3,
+        )
+        await self.metrics.incr("ai.admin.chat")
+
+        tool_trace: list[dict[str, Any]] = []
+        try:
+            llm = await self._select_llm(llm_id, "recon_assist")
+            if llm is None:
+                offline = await offline_chat_intent(state, auth, safe_msg)
+                if offline:
+                    out = {
+                        "mode": "offline",
+                        "reply": offline["reply"],
+                        "tool_trace": offline.get("tool_trace") or [],
+                    }
+                    self._finish_ok(out, mode="offline", llm=None, t0=t0)
+                    return out
+                out = {
+                    "mode": "offline",
+                    "reply": (
+                        "No LLM configured. Configure a provider under AI → Configure LLM, "
+                        "then I can chat and drive listeners/sessions/payloads with tools.\n\n"
+                        "Offline I can still handle simple phrases like:\n"
+                        "• list sessions / list listeners\n"
+                        "• setup reverse shell listener on 4444\n"
+                        "• metrics / events"
+                    ),
+                    "tool_trace": [],
+                }
+                self._finish_ok(out, mode="offline", llm=None, t0=t0)
+                return out
+
+            messages: list[dict[str, Any]] = [{"role": "system", "content": CHAT_SYSTEM_PROMPT}]
+            for h in (history or [])[-12:]:
+                role = (h.get("role") or "").strip()
+                content = sanitize_untrusted(str(h.get("content") or ""), max_chars=2000)
+                if role in ("user", "assistant") and content.strip():
+                    messages.append({"role": role, "content": content})
+            messages.append({"role": "user", "content": safe_msg})
+
+            tools_used = 0
+            final_text = ""
+            for _round in range(max_rounds):
+                data = await self._call_llm_chat(llm, messages, tools=OPENAI_TOOLS)
+                choice = (data.get("choices") or [{}])[0]
+                msg = choice.get("message") or {}
+                tool_calls = msg.get("tool_calls") or []
+                content = msg.get("content") or ""
+
+                if tool_calls and tools_used < max_tools:
+                    # Append assistant turn with tool_calls
+                    messages.append(
+                        {
+                            "role": "assistant",
+                            "content": content or None,
+                            "tool_calls": tool_calls,
+                        }
+                    )
+                    for tc in tool_calls:
+                        if tools_used >= max_tools:
+                            break
+                        fn = tc.get("function") or {}
+                        name = str(fn.get("name") or "")
+                        raw_args = fn.get("arguments") or "{}"
+                        try:
+                            args = json.loads(raw_args) if isinstance(raw_args, str) else dict(raw_args)
+                        except json.JSONDecodeError:
+                            args = {}
+                        if not isinstance(args, dict):
+                            args = {}
+                        result = await execute_ops_tool(state, auth, name, args)
+                        tools_used += 1
+                        tool_trace.append(
+                            {
+                                "tool": name,
+                                "ok": bool(result.get("ok")),
+                                "error": result.get("error"),
+                                "summary": _tool_summary(result),
+                            }
+                        )
+                        tid = tc.get("id") or f"call_{tools_used}"
+                        messages.append(
+                            {
+                                "role": "tool",
+                                "tool_call_id": tid,
+                                "content": sanitize_tool_payload(result, max_chars=5000),
+                            }
+                        )
+                    continue
+
+                final_text = (content or "").strip()
+                if not final_text and tool_trace:
+                    final_text = "Done. " + "; ".join(
+                        f"{t['tool']}: {'ok' if t['ok'] else t.get('error') or 'fail'}"
+                        for t in tool_trace
+                    )
+                break
+            else:
+                final_text = final_text or (
+                    "Reached tool-round limit. Partial results:\n"
+                    + json.dumps(tool_trace, default=str)[:2000]
+                )
+
+            # Never leave empty
+            if not final_text:
+                final_text = "No response from model."
+
+            await self.db.audit(
+                actor=actor,
+                actor_type="admin_ai",
+                action="ai.admin.chat.completed",
+                details={
+                    "llm_id": llm.get("id"),
+                    "model": llm.get("model"),
+                    "tools_used": tools_used,
+                    "tools": [t.get("tool") for t in tool_trace],
+                },
+                risk_score=3,
+            )
+            await self.metrics.incr("ai.admin.chat_ok")
+            out = {
+                "mode": "llm",
+                "reply": final_text[:12000],
+                "tool_trace": tool_trace,
+                "llm_id": llm.get("id"),
+                "model": llm.get("model"),
+                "provider": llm.get("provider"),
+            }
+            self._finish_ok(out, mode="llm", llm=llm, t0=t0)
+            return out
+        except Exception as exc:
+            await self.metrics.incr("ai.admin.errors")
+            latency = int((_time.time() - t0) * 1000)
+            self._last.update(
+                {
+                    "status": "error",
+                    "ok": False,
+                    "error": str(exc)[:500],
+                    "latency_ms": latency,
+                    "mode": "error",
+                    "capability": "chat",
+                }
+            )
+            self._push_history(dict(self._last))
+            raise
+        finally:
+            self._busy = False
+
+    async def _call_llm_chat(
+        self,
+        llm: dict[str, Any],
+        messages: list[dict[str, Any]],
+        *,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """OpenAI-compatible chat completion (optional tools). Returns raw API JSON."""
+        from squidc5.security.ssrf import validate_llm_base_url
+
+        raw_base = (llm.get("base_url") or "https://api.openai.com/v1").rstrip("/")
+        try:
+            base = validate_llm_base_url(raw_base, allow_private=False)
+        except ValueError as e:
+            raise PermissionError(f"LLM base_url blocked: {e}") from e
+        base = _ensure_openai_compat_root(base, provider=str(llm.get("provider") or ""))
+        model = llm["model"]
+        raw_key = llm.get("api_key_enc") or ""
+        if self.secrets is not None and raw_key:
+            api_key = self.secrets.decrypt(raw_key) or ""
+        else:
+            api_key = raw_key
+
+        headers = {"Content-Type": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+
+        payload: dict[str, Any] = {
+            "model": model,
+            "messages": messages,
+            "temperature": 0.35,
+            "max_tokens": 1600,
+        }
+        if tools:
+            payload["tools"] = tools
+            payload["tool_choice"] = "auto"
+
+        url = f"{base}/chat/completions"
+        async with httpx.AsyncClient(timeout=90.0, follow_redirects=False) as client:
+            resp = await client.post(url, headers=headers, json=payload)
+            resp.raise_for_status()
+            return resp.json()
+
     def _offline_fallback(self, capability: str, safe_data: str) -> dict[str, Any]:
         if capability == "payload_template":
             choice = "http_beacon_python"
@@ -708,3 +962,18 @@ class AdminAI:
                 "suggestions": ["Compare to profile sleep/jitter", "Check max_missed_checkins"],
             }
         return {"error": "unknown capability"}
+
+
+def _tool_summary(result: dict[str, Any]) -> str:
+    if not result.get("ok"):
+        return str(result.get("error") or "failed")[:200]
+    r = result.get("result")
+    if isinstance(r, dict):
+        if "count" in r:
+            return f"count={r.get('count')}"
+        if "created" in r:
+            c = r.get("created") or {}
+            return f"created id={c.get('id')} port={c.get('port')} status={c.get('status')}"
+        if "id" in r:
+            return f"id={r.get('id')}"
+    return "ok"

--- a/src/squidc5/ai/ops_tools.py
+++ b/src/squidc5/ai/ops_tools.py
@@ -1,0 +1,640 @@
+"""Allow-listed C5 ops tools for Admin AI chat (railed — not open agent).
+
+Each tool runs through the same scopes + policy engine as REST/MCP.
+Tool results are size-capped and sanitized before returning to the LLM.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from squidc5.ai.admin_ai import sanitize_untrusted
+from squidc5.auth.tokens import AuthContext
+from squidc5.core.state import AppState
+
+# tool -> (required scopes any-of, policy action)
+TOOL_GATES: dict[str, tuple[list[str], str]] = {
+    "list_sessions": (["sessions:read", "admin"], "sessions.list"),
+    "get_session": (["sessions:read", "admin"], "sessions.list"),
+    "list_listeners": (["listeners:read", "admin"], "listeners.list"),
+    "create_listener": (["listeners:write", "admin"], "listeners.create"),
+    "start_listener": (["listeners:write", "admin"], "listeners.start"),
+    "stop_listener": (["listeners:write", "admin"], "listeners.stop"),
+    "delete_listener": (["listeners:write", "admin"], "listeners.stop"),
+    "list_tasks": (["tasks:read", "admin"], "tasks.list"),
+    "create_task": (["tasks:write", "admin"], "tasks.create"),
+    "generate_payload": (["payloads:generate", "admin"], "payloads.generate"),
+    "list_payload_templates": (["payloads:generate", "admin"], "payloads.generate"),
+    "get_metrics": (["metrics:read", "admin"], "metrics.read"),
+    "list_recent_events": (["metrics:read", "sessions:read", "admin"], "metrics.read"),
+    "list_audit": (["audit:read", "admin"], "audit.read"),
+    "get_platform_status": (["metrics:read", "ai:use", "admin"], "metrics.read"),
+    "interact_shell": (["shell:interact", "admin"], "shell.interact"),
+}
+
+# OpenAI-compatible tool schemas for chat/completions
+OPENAI_TOOLS: list[dict[str, Any]] = [
+    {
+        "type": "function",
+        "function": {
+            "name": "list_sessions",
+            "description": "List C2 sessions (beacons and reverse shells). Filter by status if needed.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "description": "Optional: active, closed, or omit for default",
+                    },
+                    "kind": {
+                        "type": "string",
+                        "description": "Optional: beacon, reverse_shell",
+                    },
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_session",
+            "description": "Get one session by id with metadata.",
+            "parameters": {
+                "type": "object",
+                "properties": {"session_id": {"type": "string"}},
+                "required": ["session_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_listeners",
+            "description": "List all listeners (http, reverse_shell, dns, smtp, tcp) and their status/ports.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_listener",
+            "description": (
+                "Create a new listener. For reverse shells use kind=reverse_shell. "
+                "Does not start it — call start_listener after create unless auto_start is true."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string", "description": "Short name e.g. rev-444"},
+                    "kind": {
+                        "type": "string",
+                        "enum": ["http", "tcp", "reverse_shell", "dns", "smtp"],
+                    },
+                    "port": {"type": "integer", "description": "TCP/UDP port 1-65535"},
+                    "host": {
+                        "type": "string",
+                        "description": "Bind address, default 0.0.0.0",
+                    },
+                    "auto_start": {
+                        "type": "boolean",
+                        "description": "If true, start the listener immediately after create",
+                    },
+                    "zone": {
+                        "type": "string",
+                        "description": "DNS zone when kind=dns",
+                    },
+                },
+                "required": ["name", "kind", "port"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "start_listener",
+            "description": "Start an existing listener by id.",
+            "parameters": {
+                "type": "object",
+                "properties": {"listener_id": {"type": "string"}},
+                "required": ["listener_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "stop_listener",
+            "description": "Stop a running listener by id.",
+            "parameters": {
+                "type": "object",
+                "properties": {"listener_id": {"type": "string"}},
+                "required": ["listener_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "delete_listener",
+            "description": "Stop (if needed) and delete a listener by id.",
+            "parameters": {
+                "type": "object",
+                "properties": {"listener_id": {"type": "string"}},
+                "required": ["listener_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_tasks",
+            "description": "List tasks, optionally for one session.",
+            "parameters": {
+                "type": "object",
+                "properties": {"session_id": {"type": "string"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "create_task",
+            "description": "Queue a command/task on a beacon or session.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {"type": "string"},
+                    "command": {"type": "string"},
+                    "args": {"type": "object"},
+                },
+                "required": ["session_id", "command"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_payload_templates",
+            "description": "List available payload template names.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "generate_payload",
+            "description": (
+                "Generate a deterministic payload from a template "
+                "(e.g. reverse_shell_bash, http_beacon_python)."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "template": {"type": "string"},
+                    "host": {"type": "string"},
+                    "port": {"type": "integer"},
+                    "interval": {"type": "integer"},
+                },
+                "required": ["template", "host", "port"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_metrics",
+            "description": "Get teamserver metrics counters snapshot.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_recent_events",
+            "description": "Get recent live events from the event buffer (shell connect, tasks, etc.).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "limit": {
+                        "type": "integer",
+                        "description": "Max events (default 30, max 80)",
+                    }
+                },
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_audit",
+            "description": "List recent audit log entries.",
+            "parameters": {
+                "type": "object",
+                "properties": {"limit": {"type": "integer"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "get_platform_status",
+            "description": "High-level platform status: AI, features summary, version-ish health.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "interact_shell",
+            "description": (
+                "Send a command to a live reverse_shell session. High risk — "
+                "requires shell:interact and may need HITL for non-admins."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "session_id": {"type": "string"},
+                    "command": {"type": "string"},
+                    "hitl_request_id": {"type": "string"},
+                },
+                "required": ["session_id", "command"],
+            },
+        },
+    },
+]
+
+CHAT_SYSTEM_PROMPT = """You are SquidC5 Admin AI — the operator assistant for this C5 (Command, Control, Cognitive, Collaborative, Coordination) teamserver.
+
+You can:
+1) Answer general security/ops questions clearly and helpfully.
+2) Inspect THIS environment via tools (sessions, listeners, tasks, payloads, metrics, events, audit).
+3) Perform allow-listed actions via tools (create/start/stop listeners, generate payloads, queue tasks, etc.).
+
+Rules:
+- Prefer tools over guessing about live environment state.
+- When the user asks to set up a listener, create it AND start it (auto_start true or start_listener).
+- For reverse shells use kind=reverse_shell. For HTTP beacons use kind=http.
+- Never invent session IDs, listener IDs, or secrets. Use tools.
+- Never dump API keys, tokens, or raw PII. Summarize tool results for the operator.
+- Do not claim you ran a tool unless you did.
+- Keep answers concise and operational. Use short bullet lists when listing resources.
+- If a tool fails due to permissions/HITL, explain what the operator must approve or which scope is missing.
+- You are authorized-use only; refuse illegal/unauthorized hacking requests outside this engagement platform.
+"""
+
+
+def _cap_json(obj: Any, max_chars: int = 6000) -> str:
+    try:
+        raw = json.dumps(obj, default=str)
+    except Exception:
+        raw = str(obj)
+    if len(raw) > max_chars:
+        return raw[: max_chars - 20] + "...[truncated]"
+    return raw
+
+
+def sanitize_tool_payload(obj: Any, max_chars: int = 6000) -> str:
+    """Serialize tool output for the model — truncated + injection-scrubbed."""
+    text = _cap_json(obj, max_chars=max_chars)
+    return sanitize_untrusted(text, max_chars=max_chars)
+
+
+def _handlers(
+    state: AppState, auth: AuthContext
+) -> dict[str, Callable[[dict[str, Any]], Awaitable[Any]]]:
+    async def list_sessions(args: dict[str, Any]) -> Any:
+        rows = await state.sessions.list(status=args.get("status"))
+        kind = (args.get("kind") or "").strip()
+        if kind:
+            rows = [r for r in rows if r.get("kind") == kind]
+        # slim for context
+        out = []
+        for r in rows[:80]:
+            out.append(
+                {
+                    "id": r.get("id"),
+                    "kind": r.get("kind"),
+                    "status": r.get("status"),
+                    "remote_addr": r.get("remote_addr"),
+                    "hostname": r.get("hostname"),
+                    "username": r.get("username"),
+                    "verified": r.get("verified"),
+                    "last_seen_at": r.get("last_seen_at"),
+                }
+            )
+        return {"count": len(out), "sessions": out}
+
+    async def get_session(args: dict[str, Any]) -> Any:
+        s = await state.sessions.get(args["session_id"])
+        if not s:
+            raise KeyError("session not found")
+        return s
+
+    async def list_listeners(args: dict[str, Any]) -> Any:
+        rows = await state.listeners.list()
+        return {
+            "count": len(rows),
+            "listeners": [
+                {
+                    "id": r.get("id"),
+                    "name": r.get("name"),
+                    "kind": r.get("kind"),
+                    "host": r.get("host"),
+                    "port": r.get("port"),
+                    "status": r.get("status"),
+                }
+                for r in rows
+            ],
+        }
+
+    async def create_listener(args: dict[str, Any]) -> Any:
+        kind = str(args.get("kind") or "")
+        if not await state.features.enabled("http_listeners") and kind == "http":
+            raise PermissionError("HTTP listeners disabled")
+        if kind in ("tcp", "reverse_shell") and not await state.features.enabled(
+            "reverse_shell_listeners"
+        ):
+            raise PermissionError("Reverse-shell listeners disabled")
+        cfg: dict[str, Any] = {}
+        if args.get("zone"):
+            cfg["zone"] = str(args["zone"])
+        row = await state.listeners.create(
+            name=str(args["name"]),
+            kind=kind,
+            port=int(args["port"]),
+            host=str(args.get("host") or "0.0.0.0"),
+            config=cfg or None,
+        )
+        started = None
+        if args.get("auto_start"):
+            started = await state.listeners.start(row["id"])
+        return {"created": row, "started": started}
+
+    async def start_listener(args: dict[str, Any]) -> Any:
+        return await state.listeners.start(args["listener_id"])
+
+    async def stop_listener(args: dict[str, Any]) -> Any:
+        return await state.listeners.stop(args["listener_id"])
+
+    async def delete_listener(args: dict[str, Any]) -> Any:
+        lid = args["listener_id"]
+        try:
+            await state.listeners.stop(lid)
+        except Exception:
+            pass
+        await state.listeners.delete(lid)
+        return {"deleted": lid}
+
+    async def list_tasks(args: dict[str, Any]) -> Any:
+        rows = await state.tasks.list(session_id=args.get("session_id"))
+        return {"count": len(rows), "tasks": rows[:60]}
+
+    async def create_task(args: dict[str, Any]) -> Any:
+        sid = args["session_id"]
+        await state.teams.assert_write_access(sid, auth.name, is_admin=auth.has_scope("admin"))
+        return await state.tasks.create(
+            session_id=sid,
+            command=str(args["command"]),
+            args=args.get("args"),
+            created_by=auth.name,
+        )
+
+    async def list_payload_templates(args: dict[str, Any]) -> Any:
+        if hasattr(state.payloads, "list_templates"):
+            names = state.payloads.list_templates()
+        else:
+            names = list(getattr(state.payloads, "TEMPLATES", ()) or ())
+        return {"templates": names}
+
+    async def generate_payload(args: dict[str, Any]) -> Any:
+        if not await state.features.enabled("payloads_generate"):
+            raise PermissionError("Payload generation disabled")
+        result = state.payloads.generate(
+            template=str(args["template"]),
+            host=str(args["host"]),
+            port=int(args["port"]),
+            interval=int(args.get("interval") or 5),
+        )
+        # payloads may be large — cap script body
+        if isinstance(result, dict) and "payload" in result:
+            body = str(result.get("payload") or "")
+            if len(body) > 4000:
+                result = dict(result)
+                result["payload"] = body[:4000] + "\n...[truncated]"
+                result["truncated"] = True
+        return result
+
+    async def get_metrics(args: dict[str, Any]) -> Any:
+        snap = await state.metrics.snapshot()
+        # drop bulky recent_events here — use list_recent_events
+        if isinstance(snap, dict):
+            snap = {k: v for k, v in snap.items() if k != "recent_events"}
+        return snap
+
+    async def list_recent_events(args: dict[str, Any]) -> Any:
+        snap = await state.metrics.snapshot()
+        ev = list(snap.get("recent_events") or [])
+        limit = max(1, min(int(args.get("limit") or 30), 80))
+        return {"count": len(ev[-limit:]), "events": ev[-limit:]}
+
+    async def list_audit(args: dict[str, Any]) -> Any:
+        limit = max(1, min(int(args.get("limit") or 40), 100))
+        rows = await state.audit.list(limit=limit)
+        return {"count": len(rows), "entries": rows}
+
+    async def get_platform_status(args: dict[str, Any]) -> Any:
+        ai = await state.admin_ai.status(debug=False)
+        feats = await state.features.get_all()
+        return {
+            "ai": ai,
+            "features": feats,
+            "public_host": getattr(state.settings, "public_host", None),
+        }
+
+    async def interact_shell(args: dict[str, Any]) -> Any:
+        sid = args["session_id"]
+        await state.teams.assert_write_access(sid, auth.name, is_admin=auth.has_scope("admin"))
+        ok = await state.listeners.send_shell(sid, str(args["command"]))
+        if not ok:
+            raise RuntimeError("No live reverse shell for session")
+        return {"sent": True, "session_id": sid}
+
+    return {
+        "list_sessions": list_sessions,
+        "get_session": get_session,
+        "list_listeners": list_listeners,
+        "create_listener": create_listener,
+        "start_listener": start_listener,
+        "stop_listener": stop_listener,
+        "delete_listener": delete_listener,
+        "list_tasks": list_tasks,
+        "create_task": create_task,
+        "list_payload_templates": list_payload_templates,
+        "generate_payload": generate_payload,
+        "get_metrics": get_metrics,
+        "list_recent_events": list_recent_events,
+        "list_audit": list_audit,
+        "get_platform_status": get_platform_status,
+        "interact_shell": interact_shell,
+    }
+
+
+async def execute_ops_tool(
+    state: AppState,
+    auth: AuthContext,
+    name: str,
+    arguments: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Run one allow-listed tool with scope + policy gates."""
+    args = dict(arguments or {})
+    name = (name or "").strip()
+    gate = TOOL_GATES.get(name)
+    if not gate:
+        return {"ok": False, "tool": name, "error": "Unknown tool"}
+    need_scopes, policy_action = gate
+    if not any(auth.has_scope(s) for s in need_scopes) and not auth.has_scope("admin"):
+        return {
+            "ok": False,
+            "tool": name,
+            "error": f"Missing scope (need one of {need_scopes})",
+        }
+
+    extra: dict[str, Any] = {
+        "args_keys": list(args.keys()),
+        "command": args.get("command"),
+        "hitl_request_id": args.get("hitl_request_id"),
+        "via": "admin_ai.chat",
+    }
+    resource = args.get("session_id") or args.get("listener_id")
+    decision = await state.policy.check_and_audit(
+        auth,
+        action=policy_action,
+        resource=resource if isinstance(resource, str) else None,
+        extra=extra,
+    )
+    if not decision.allowed:
+        out: dict[str, Any] = {
+            "ok": False,
+            "tool": name,
+            "error": decision.reason or "policy denied",
+        }
+        if getattr(decision, "require_hitl", False) or "hitl" in (decision.reason or "").lower():
+            out["require_hitl"] = True
+            hid = getattr(decision, "hitl_request_id", None)
+            if hid:
+                out["hitl_request_id"] = hid
+        return out
+
+    handlers = _handlers(state, auth)
+    handler = handlers.get(name)
+    if not handler:
+        return {"ok": False, "tool": name, "error": "Unknown tool"}
+    try:
+        result = await handler(args)
+        await state.metrics.incr("ai.chat.tool_ok")
+        await state.metrics.emit(
+            "ai.chat.tool",
+            {"tool": name, "actor": auth.name, "ok": True},
+        )
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action=f"ai.chat.tool.{name}",
+            resource=str(resource) if resource else None,
+            details={"tool": name, "ok": True},
+            risk_score=4 if name in ("create_listener", "create_task", "interact_shell", "generate_payload") else 2,
+        )
+        return {"ok": True, "tool": name, "result": result}
+    except PermissionError as exc:
+        return {"ok": False, "tool": name, "error": str(exc)}
+    except KeyError as exc:
+        return {"ok": False, "tool": name, "error": str(exc) or "not found"}
+    except Exception as exc:
+        await state.metrics.incr("ai.chat.tool_err")
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="ai.chat.tool.error",
+            details={"tool": name, "error": type(exc).__name__},
+            allowed=False,
+            risk_score=4,
+        )
+        return {"ok": False, "tool": name, "error": f"{type(exc).__name__}: {exc}"[:300]}
+
+
+# --- Offline deterministic intents (no LLM) ---
+
+_RE_CREATE_LISTENER = re.compile(
+    r"(?i)\b(?:create|setup|set\s*up|add|start)\b.*\b(?:listener|reverse\s*shell|rev\s*shell)\b.*\b(?:port\s*)?(\d{2,5})\b"
+)
+_RE_LIST_SESSIONS = re.compile(r"(?i)\b(list|show|what)\b.*\b(sessions?|shells?|beacons?)\b")
+_RE_LIST_LISTENERS = re.compile(r"(?i)\b(list|show|what)\b.*\blisteners?\b")
+_RE_METRICS = re.compile(r"(?i)\b(metrics|status|health)\b")
+_RE_EVENTS = re.compile(r"(?i)\b(events?|event\s*stream)\b")
+
+
+async def offline_chat_intent(
+    state: AppState, auth: AuthContext, message: str
+) -> dict[str, Any] | None:
+    """Best-effort offline handling for common ops phrases when no LLM is configured."""
+    msg = (message or "").strip()
+    if not msg:
+        return None
+    m = _RE_CREATE_LISTENER.search(msg)
+    if m:
+        port = int(m.group(1))
+        kind = "reverse_shell"
+        if re.search(r"(?i)\bhttp\b", msg):
+            kind = "http"
+        elif re.search(r"(?i)\bdns\b", msg):
+            kind = "dns"
+        name = f"ai-{kind}-{port}"
+        r = await execute_ops_tool(
+            state,
+            auth,
+            "create_listener",
+            {"name": name, "kind": kind, "port": port, "auto_start": True},
+        )
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, f"Create {kind} listener on {port}"),
+            "tool_trace": [r],
+        }
+    if _RE_LIST_SESSIONS.search(msg):
+        r = await execute_ops_tool(state, auth, "list_sessions", {})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "Sessions"),
+            "tool_trace": [r],
+        }
+    if _RE_LIST_LISTENERS.search(msg):
+        r = await execute_ops_tool(state, auth, "list_listeners", {})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "Listeners"),
+            "tool_trace": [r],
+        }
+    if _RE_EVENTS.search(msg):
+        r = await execute_ops_tool(state, auth, "list_recent_events", {"limit": 20})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "Recent events"),
+            "tool_trace": [r],
+        }
+    if _RE_METRICS.search(msg):
+        r = await execute_ops_tool(state, auth, "get_metrics", {})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "Metrics"),
+            "tool_trace": [r],
+        }
+    return None
+
+
+def _offline_reply_for_tool(r: dict[str, Any], title: str) -> str:
+    if not r.get("ok"):
+        return f"{title}: failed — {r.get('error') or 'unknown error'}"
+    return f"{title}:\n{_cap_json(r.get('result'), 3500)}"

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -98,6 +98,18 @@ class AIRunRequest(BaseModel):
     llm_id: str | None = None
 
 
+class AIChatMessage(BaseModel):
+    role: str
+    content: str = ""
+
+
+class AIChatRequest(BaseModel):
+    message: str
+    history: list[AIChatMessage] = Field(default_factory=list)
+    llm_id: str | None = None
+    max_rounds: int | None = None
+
+
 class ShellCommand(BaseModel):
     session_id: str
     command: str
@@ -1681,6 +1693,61 @@ def build_api_router() -> APIRouter:
             raise HTTPException(400, str(e)) from e
         except Exception as e:
             raise HTTPException(502, f"Admin AI error: {e}") from e
+
+    @api.post("/ai/chat")
+    async def ai_chat(
+        body: AIChatRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("ai:use", "admin")),
+    ) -> dict[str, Any]:
+        """Operator chat with allow-listed C5 tools (sessions, listeners, payloads, …)."""
+        state = get_state(request)
+        if not await state.features.enabled("ai_enabled"):
+            raise HTTPException(403, "Admin AI is disabled by feature flag")
+        decision = await state.policy.check_and_audit(
+            auth, "ai.admin", extra={"capability": "chat"}
+        )
+        if not decision.allowed:
+            raise HTTPException(403, decision.reason)
+        hist = [{"role": m.role, "content": m.content} for m in (body.history or [])]
+        try:
+            return await state.admin_ai.chat(
+                message=body.message,
+                history=hist,
+                actor=auth.name,
+                llm_id=body.llm_id,
+                state=state,
+                auth=auth,
+                max_rounds=body.max_rounds or 6,
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        except Exception as e:
+            raise HTTPException(502, f"Admin AI error: {e}") from e
+
+    @api.get("/ai/tools")
+    async def ai_tools_catalog(
+        auth: AuthContext = Depends(require_scope("ai:use", "admin")),
+    ) -> dict[str, Any]:
+        """List Admin AI chat tools (names + descriptions only)."""
+        from squidc5.ai.ops_tools import OPENAI_TOOLS, TOOL_GATES
+
+        tools = []
+        for t in OPENAI_TOOLS:
+            fn = t.get("function") or {}
+            name = fn.get("name")
+            if not name:
+                continue
+            scopes, action = TOOL_GATES.get(name, ([], ""))
+            tools.append(
+                {
+                    "name": name,
+                    "description": fn.get("description"),
+                    "scopes": scopes,
+                    "policy_action": action,
+                }
+            )
+        return {"tools": tools, "note": "Railed tool-calling; policy + scopes enforced per call"}
 
     # ----- Malleable C2 profiles -----
 

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -1,0 +1,102 @@
+"""Admin AI operator chat — railed tools + offline intents."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_aichat01"
+
+
+def _settings(tmp_path, **kw):
+    base = dict(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=5000,
+    )
+    base.update(kw)
+    return Settings(**base)
+
+
+@pytest.mark.asyncio
+async def test_ai_chat_offline_create_listener(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.post(
+                "/api/v1/ai/chat",
+                headers=h,
+                json={"message": "Setup a reverse shell listener on 4444"},
+            )
+            assert r.status_code == 200, r.text
+            body = r.json()
+            assert body["mode"] == "offline"
+            assert body.get("tool_trace")
+            assert any(t.get("tool") == "create_listener" and t.get("ok") for t in body["tool_trace"])
+            # listener exists and started
+            lis = await client.get("/api/v1/listeners", headers=h)
+            assert lis.status_code == 200
+            rows = lis.json()
+            assert any(int(x.get("port") or 0) == 4444 for x in rows)
+
+
+@pytest.mark.asyncio
+async def test_ai_chat_offline_list_sessions(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.post(
+                "/api/v1/ai/chat",
+                headers=h,
+                json={"message": "list sessions please"},
+            )
+            assert r.status_code == 200
+            body = r.json()
+            assert body["mode"] == "offline"
+            assert any(t.get("tool") == "list_sessions" for t in body.get("tool_trace") or [])
+
+
+@pytest.mark.asyncio
+async def test_ai_tools_catalog(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.get("/api/v1/ai/tools", headers=h)
+            assert r.status_code == 200
+            names = {t["name"] for t in r.json()["tools"]}
+            assert "create_listener" in names
+            assert "list_sessions" in names
+            assert "generate_payload" in names
+
+
+@pytest.mark.asyncio
+async def test_ai_chat_requires_scope(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            t = await client.post(
+                "/api/v1/tokens",
+                headers=h,
+                json={"name": "noscope", "scopes": ["sessions:read"]},
+            )
+            tok = t.json()["token"]
+            r = await client.post(
+                "/api/v1/ai/chat",
+                headers={"Authorization": f"Bearer {tok}"},
+                json={"message": "hi"},
+            )
+            assert r.status_code == 403

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1064,6 +1064,9 @@
 
   /* —— Admin —— */
   /* —— AI tab —— */
+  /** Multi-turn chat history for Admin AI (user/assistant text only) */
+  let aiChatHistory = [];
+
   function renderAiView() {
     const root = el("view-ai");
     if (!root) return;
@@ -1074,20 +1077,31 @@
     root.innerHTML = `
       <div class="form-grid ai-layout">
         <div class="work-panel">
-          <div class="wp-head">Run capability</div>
+          <div class="wp-head">Operator chat</div>
           <div class="wp-body">
+            <p class="muted" style="font-size:0.78rem;margin:0 0 8px">
+              Free-form chat with railed tools: sessions, listeners, tasks, payloads, metrics, events, audit.
+              Example: <em>“Setup a reverse shell listener on 4444 and start it.”</em>
+            </p>
             <label>LLM connection</label>
             <select id="aiLlmPick"><option value="">Loading…</option></select>
-            <label>Capability</label>
-            <select id="aiCap">${AI_CAPS.map((c) => `<option value="${c}">${c}</option>`).join("")}</select>
-            <label>Input (untrusted — sanitized server-side)</label>
-            <textarea id="aiData" rows="5" placeholder="Describe target, paste metrics text, ask for recon assist…"></textarea>
+            <label>Message</label>
+            <textarea id="aiData" rows="4" placeholder="Ask a question or give an ops instruction…"></textarea>
             <div class="row">
-              <button type="button" class="primary" id="aiRun">Run</button>
+              <button type="button" class="primary" id="aiRun">Send</button>
+              <button type="button" id="aiClearPage">Clear chat</button>
               <button type="button" id="aiStatus">AI status</button>
-              <button type="button" id="aiOpenDrawer">Open floating chat</button>
+              <button type="button" id="aiTools">Tools</button>
+              <button type="button" id="aiOpenDrawer">Floating chat</button>
             </div>
-            <div class="outbox empty" id="aiOut">—</div>
+            <div id="aiPageLog" class="outbox" style="max-height:min(420px,45vh);min-height:160px"></div>
+            <details style="margin-top:10px">
+              <summary class="muted" style="cursor:pointer;font-size:0.78rem">Legacy capability runner</summary>
+              <label style="margin-top:8px">Capability</label>
+              <select id="aiCap">${AI_CAPS.map((c) => `<option value="${c}">${c}</option>`).join("")}</select>
+              <div class="row"><button type="button" id="aiRunCap">Run capability</button></div>
+              <div class="outbox empty" id="aiOut">—</div>
+            </details>
           </div>
         </div>
         <div class="work-panel">
@@ -1109,7 +1123,17 @@
       saveSel("sc5_ops_llm", el("aiLlmPick").value || "");
       if (el("aiLlmGlobal") && el("aiLlmPick").value) el("aiLlmGlobal").value = el("aiLlmPick").value;
     };
-    if (el("aiRun")) el("aiRun").onclick = () => runAi(el("aiCap").value, el("aiData").value, "aiOut");
+    if (el("aiRun")) el("aiRun").onclick = async () => {
+      const msg = (el("aiData") && el("aiData").value) || "";
+      if (!msg.trim()) return showError("Enter a message");
+      el("aiRun").disabled = true;
+      try {
+        await runAiChat(msg);
+        if (el("aiData")) el("aiData").value = "";
+      } finally { el("aiRun").disabled = false; }
+    };
+    if (el("aiClearPage")) el("aiClearPage").onclick = () => clearAiChat();
+    if (el("aiRunCap")) el("aiRunCap").onclick = () => runAiCapability(el("aiCap").value, el("aiData").value, "aiOut");
     if (el("aiStatus")) el("aiStatus").onclick = async () => {
       try {
         const r = await api("GET", "/api/v1/ai/status");
@@ -1117,20 +1141,63 @@
         el("aiOut").classList.remove("empty");
       } catch (e) { showError(String(e.message || e)); }
     };
+    if (el("aiTools")) el("aiTools").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/ai/tools");
+        el("aiOut").textContent = JSON.stringify(r, null, 2);
+        el("aiOut").classList.remove("empty");
+      } catch (e) { showError(String(e.message || e)); }
+    };
     if (el("aiOpenDrawer")) el("aiOpenDrawer").onclick = () => openAiDrawer(true);
+    syncAiPageLog();
   }
 
+  function selectedLlmId() {
+    return (el("aiLlmPick") && el("aiLlmPick").value)
+      || (el("aiLlmGlobal") && el("aiLlmGlobal").value)
+      || loadSel("sc5_ops_llm")
+      || null;
+  }
 
-  async function runAi(capability, user_data, outId) {
+  async function runAiChat(message) {
+    const text = (message || "").trim();
+    if (!text) return;
+    appendAiChat("user", text);
+    aiChatHistory.push({ role: "user", content: text });
+    // keep history bounded
+    if (aiChatHistory.length > 24) aiChatHistory = aiChatHistory.slice(-24);
     try {
-      const llm_id = (el("aiLlmPick") && el("aiLlmPick").value)
-        || (el("aiLlmGlobal") && el("aiLlmGlobal").value)
-        || loadSel("sc5_ops_llm")
-        || null;
+      const body = {
+        message: text,
+        history: aiChatHistory.slice(0, -1), // prior turns only
+      };
+      const llm_id = selectedLlmId();
+      if (llm_id) body.llm_id = llm_id;
+      const r = await api("POST", "/api/v1/ai/chat", body);
+      const reply = (r && r.reply) || JSON.stringify(r, null, 2);
+      const tools = (r && r.tool_trace) || [];
+      appendAiChat("bot", reply, tools);
+      aiChatHistory.push({ role: "assistant", content: reply });
+      if (tools.some((t) => t.ok && /listener|session|task|payload/i.test(t.tool || ""))) {
+        if (window.__SC5_refresh) try { await window.__SC5_refresh(); } catch (_) {}
+      }
+      showOk(r.mode === "offline" ? "AI (offline tools)" : "AI reply");
+      return r;
+    } catch (e) {
+      const err = String(e.message || e);
+      showError(err);
+      appendAiChat("bot", "Error: " + err);
+      aiChatHistory.push({ role: "assistant", content: "Error: " + err });
+    }
+  }
+
+  async function runAiCapability(capability, user_data, outId) {
+    try {
       const body = {
         capability: capability || "recon_assist",
         user_data: user_data || "",
       };
+      const llm_id = selectedLlmId();
       if (llm_id) body.llm_id = llm_id;
       const r = await api("POST", "/api/v1/ai/run", body);
       const text = typeof r === "string" ? r : JSON.stringify(r, null, 2);
@@ -1138,32 +1205,55 @@
         el(outId).textContent = text;
         el(outId).classList.remove("empty");
       }
-      appendAiChat("user", `[${capability}${llm_id ? " · " + llm_id.slice(0, 10) : ""}] ${user_data || "(empty)"}`);
-      appendAiChat("bot", text);
-      showOk("AI complete");
+      showOk("Capability complete");
       return r;
     } catch (e) {
       showError(String(e.message || e));
-      appendAiChat("bot", "Error: " + String(e.message || e));
     }
   }
 
-  function appendAiChat(who, text) {
+  function appendAiChat(who, text, toolTrace) {
     const log = el("aiChatLog");
-    if (!log) return;
-    const div = document.createElement("div");
-    div.className = "ai-msg " + (who === "user" ? "user" : "bot");
-    const w = document.createElement("div");
-    w.className = "who";
-    w.textContent = who === "user" ? "You" : "Admin AI";
-    const b = document.createElement("div");
-    b.className = "mono";
-    b.style.whiteSpace = "pre-wrap";
-    b.textContent = text;
-    div.appendChild(w);
-    div.appendChild(b);
-    log.appendChild(div);
-    log.scrollTop = log.scrollHeight;
+    const page = el("aiPageLog");
+    const make = (parent) => {
+      if (!parent) return;
+      const div = document.createElement("div");
+      div.className = "ai-msg " + (who === "user" ? "user" : "bot");
+      const w = document.createElement("div");
+      w.className = "who";
+      w.textContent = who === "user" ? "You" : "Admin AI";
+      const b = document.createElement("div");
+      b.style.whiteSpace = "pre-wrap";
+      b.textContent = text;
+      div.appendChild(w);
+      div.appendChild(b);
+      if (toolTrace && toolTrace.length) {
+        const row = document.createElement("div");
+        row.className = "tools-used";
+        toolTrace.forEach((t) => {
+          const chip = document.createElement("span");
+          chip.className = "tool-chip " + (t.ok ? "ok" : "bad");
+          chip.textContent = (t.ok ? "✓ " : "✗ ") + (t.tool || "?") + (t.summary ? " · " + t.summary : "");
+          row.appendChild(chip);
+        });
+        div.appendChild(row);
+      }
+      parent.appendChild(div);
+      parent.scrollTop = parent.scrollHeight;
+    };
+    make(log);
+    make(page);
+  }
+
+  function clearAiChat() {
+    aiChatHistory = [];
+    if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
+    if (el("aiPageLog")) el("aiPageLog").innerHTML = "";
+    showOk("Chat cleared");
+  }
+
+  function syncAiPageLog() {
+    // page log is independent DOM; drawer keeps history via aiChatHistory display only on new msgs
   }
 
   function openAiDrawer(open) {
@@ -1183,16 +1273,6 @@
       drawer.classList.add("hidden");
       return;
     }
-    const sel = el("aiCapGlobal");
-    if (sel && !sel.options.length) {
-      AI_CAPS.forEach((c) => {
-        const o = document.createElement("option");
-        o.value = c; o.textContent = c;
-        sel.appendChild(o);
-      });
-      sel.value = "recon_assist";
-    }
-    // LLM picker in drawer
     loadSavedLlms().then((llms) => {
       fillLlmSelect(el("aiLlmGlobal"), llms, loadSel("sc5_ops_llm") || "");
     });
@@ -1202,18 +1282,27 @@
     };
     fab.onclick = () => openAiDrawer();
     if (el("aiDrawerClose")) el("aiDrawerClose").onclick = () => openAiDrawer(false);
+    if (el("aiClearGlobal")) el("aiClearGlobal").onclick = () => clearAiChat();
     if (el("aiSendGlobal")) el("aiSendGlobal").onclick = async () => {
-      const cap = (el("aiCapGlobal") && el("aiCapGlobal").value) || "recon_assist";
       const prompt = (el("aiPromptGlobal") && el("aiPromptGlobal").value) || "";
-      if (!prompt.trim()) return showError("Enter a prompt");
+      if (!prompt.trim()) return showError("Enter a message");
       el("aiSendGlobal").disabled = true;
       try {
-        await runAi(cap, prompt, null);
+        await runAiChat(prompt);
         if (el("aiPromptGlobal")) el("aiPromptGlobal").value = "";
       } finally {
         el("aiSendGlobal").disabled = false;
       }
     };
+    // Enter to send (Shift+Enter newline)
+    if (el("aiPromptGlobal")) {
+      el("aiPromptGlobal").onkeydown = (e) => {
+        if (e.key === "Enter" && !e.shiftKey) {
+          e.preventDefault();
+          if (el("aiSendGlobal")) el("aiSendGlobal").click();
+        }
+      };
+    }
   }
 
   function renderAdminView() {

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -400,7 +400,8 @@
     .ai-fab:hover { background: rgba(233,30,140,0.4); }
     .ai-drawer {
       position: fixed; right: 16px; bottom: calc(var(--bottom-h) + 68px); z-index: 41;
-      width: min(380px, calc(100vw - 24px)); height: min(420px, 50vh);
+      width: min(440px, calc(100vw - 24px));
+      height: min(580px, calc(100dvh - var(--bottom-h) - 90px));
       background: var(--bg2); border: 1px solid var(--border2); border-radius: 12px;
       display: flex; flex-direction: column; box-shadow: 0 16px 48px rgba(0,0,0,0.5);
       overflow: hidden;
@@ -408,17 +409,27 @@
     .ai-drawer.hidden, .ai-fab.hidden { display: none !important; }
     .ai-drawer-head {
       display: flex; align-items: center; gap: 8px; padding: 8px 10px;
-      border-bottom: 1px solid var(--border); font-size: 0.85rem;
+      border-bottom: 1px solid var(--border); font-size: 0.85rem; flex-shrink: 0;
     }
     .ai-drawer-body {
-      flex: 1; overflow: auto; padding: 10px; font-size: 0.8rem; min-height: 0;
+      flex: 1; overflow: auto; padding: 10px; font-size: 0.82rem; min-height: 0;
     }
-    .ai-msg { margin-bottom: 10px; padding: 8px 10px; border-radius: 8px; line-height: 1.4; }
+    .ai-msg { margin-bottom: 10px; padding: 8px 10px; border-radius: 8px; line-height: 1.45; }
     .ai-msg.user { background: rgba(255,255,255,0.04); border: 1px solid var(--border); }
     .ai-msg.bot { background: rgba(233,30,140,0.08); border: 1px solid rgba(233,30,140,0.25); }
     .ai-msg .who { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; margin-bottom: 4px; }
+    .ai-msg .tools-used {
+      margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px;
+    }
+    .ai-msg .tool-chip {
+      font: 600 0.62rem/1 var(--mono); padding: 3px 6px; border-radius: 999px;
+      background: rgba(255,255,255,0.06); border: 1px solid var(--border); color: var(--muted);
+    }
+    .ai-msg .tool-chip.ok { color: var(--ok); border-color: rgba(52,211,153,0.35); }
+    .ai-msg .tool-chip.bad { color: var(--bad); border-color: rgba(248,113,113,0.35); }
     .ai-drawer-foot {
       border-top: 1px solid var(--border); padding: 8px; display: flex; flex-direction: column; gap: 6px;
+      flex-shrink: 0;
     }
     .ai-drawer-foot select, .ai-drawer-foot textarea { width: 100%; }
     @media (max-width: 900px) {
@@ -600,9 +611,11 @@
       <div class="ai-drawer-body" id="aiChatLog"></div>
       <div class="ai-drawer-foot">
         <select id="aiLlmGlobal" title="LLM connection"></select>
-        <select id="aiCapGlobal" title="Capability"></select>
-        <textarea id="aiPromptGlobal" rows="2" placeholder="Ask the sandboxed Admin AI…"></textarea>
-        <button type="button" class="primary" id="aiSendGlobal">Send</button>
+        <textarea id="aiPromptGlobal" rows="3" placeholder="Ask anything — e.g. list sessions, setup reverse shell on 4444…"></textarea>
+        <div class="row" style="margin:0;gap:6px">
+          <button type="button" class="primary" id="aiSendGlobal" style="flex:1">Send</button>
+          <button type="button" id="aiClearGlobal" title="Clear chat">Clear</button>
+        </div>
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
- **Real operator chat** via `POST /api/v1/ai/chat` — multi-turn, free-form Q&A
- **Railed tools** (policy + scopes): list/get sessions, create/start/stop/delete listeners, tasks, payloads, metrics, events, audit, shell (HITL when required)
- Example: *“Setup a reverse shell listener on 4444”* → create + start
- Offline deterministic intents when no LLM configured
- Ops UI: floating drawer + AI tab are chat-first (legacy capabilities under a details panel)
- Still sandboxed: allow-listed tools only, max 6–8 rounds, sanitized I/O, full audit

## Test plan
- [x] `pytest tests/test_ai_chat.py tests/test_ai_sandbox.py tests/test_security_hardening.py`
- [ ] With LLM: ask “list listeners” and “setup reverse shell on 5555”
- [ ] Confirm tool chips show in chat; listeners refresh