### PR TITLE
fix(ops): mobile fixed header + scrollable context sheet

### DIFF
--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -344,6 +344,12 @@
 
   /* —— Context rail —— */
   let ctxBoundSid = null;
+  function bindCtxChrome() {
+    if (el("ctxClose")) el("ctxClose").onclick = () => openCtxSheet(false);
+    if (el("ctxBackdrop")) el("ctxBackdrop").onclick = () => openCtxSheet(false);
+  }
+  bindCtxChrome();
+
   function bindContextHandlers() {
     if (el("ctxClaim")) el("ctxClaim").onclick = async () => {
       try {
@@ -458,6 +464,22 @@
     bindContextHandlers();
   }
 
+  function isMobileShell() {
+    try { return window.matchMedia && window.matchMedia("(max-width: 900px)").matches; } catch (_) { return false; }
+  }
+  function openCtxSheet(open) {
+    const rail = el("ctxRail");
+    const bd = el("ctxBackdrop");
+    if (!rail) return;
+    if (!isMobileShell()) {
+      rail.classList.remove("open");
+      if (bd) bd.classList.add("hidden");
+      return;
+    }
+    const show = open !== false && !!selectedId;
+    rail.classList.toggle("open", show);
+    if (bd) bd.classList.toggle("hidden", !show);
+  }
   function selectSession(id) {
     selectedId = id || null;
     state.selectedId = selectedId;
@@ -478,6 +500,7 @@
     }
     if (el("pxSid")) el("pxSid").textContent = selectedId || "(none — pick in Sessions)";
     renderContext();
+    openCtxSheet(!!selectedId);
     if (el("tskList")) loadTasksPanel();
   }
   window.__SC5_selectSession = selectSession;
@@ -598,10 +621,11 @@
     if (el("tskReload")) el("tskReload").onclick = () => loadTasksPanel();
     if (el("tskCancel")) el("tskCancel").onclick = () => cancelSelectedTask();
     if (el("tskSave")) el("tskSave").onclick = () => saveSelectedTask();
-    tools(` <button type="button" class="primary" id="toolNewShell">Focus rail</button>`);
+    tools(`<button type="button" class="primary" id="toolNewShell">Context</button>`);
     if (el("toolNewShell")) el("toolNewShell").onclick = () => {
       if (!selectedId) return showError("Select a session first");
-      renderContext();
+      renderContext(true);
+      openCtxSheet(true);
     };
     if (selectedId) selectSession(selectedId);
     loadTasksPanel();
@@ -1418,8 +1442,15 @@
     }
     setPageDocs(name || "dashboard");
     renderContext();
+    // Admin/AI hide ctx on desktop; on mobile keep sheet available when a session is selected
+    if (name === "admin" || name === "ai") {
+      if (!isMobileShell()) openCtxSheet(false);
+    } else if (selectedId && isMobileShell()) {
+      /* leave sheet closed until user re-selects unless already open */
+    }
   }
   window.__SC5_setPageDocs = setPageDocs;
+  window.__SC5_openCtx = openCtxSheet;
 
   window.__SC5_onView = renderView;
   window.__SC5_onRefresh = (data) => {

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -187,12 +187,28 @@
       min-height: 0; overflow: hidden;
     }
     .ctx-head {
+      display: flex; align-items: center; gap: 8px;
       padding: 10px 12px; border-bottom: 1px solid var(--border);
       font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em;
       color: var(--muted); font-weight: 700; flex-shrink: 0;
     }
-    .ctx-body { flex: 1; overflow: auto; padding: 10px 12px; min-height: 0; }
+    .ctx-drag { display: none; }
+    .ctx-close {
+      display: none; margin-left: auto;
+      padding: 6px 10px; min-height: 36px; font-size: 0.85rem;
+    }
+    .ctx-body {
+      flex: 1; overflow-y: auto; overflow-x: hidden;
+      padding: 10px 12px; min-height: 0;
+      -webkit-overflow-scrolling: touch;
+      overscroll-behavior: contain;
+      touch-action: pan-y;
+    }
     .ctx-empty { color: var(--muted); font-size: 0.85rem; line-height: 1.45; padding: 12px 4px; }
+    .ctx-backdrop {
+      display: none; position: fixed; inset: 0; z-index: 44;
+      background: rgba(0,0,0,0.55);
+    }
 
     /* Bottom console */
     .bottom {
@@ -437,16 +453,17 @@
       .ai-drawer { bottom: 76px; right: 8px; left: 8px; width: auto; }
     }
 
-    /* Mobile: stack — keep shell height, scroll main only */
+    /* Mobile: fixed header + scrollable nav + context bottom-sheet */
     @media (max-width: 900px) {
       :root {
-        --top-h: 52px;
-        --bottom-h: 28vh;
+        --top-h: calc(48px + env(safe-area-inset-top, 0px));
+        --nav-h: 48px;
+        --bottom-h: 22vh;
         --sidebar-w: 100%;
       }
       body { overflow: hidden; }
       .app {
-        grid-template-rows: var(--top-h) 48px 1fr var(--bottom-h);
+        grid-template-rows: var(--top-h) var(--nav-h) 1fr var(--bottom-h);
         grid-template-columns: 1fr;
         grid-template-areas:
           "top"
@@ -454,36 +471,163 @@
           "main"
           "bottom";
         height: 100dvh;
+        height: 100svh;
         overflow: hidden;
+        padding-bottom: env(safe-area-inset-bottom, 0px);
       }
+      .app.no-bottom {
+        grid-template-rows: var(--top-h) var(--nav-h) 1fr;
+        grid-template-areas:
+          "top"
+          "side"
+          "main";
+      }
+      .app.no-ctx {
+        grid-template-columns: 1fr;
+        grid-template-areas:
+          "top"
+          "side"
+          "main"
+          "bottom";
+      }
+      .app.no-bottom.no-ctx {
+        grid-template-areas:
+          "top"
+          "side"
+          "main";
+      }
+
+      /* —— Fixed compact header —— */
       .top {
-        padding: 0 8px; gap: 6px; flex-wrap: nowrap;
+        position: sticky; top: 0; z-index: 50;
+        padding: 0 8px;
+        padding-top: env(safe-area-inset-top, 0px);
+        gap: 6px; flex-wrap: nowrap;
+        min-height: var(--top-h);
+        height: var(--top-h);
+        overflow: hidden;
+        background: var(--bg2);
+        align-items: center;
       }
-      .top .title { font-size: 0.85rem; }
+      .top .logo { width: 24px; height: 24px; flex-shrink: 0; }
+      .top .title { font-size: 0.82rem; flex-shrink: 0; }
       .top .host { display: none; }
       .top .sep { display: none; }
-      .top button { padding: 8px 10px; font-size: 0.75rem; min-height: 40px; }
+      .top .spacer { flex: 1 1 auto; min-width: 4px; }
+      .top .pill {
+        padding: 4px 6px; font-size: 0.58rem; flex-shrink: 0;
+        max-width: 72px; overflow: hidden; text-overflow: ellipsis;
+      }
+      .top #roleBadge { display: none !important; }
+      .top button {
+        padding: 0 10px; font-size: 0.72rem; min-height: 36px;
+        flex-shrink: 0; white-space: nowrap;
+      }
+      .top #btnPhoneQr {
+        padding: 0 8px; min-width: 36px;
+        font-size: 0; /* hide label text */
+      }
+      .top #btnPhoneQr::before {
+        content: "QR"; font-size: 0.72rem; font-weight: 700;
+      }
+      .top #btnRefresh { min-width: 36px; padding: 0 8px; }
+
+      /* —— Horizontal nav (easy swipe scroll) —— */
       .side {
+        position: sticky; top: var(--top-h); z-index: 45;
         flex-direction: row; border-right: 0; border-bottom: 1px solid var(--border);
-        overflow: hidden; max-height: 48px;
+        overflow: hidden; height: var(--nav-h); max-height: var(--nav-h);
+        background: var(--bg2);
       }
       .side-nav {
-        flex-direction: row; padding: 4px 6px; gap: 4px;
+        flex-direction: row; align-items: center;
+        padding: 4px 8px; gap: 6px;
         overflow-x: auto; overflow-y: hidden;
         -webkit-overflow-scrolling: touch;
+        overscroll-behavior-x: contain;
+        scroll-snap-type: x proximity;
         flex: 1;
+        scrollbar-width: none;
       }
+      .side-nav::-webkit-scrollbar { display: none; }
       .nav-item {
-        white-space: nowrap; flex: 0 0 auto; padding: 8px 12px;
-        min-height: 40px; font-size: 0.78rem;
+        white-space: nowrap; flex: 0 0 auto;
+        padding: 8px 14px; min-height: 38px;
+        font-size: 0.8rem; scroll-snap-align: start;
+        border: 1px solid var(--border);
       }
       .nav-item .badge-n { display: none; }
       .nav-item .ico { display: none; }
       .side-foot { display: none; }
-      .ctx { display: none !important; }
+
+      /* —— Context as scrollable bottom sheet —— */
+      .ctx {
+        display: flex !important;
+        position: fixed;
+        left: 0; right: 0; bottom: 0;
+        top: auto;
+        z-index: 46;
+        height: min(72dvh, 560px);
+        max-height: calc(100dvh - var(--top-h) - 24px);
+        border-left: 0;
+        border-top: 1px solid var(--border2);
+        border-radius: 16px 16px 0 0;
+        box-shadow: 0 -12px 40px rgba(0,0,0,0.5);
+        transform: translateY(110%);
+        transition: transform 0.22s ease;
+        padding-bottom: env(safe-area-inset-bottom, 0px);
+        background: var(--bg2);
+      }
+      .ctx.open {
+        transform: translateY(0);
+      }
+      .app.no-ctx .ctx { display: flex !important; } /* still available as sheet */
+      .ctx-head {
+        padding: 8px 12px 10px;
+        position: relative;
+        cursor: default;
+      }
+      .ctx-drag {
+        display: block;
+        position: absolute; left: 50%; top: 6px;
+        width: 40px; height: 4px; margin-left: -20px;
+        border-radius: 999px; background: rgba(255,255,255,0.2);
+      }
+      .ctx-close { display: inline-flex !important; align-items: center; justify-content: center; }
+      .ctx-body {
+        flex: 1;
+        overflow-y: auto !important;
+        -webkit-overflow-scrolling: touch;
+        overscroll-behavior: contain;
+        padding: 12px 14px 24px;
+        max-height: none;
+      }
+      .ctx-backdrop:not(.hidden) {
+        display: block;
+      }
+
       .main { min-height: 0; overflow: hidden; }
-      .main-head { padding: 8px 10px; flex-wrap: wrap; gap: 6px; }
-      .main-head h2 { font-size: 0.9rem; }
+      .main-head {
+        padding: 8px 10px;
+        flex-wrap: nowrap;
+        gap: 6px;
+        position: sticky; top: 0; z-index: 5;
+        background: var(--bg);
+      }
+      .main-head > div:first-child { min-width: 0; flex: 1; }
+      .main-head h2 { font-size: 0.88rem; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+      .main-head .sub {
+        font-size: 0.68rem;
+        white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+      }
+      .main-head .tools { margin-left: 0; flex-shrink: 0; }
+      .docs-drop { flex-shrink: 0; }
+      .docs-menu {
+        max-height: min(50vh, 320px);
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+        right: 0; left: auto;
+      }
       .main-body {
         overflow: auto; padding: 10px;
         -webkit-overflow-scrolling: touch;
@@ -494,7 +638,11 @@
         min-height: 0;
       }
       .bottom-pane:first-child { border-right: 0; border-bottom: 1px solid var(--border); max-height: 50%; }
-      .bottom-pane .bp-body { font-size: 0.68rem; }
+      .bottom-pane .bp-body {
+        font-size: 0.68rem;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
+      }
       .split {
         grid-template-columns: 1fr;
         height: auto;
@@ -503,21 +651,33 @@
       }
       .list-panel, .work-panel {
         height: auto;
-        min-height: 180px;
+        min-height: 160px;
         max-height: none;
       }
-      .list-panel .lp-body { max-height: 40vh; }
-      .view.active { height: auto; display: block; }
-      .view.active > .form-grid {
-        grid-template-columns: 1fr;
+      .list-panel .lp-body {
+        max-height: 45vh;
+        overflow-y: auto;
+        -webkit-overflow-scrolling: touch;
       }
-      .view.active > .form-grid > .work-panel { height: auto; min-height: 200px; }
+      .view.active { height: auto; display: block; }
+      .view.active > .form-grid { grid-template-columns: 1fr; }
+      .view.active > .form-grid > .work-panel { height: auto; min-height: 180px; }
       .admin-row { grid-template-columns: 1fr; }
       .stats { grid-template-columns: repeat(2, 1fr); }
       .scope-grid { grid-template-columns: 1fr 1fr; max-height: 180px; }
       button, .nav-item, input, select, textarea { font-size: 16px; } /* prevent iOS zoom */
       input, select, textarea { padding: 10px; min-height: 42px; }
       label { margin-top: 10px; }
+      .ai-fab { bottom: calc(var(--bottom-h) + 12px + env(safe-area-inset-bottom, 0px)); }
+      .ai-drawer {
+        bottom: calc(var(--bottom-h) + 64px + env(safe-area-inset-bottom, 0px));
+        max-height: calc(100dvh - var(--top-h) - var(--nav-h) - 80px);
+      }
+    }
+
+    @media (max-width: 420px) {
+      .top #btnConnect { padding: 0 8px; }
+      .top .title { max-width: 88px; overflow: hidden; }
     }
   </style>
 </head>
@@ -620,11 +780,16 @@
     </div>
 
     <aside class="ctx" id="ctxRail">
-      <div class="ctx-head">Session context</div>
+      <div class="ctx-head">
+        <span class="ctx-drag" aria-hidden="true"></span>
+        <span>Session context</span>
+        <button type="button" class="ctx-close" id="ctxClose" title="Close context" aria-label="Close">✕</button>
+      </div>
       <div class="ctx-body" id="ctxBody">
         <div class="ctx-empty">Select a session to see details, claim/release, and interact.</div>
       </div>
     </aside>
+    <div class="ctx-backdrop hidden" id="ctxBackdrop" aria-hidden="true"></div>
 
     <footer class="bottom">
       <div class="bottom-pane">


### PR DESCRIPTION
## Summary
- **Fixed compact mobile header** — sticky top bar, safe-area, no wrap overflow; QR condensed
- **Nav** — horizontal swipe strip with scroll-snap (no cramped wrap)
- **Session context** — bottom sheet with touch scrolling (was fully hidden on mobile)
- Tap session or **Context** button to open; backdrop/✕ to close
- Docs dropdown max-height + scroll

## Test plan
- [ ] Phone: header stays one row, controls usable
- [ ] Swipe nav left/right easily
- [ ] Select session → context sheet opens and scrolls smoothly
- [ ] Desktop context rail unchanged