### PR TITLE
feat(ui): INKO branding + top-bar flyout chat

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Ops UI: `/ops` (admin UI loaded only after server-side admin token check)
 
 1. **Secure by default**: New installs must ship hardened (no public docs/OpenAPI, no wildcard CORS, MCP off until enabled, exec probe on, false-shell filter on).
 2. **External AI restriction**: MCP tools must remain allow-listed per token. No open-ended autonomous agent loops for external models.
-3. **Admin AI shielding**: Never feed raw session output into LLM prompts without `sanitize_untrusted()`. Keep capabilities allow-listed. Prefer offline/deterministic fallbacks when no LLM is configured.
+3. **Admin AI / INKO shielding**: Never feed raw session output into LLM prompts without `sanitize_untrusted()`. Keep capabilities and chat tools allow-listed. Prefer offline/deterministic fallbacks when no LLM is configured. No open-ended autonomous agent loops.
 4. **Determinism preference**: Templates, fixed prompts, single-step tools over free-form agentic planning.
 5. **Audit everything**: Operator, MCP, Admin AI, feature toggles, and admin UI loads go through the policy engine / audit trail.
 6. **No secrets in git**: Tokens, API keys, `data/`, `admin_token.txt`, `~/.config/squidc5/config.json` stay out of the repository.
@@ -181,7 +181,8 @@ sc5 tokens create <name> --scopes "a,b,c" [--mcp-tools "t1,t2"]
 sc5 tokens revoke <id>
 
 sc5 ai <capability> [--data "..."] [--llm <id>]
-# capabilities: payload_template | phishing_asset | doc_generate | shell_classify | recon_assist
+# capabilities: payload_template | phishing_asset | doc_generate | shell_classify | recon_assist | …
+# Ops UI INKO chat uses POST /api/v1/ai/chat (multi-turn + railed tools); CLI remains capability-oriented
 
 sc5 llm list
 sc5 llm add <name> <model> [--provider openai|xai] [--base-url URL] [--api-key KEY]
@@ -245,13 +246,17 @@ Beacon flow:
 - Deterministic single-tool preference; chain length limited by policy
 - Feature flag / settings: MCP **off by default**
 
-### Server-side Admin AI
+### Server-side Admin AI + INKO
 
-- BYO LLM (OpenAI-compatible, including xAI Grok at `https://api.x.ai/v1`)
-- Capabilities allow-list only
-- `sanitize_untrusted` on untrusted input
-- Offline fallback if no LLM configured
+**INKO** (Intelligent Neural Kinetic Operator) is the operator-facing neural chat surface on top of the sandboxed Admin AI stack.
+
+- BYO LLM (OpenAI-compatible, including xAI Grok at `https://api.x.ai/v1`); configure in Ops **Admin** or `sc5 llm add`
+- Capabilities allow-list only (`POST /api/v1/ai/run`); chat tools allow-list (`POST /api/v1/ai/chat`)
+- `sanitize_untrusted` on untrusted input; tool results sanitized before model re-entry
+- Offline fallbacks when no LLM configured (deterministic intents + capability offline JSON)
+- Ops UI: top-bar **INKO** opens right flyout (full-screen mobile); nav **INKO** page for workspace chat
 - Status: `GET /api/v1/ai/status` (+ `?debug=true`) — **never returns API keys**
+- Tool catalog: `GET /api/v1/ai/tools` (names/descriptions only)
 
 ## Deployment Knowledge (Docker)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,15 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- **INKO** (Intelligent Neural Kinetic Operator): rebrand of ops neural operator chat
+- INKO opens from a **top-bar button** as a right flyout panel (full-screen on mobile); floating FAB removed
 - SOCKS5 **duplex**: direct mode + implant reverse-dial bridge (`socks:connect`)
 - Local Ollama path via `SQUIDC5_LOCAL_LLM_*` when no cloud LLM configured
 - README badges fixed (live CI + SquidGate workflow shields)
 - Docs index links to five-star roadmap + implant paths
+
+### Changed
+- Ops UI and chat system prompt use **INKO** naming; user guide / runbook / README updated
 
 ### Security / OPSEC
 - Native agent remains AEAD-only with full TLS verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/).
 
 ### Changed
 - Ops UI and chat system prompt use **INKO** naming; user guide / runbook / README updated
+- INKO chat: **persisted history** (browser localStorage), clear input on send, pending indicator, block send while waiting, **markdown** rendering for assistant replies
 
 ### Security / OPSEC
 - Native agent remains AEAD-only with full TLS verify

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,9 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/).
 - Docs index links to five-star roadmap + implant paths
 
 ### Changed
-- Ops UI and chat system prompt use **INKO** naming; user guide / runbook / README updated
+- Ops UI and chat system prompt use **INKO** naming; user guide / runbook / README / AGENTS updated
 - INKO chat: **persisted history** (browser localStorage), clear input on send, pending indicator, block send while waiting, **markdown** rendering for assistant replies
+- Docs: INKO flyout UX, `/api/v1/ai/chat` + tools catalog, Admin LLM configure path
 
 ### Security / OPSEC
 - Native agent remains AEAD-only with full TLS verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,5 +16,5 @@ Also read:
 - Secure by default (no public docs/OpenAPI, no wildcard CORS, MCP off until enabled)
 - Admin UI only after server validates admin token (`/api/v1/ops/admin.js`)
 - No secrets in git
-- MCP allow-lists and Admin AI sandbox are non-negotiable
+- MCP allow-lists and Admin AI / INKO sandbox (capability + chat tools) are non-negotiable
 - Do not help with unauthorized access

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ Security-first, AI-native C5 teamserver for **authorized** red team and penetrat
 |--------|------|
 | **Command** | Tasking shells, beacons, native implants |
 | **Control** | Scoped tokens, policy, HITL, feature flags |
-| **Cognitive** | Sandboxed Admin AI + restricted MCP |
+| **Cognitive** | INKO (Intelligent Neural Kinetic Operator) + sandboxed Admin AI + restricted MCP |
 | **Collaborative** | Teams, handoff, per-operator audit |
 | **Coordination** | Profiles, OAST, timeline, reports |
 
 ## Features
 
 - **Scoped API tokens** + immutable audit hash chain (`sc5 audit-verify`)
-- **Dual AI** — MCP off by default; Admin AI with 15 allow-listed capabilities; optional local Ollama
+- **Dual AI** — MCP off by default; **INKO** neural operator chat + Admin AI (15 allow-listed capabilities); optional local Ollama
 - **Native implant** — `agents/sc5beacon` (Go): AEAD, sleep/jitter/kill/hours, files, SOCKS reverse-dial
 - **Implant factory** — `sc5 implants build` / `POST /api/v1/implants/build`
 - **Malleable transforms** — base64, prepend/append, xor, netbios + profile push
@@ -127,7 +127,7 @@ Docs: [agents/sc5beacon/README.md](agents/sc5beacon/README.md)
 | Engagement | `GET/PUT /api/v1/engagement` |
 | HITL | `GET /api/v1/policy/hitl` |
 | Audit verify | `GET /api/v1/audit/verify` |
-| Admin AI | `POST /api/v1/ai/run` |
+| Admin AI / INKO chat | `POST /api/v1/ai/run` · `POST /api/v1/ai/chat` |
 
 Auth: `Authorization: Bearer <token>`. **No public OpenAPI** on the server.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Security-first, AI-native C5 teamserver for **authorized** red team and penetrat
 - **File ops** — `file:list|read|write|delete` (+ chunk offset/length)
 - **Engagement ROE** — banned commands, end time, HITL file-write
 - **Multi-op collab** — session claim/lock, handoff packs, spectator, presence, team chat, per-op audit
-- **Ops console** — multi-page nav (Dashboard/Sessions/Listeners/Post-Ex/Collab/Admin), role layouts, workbench
+- **Ops console** — multi-page nav, mobile drawer, **INKO** top-bar flyout chat, resizable event/console dock
 - **Secure defaults** — TLS on, empty CORS (no null), no public OpenAPI, admin.js gated, MCP scoped+HITL, implant AEAD on all listeners
 
 - **Binary CI** — Linux/Windows server+CLI, native agents, SBOM
@@ -127,7 +127,9 @@ Docs: [agents/sc5beacon/README.md](agents/sc5beacon/README.md)
 | Engagement | `GET/PUT /api/v1/engagement` |
 | HITL | `GET /api/v1/policy/hitl` |
 | Audit verify | `GET /api/v1/audit/verify` |
-| Admin AI / INKO chat | `POST /api/v1/ai/run` · `POST /api/v1/ai/chat` |
+| INKO chat (ops) | `POST /api/v1/ai/chat` · `GET /api/v1/ai/tools` |
+| Admin AI capabilities | `POST /api/v1/ai/run` · `GET /api/v1/ai/status` |
+| LLM connections | `GET/POST /api/v1/llm` · `POST /api/v1/llm/models` |
 
 Auth: `Authorization: Bearer <token>`. **No public OpenAPI** on the server.
 
@@ -166,7 +168,7 @@ See [.env.example](.env.example). Prefix `SQUIDC5_`.
 ## Security model
 
 1. Deny by default · scoped tokens · server-side HITL  
-2. Admin AI capability allow-list + `sanitize_untrusted`  
+2. INKO / Admin AI: capability + chat-tool allow-lists, `sanitize_untrusted`, audited tool calls  
 3. Implant AEAD · no skip-verify in native agent  
 4. Audit chain + verify · engagement ROE  
 5. [SquidGate](https://github.com/SquidSec/SquidGate) on PRs  

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,8 +8,8 @@
 
 | Document | Description |
 |----------|-------------|
-| [User guide](user-guide.md) | Features, workflows, examples |
-| [Operator runbook](operator-runbook.md) | Day-2 shells, beacons, native implant |
+| [User guide](user-guide.md) | Features, workflows, examples (includes **INKO** neural operator) |
+| [Operator runbook](operator-runbook.md) | Day-2 shells, beacons, native implant, INKO chat |
 | [Deployment](deployment.md) | Binary prod + Docker lab + systemd |
 | [Threat model](threat-model.md) | Assets, adversaries, STRIDE |
 | [Vision](squidc5-vision.md) | Architecture |

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -78,17 +78,28 @@ sc5 tokens create ext-ai \
 
 ## INKO (Intelligent Neural Kinetic Operator)
 
-Ops UI: top-bar **INKO** opens the right flyout chat (full screen on mobile). Needs `ai:use` or `admin`.
+**INKO** is the ops neural operator (chat + railed C5 tools).
 
-Structured capabilities (CLI):
+Ops UI:
+
+1. Configure LLM under **Admin** (or `sc5 llm add …`) — optional; offline intents still work.
+2. Top-bar **INKO** → right flyout (full screen on mobile). Nav **INKO** page for full workspace.
+3. Needs `ai:use` or `admin`. Enter sends; Shift+Enter newline. Escape / backdrop closes flyout.
+4. Chat history is browser-local; tool calls are audited server-side (scopes + policy + HITL).
+
+Example asks: *“list sessions”*, *“setup reverse shell listener on 4444”*, *“show recent events”*.
+
+Structured capabilities (CLI / API — not the free-form chat box):
 
 ```bash
 sc5 ai recon_assist --data "windows domain host"
 sc5 ai shell_classify --data "uid=0(root)"
 sc5 ai payload_template --data "need bash http beacon"
+sc5 llm list
+sc5 llm add grok-prod grok-3 --provider xai --base-url https://api.x.ai/v1 --api-key "$XAI_KEY"
 ```
 
-Offline mode works without configured LLMs. Configure BYO LLM via `sc5 llm add ...`.
+REST: `POST /api/v1/ai/chat`, `POST /api/v1/ai/run`, `GET /api/v1/ai/tools`, `GET /api/v1/ai/status`.
 
 ## Observability
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -76,7 +76,11 @@ sc5 tokens create ext-ai \
   --mcp-tools "list_sessions,get_session,list_tasks,create_task,get_metrics"
 ```
 
-## Admin AI
+## INKO (Intelligent Neural Kinetic Operator)
+
+Ops UI: top-bar **INKO** opens the right flyout chat (full screen on mobile). Needs `ai:use` or `admin`.
+
+Structured capabilities (CLI):
 
 ```bash
 sc5 ai recon_assist --data "windows domain host"

--- a/docs/roadmap-2026-2027.md
+++ b/docs/roadmap-2026-2027.md
@@ -42,7 +42,7 @@ Never deploy WIP source or Docker rebuilds to production.
 
 ### 5. Deeper AI Integration (next-gen edge)
 
-- Admin AI task chaining under **policy rails** (HITL thresholds, max steps, capability allow-list)
+- **INKO** (Intelligent Neural Kinetic Operator) chat + Admin AI task chaining under **policy rails** (HITL thresholds, max steps, capability/tool allow-list)
 - Local LLM (Ollama / GGUF) for air-gapped ops
 - Anomaly detection on beacon behavior + remediation **suggestions**
 

--- a/docs/squidc5-vision.md
+++ b/docs/squidc5-vision.md
@@ -12,7 +12,7 @@
 
 SquidC5 is a professional, lightweight, **military-grade**, security-first, AI-native C5 / command-and-control framework under active development. It is designed open-source-ready from the first commit, with strong emphasis on **secure defaults**, AI restriction, determinism, auditability, and low resource usage.
 
-Hardened posture includes: no public API documentation surface, scoped tokens, server-gated admin UI, feature flags, false-shell filtering, shell exec verification, and dual AI controls (restricted MCP + sandboxed Admin AI).
+Hardened posture includes: no public API documentation surface, scoped tokens, server-gated admin UI, feature flags, false-shell filtering, shell exec verification, and dual AI controls (restricted MCP + sandboxed Admin AI / INKO).
 
 ## Dual AI Architecture
 
@@ -27,7 +27,9 @@ External AI agents connect using scoped API tokens and interact via the MCP-comp
 - Policy engine enforces `max_chain_length` (default 1)
 - All tool calls are audited
 
-### 2. Server-Side Admin AI (Internal Intelligence Layer)
+### 2. Server-Side Admin AI / INKO (Internal Intelligence Layer)
+
+**INKO** (Intelligent Neural Kinetic Operator) is the operator-facing neural chat surface on top of the sandboxed Admin AI stack.
 
 Administrators configure BYO LLM connections. The Admin AI supports limited capabilities:
 

--- a/docs/squidc5-vision.md
+++ b/docs/squidc5-vision.md
@@ -31,7 +31,7 @@ External AI agents connect using scoped API tokens and interact via the MCP-comp
 
 **INKO** (Intelligent Neural Kinetic Operator) is the operator-facing neural chat surface on top of the sandboxed Admin AI stack.
 
-Administrators configure BYO LLM connections. The Admin AI supports limited capabilities:
+Administrators configure BYO LLM connections (Ops **Admin** UI or CLI). **INKO** exposes multi-turn chat with railed C5 tools (`POST /api/v1/ai/chat`). The Admin AI also supports limited structured capabilities (`POST /api/v1/ai/run`):
 
 - `payload_template`
 - `phishing_asset`

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -13,7 +13,7 @@ This guide lives in the GitHub repository. It is **not** served by the C2 proces
 |--------|------------|
 | **Command** | Task shells and beacons; issue operator intent |
 | **Control** | Auth scopes, policy engine, listeners, feature kill-switches |
-| **Cognitive** | Admin AI (railed) + external MCP tools (allow-listed) |
+| **Cognitive** | INKO (Intelligent Neural Kinetic Operator) + Admin AI rails + external MCP tools (allow-listed) |
 | **Collaborative** | Teams, chat, handoff, shared ops console |
 | **Coordination** | C2 profiles, task queues, metrics, timeline, reports |
 
@@ -67,7 +67,7 @@ Operators use:
 - **Deterministic implants** — templates and fixed generators over free-form agent loops
 - **Auditability** — operator, AI, MCP, and feature changes go through policy/audit
 - **Port flexibility** — no hard requirement for 80/443
-- **Dual AI** — external models stay on allow-listed MCP tools; Admin AI stays capability-gated and sanitizes untrusted input
+- **Dual AI** — external models stay on allow-listed MCP tools; INKO / Admin AI stays capability-gated and sanitizes untrusted input
 
 ### High-level architecture
 
@@ -75,7 +75,7 @@ Operators use:
 Operator (CLI /ops)
     → API (scopes + policy)
         → Sessions / Tasks / Listeners / Payloads
-        → Admin AI (sandboxed) / MCP (allow-listed)
+        → INKO + Admin AI (sandboxed) / MCP (allow-listed)
         → SQLite data/ (local, never commit)
 Implants / reverse shells → Listeners → Sessions
 ```
@@ -98,7 +98,7 @@ Implants / reverse shells → Listeners → Sessions
 
 - **Tokens** `sc5_<urlsafe>` with scopes (`admin`, `sessions:read`, `shell:interact`, …)
 - **Admin UI code** (`console.js`) only after the server validates the token
-- **Admin AI** sanitizes untrusted input; capabilities are allow-listed
+- **INKO / Admin AI** sanitizes untrusted input; capabilities are allow-listed
 - **MCP** tools are per-token allow-listed; feature often off by default
 - **Public docs** hard-locked off on the running server
 
@@ -555,31 +555,40 @@ UI: **Metrics** / **Audit log** buttons dump JSON into the panel outbox.
 
 ---
 
-## Admin AI
+## INKO (Intelligent Neural Kinetic Operator)
 
 ### What
 
-Sandboxed, **allow-listed** AI capabilities on the server (not free-form agents). Capabilities are fixed functions (`recon_assist`, `shell_classify`, …) with structured inputs—not an open chat that can chain arbitrary tools.
+**INKO** is SquidC5's **Intelligent Neural Kinetic Operator**: the in-ops neural operator for chat-driven inspection and railed actions on the teamserver.
+
+- **UI:** **INKO** button in the top bar opens a right-side flyout panel (full screen on mobile).
+- **Chat:** talk to INKO to list sessions, spin listeners, triage events, and run allow-listed tools.
+- **Page:** Ops nav **INKO** still has the full AI workspace (status, tools list, page chat).
+- **Server:** same sandboxed Admin AI stack underneath (capability allow-list, `sanitize_untrusted`, audit).
+
+Structured Admin AI capabilities (`recon_assist`, `shell_classify`, …) remain available via API/CLI for deterministic jobs. INKO chat is the operator-facing surface.
 
 ### Why
 
-Assist recon notes, shell classification, payload hints, and engagement docs—without:
-
-- Feeding raw hostile session output into unconstrained agent loops  
-- Giving external models direct shell  
-- Shipping API keys back to browsers  
-
-Untrusted text is passed through `sanitize_untrusted` before prompts.
-
-**Phishing-related capabilities** exist only for **authorized** engagements (phishing simulations under ROE).  
-**Learn more:** [Grokpedia: phishing](https://grok.com/pedia/phishing)
+Red team ops need AI that lives *inside* the C5 with the same scopes and audit as humans—not a browser tab that never saw your HITL policy.
 
 ### How
 
-1. Configure an LLM under **LLM connections** (optional).
-2. Without LLM → offline/deterministic fallbacks still return structured guidance.
-3. Pick capability + input → **Run AI**.
-4. Review **Status** / **Debug** (never returns API keys).
+1. Configure a BYO LLM under **Admin** (optional). Offline fallbacks still work.
+2. Click **INKO** in the top bar (needs `ai:use` or `admin`).
+3. Pick an LLM connection in the flyout, ask INKO to inspect or act.
+4. Approve HITL when policy requires it. Review audit for tool calls.
+
+### Example (CLI capabilities)
+
+```bash
+sc5 ai recon_assist --data "windows domain, no creds yet"
+sc5 ai shell_classify --data "session looks like scanner"
+```
+
+### Admin AI (structured capabilities)
+
+Legacy name for the sandboxed capability runner behind INKO. Fixed functions with structured inputs (not an open agent loop).
 
 | Capability | Intent |
 |------------|--------|
@@ -589,12 +598,7 @@ Untrusted text is passed through `sanitize_untrusted` before prompts.
 | `phishing_asset` | Authorized phishing content assist |
 | `doc_generate` | Engagement documentation drafts |
 
-### Example
-
-```bash
-sc5 ai recon_assist --data "windows domain, no creds yet"
-sc5 ai shell_classify --data "session looks like scanner"
-```
+**Phishing-related capabilities** exist only for **authorized** engagements (phishing simulations under ROE).
 
 ---
 
@@ -606,7 +610,7 @@ BYO OpenAI-compatible endpoints (including xAI Grok) stored **server-side** in `
 
 ### Why
 
-Admin AI needs a model; keys must never return in status APIs or git.
+INKO / Admin AI need a model; keys must never return in status APIs or git.
 
 ### How
 
@@ -827,10 +831,10 @@ sc5 mcp tools
 sc5 mcp call list_sessions --args-json '{}'
 ```
 
-### Contrast: MCP vs Admin AI
+### Contrast: MCP vs INKO / Admin AI
 
-| | Admin AI | MCP |
-|--|----------|-----|
+| | INKO / Admin AI | MCP |
+|--|----------------|-----|
 | Who | Operators on the team server | External models / agents |
 | Gate | `ai:use` + capability allow-list | `mcp:connect` + per-tool allow-list |
 | Default | Offline fallback if no LLM | Often feature-off |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -5,8 +5,7 @@
 **Authorized red team / penetration testing only.**  
 This guide lives in the GitHub repository. It is **not** served by the C2 process (`/docs` on the server stays disabled).
 
-**Source of truth:** [docs/user-guide.md](https://github.com/DotNetRussell/SquidC5/blob/master/docs/user-guide.md) on branch `master`.
-
+**Source of truth:** [docs/user-guide.md](https://github.com/SquidSec/SquidC5/blob/master/docs/user-guide.md) on branch `master`.
 ### What C5 stands for
 
 | Pillar | In SquidC5 |
@@ -561,12 +560,14 @@ UI: **Metrics** / **Audit log** buttons dump JSON into the panel outbox.
 
 **INKO** is SquidC5's **Intelligent Neural Kinetic Operator**: the in-ops neural operator for chat-driven inspection and railed actions on the teamserver.
 
-- **UI:** **INKO** button in the top bar opens a right-side flyout panel (full screen on mobile).
-- **Chat:** talk to INKO to list sessions, spin listeners, triage events, and run allow-listed tools.
-- **Page:** Ops nav **INKO** still has the full AI workspace (status, tools list, page chat).
-- **Server:** same sandboxed Admin AI stack underneath (capability allow-list, `sanitize_untrusted`, audit).
+- **UI:** top-bar **INKO** opens a right-side flyout (~440px desktop; full width on mobile). Backdrop or **Escape** closes it.
+- **Chat:** multi-turn Q&A; Enter to send, Shift+Enter for newline; pending “Thinking…” while waiting.
+- **History:** kept in this browser (`localStorage`); Clear wipes the thread.
+- **Page:** Ops nav **INKO** is the full workspace (LLM picker, status, tools list, page chat).
+- **Markdown:** assistant replies render safely (escaped HTML; fenced code, links https-only).
+- **Server:** sandboxed Admin AI stack underneath — allow-listed chat tools, `sanitize_untrusted`, policy/scopes/HITL per tool, full audit.
 
-Structured Admin AI capabilities (`recon_assist`, `shell_classify`, …) remain available via API/CLI for deterministic jobs. INKO chat is the operator-facing surface.
+Structured Admin AI capabilities (`recon_assist`, `shell_classify`, …) remain available via API/CLI for deterministic jobs. **INKO chat** is the operator-facing surface.
 
 ### Why
 
@@ -574,10 +575,31 @@ Red team ops need AI that lives *inside* the C5 with the same scopes and audit a
 
 ### How
 
-1. Configure a BYO LLM under **Admin** (optional). Offline fallbacks still work.
+1. Configure a BYO LLM under **Admin** → Configure LLM (or `sc5 llm add`). Optional — offline intents still handle phrases like “list sessions” / “setup reverse shell on 4444”.
 2. Click **INKO** in the top bar (needs `ai:use` or `admin`).
-3. Pick an LLM connection in the flyout, ask INKO to inspect or act.
-4. Approve HITL when policy requires it. Review audit for tool calls.
+3. Pick an LLM connection, ask INKO to inspect or act.
+4. Approve HITL when policy requires it. Review audit for `ai.chat.tool.*` / `ai.admin.chat`.
+
+### Chat API
+
+```http
+POST /api/v1/ai/chat
+Authorization: Bearer <token with ai:use|admin>
+Content-Type: application/json
+
+{
+  "message": "Setup a reverse shell listener on 4444 and start it",
+  "history": [{"role": "user", "content": "…"}, {"role": "assistant", "content": "…"}],
+  "llm_id": optional,
+  "max_rounds": 6
+}
+```
+
+Response includes `reply`, `mode` (`llm`|`offline`), and `tool_trace` (which railed tools ran).
+
+Tool catalog (no secrets): `GET /api/v1/ai/tools`.
+
+Railed tools include (scopes + policy enforced): `list_sessions`, `get_session`, `list_listeners`, `create_listener`, `start_listener`, `stop_listener`, `list_tasks`, `create_task`, `generate_payload`, `get_metrics`, `list_recent_events`, `list_audit`, `interact_shell` (HITL when required), and related helpers.
 
 ### Example (CLI capabilities)
 
@@ -588,7 +610,7 @@ sc5 ai shell_classify --data "session looks like scanner"
 
 ### Admin AI (structured capabilities)
 
-Legacy name for the sandboxed capability runner behind INKO. Fixed functions with structured inputs (not an open agent loop).
+Server name for the sandboxed **capability runner** behind INKO (`POST /api/v1/ai/run`). Fixed functions with structured inputs — not an open agent loop.
 
 | Capability | Intent |
 |------------|--------|
@@ -597,6 +619,7 @@ Legacy name for the sandboxed capability runner behind INKO. Fixed functions wit
 | `payload_template` | Template guidance |
 | `phishing_asset` | Authorized phishing content assist |
 | `doc_generate` | Engagement documentation drafts |
+| `session_triage` / `task_suggest` / `opsec_review` / … | See full allow-list in product |
 
 **Phishing-related capabilities** exist only for **authorized** engagements (phishing simulations under ROE).
 
@@ -614,12 +637,17 @@ INKO / Admin AI need a model; keys must never return in status APIs or git.
 
 ### How
 
+**Ops UI:** **Admin** → Configure LLM (provider presets: xAI, OpenAI, Groq, OpenRouter, Ollama, …). Paste API key → **Refresh models** (server proxies `/models`, SSRF-guarded). Keys encrypted at rest; never returned by API.
+
+**CLI:**
+
 ```bash
-sc5 llm add grok-prod grok-4 --provider xai --base-url https://api.x.ai/v1 --api-key "$XAI_KEY"
+sc5 llm add grok-prod grok-3 --provider xai --base-url https://api.x.ai/v1 --api-key "$XAI_KEY"
 sc5 llm list
 ```
 
-Status: `GET /api/v1/ai/status` shows provider/model presence, **not** the key.
+Status: `GET /api/v1/ai/status` shows provider/model presence, **not** the key.  
+Models probe: `POST /api/v1/llm/models` (admin / `llm:manage` only).
 
 ---
 

--- a/src/squidc5/ai/ops_tools.py
+++ b/src/squidc5/ai/ops_tools.py
@@ -266,8 +266,8 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
     },
 ]
 
-CHAT_SYSTEM_PROMPT = """You are INK — SquidC5's neural operator assistant for this C5 (Command, Control, Cognitive, Collaborative, Coordination) teamserver.
-When referring to yourself, use the name INK.
+CHAT_SYSTEM_PROMPT = """You are INKO (Intelligent Neural Kinetic Operator) — SquidC5's neural operator assistant for this C5 (Command, Control, Cognitive, Collaborative, Coordination) teamserver.
+When referring to yourself, use the name INKO.
 
 You can:
 1) Answer general security/ops questions clearly and helpfully.

--- a/tests/test_inko_branding.py
+++ b/tests/test_inko_branding.py
@@ -1,0 +1,15 @@
+"""INKO (Intelligent Neural Kinetic Operator) branding in chat system prompt."""
+
+from squidc5.ai.ops_tools import CHAT_SYSTEM_PROMPT
+
+
+def test_chat_system_prompt_uses_inko_name() -> None:
+    assert "INKO" in CHAT_SYSTEM_PROMPT
+    assert "Intelligent Neural Kinetic Operator" in CHAT_SYSTEM_PROMPT
+    assert "use the name INKO" in CHAT_SYSTEM_PROMPT
+
+
+def test_chat_system_prompt_does_not_use_legacy_ink_alone() -> None:
+    # Avoid regressing to short brand "INK" as the operator name.
+    assert "You are INK " not in CHAT_SYSTEM_PROMPT
+    assert "name INK." not in CHAT_SYSTEM_PROMPT

--- a/tests/test_inko_md_render.py
+++ b/tests/test_inko_md_render.py
@@ -1,0 +1,79 @@
+"""Safety properties for INKO client markdown rendering (mirrors ops-admin.js)."""
+
+from __future__ import annotations
+
+import html
+import re
+
+
+def _escape_html(s: str) -> str:
+    return (
+        str(s)
+        .replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&#39;")
+    )
+
+
+def render_markdown_safe(src: str) -> str:
+    """Python mirror of web/ops-admin.js renderMarkdownSafe (subset for tests)."""
+    s = str(src or "").replace("\r\n", "\n")
+    fences: list[str] = []
+
+    def fence_repl(m: re.Match[str]) -> str:
+        lang, code = m.group(1), m.group(2)
+        i = len(fences)
+        lang_attr = f' class="language-{_escape_html(lang)}"' if lang else ""
+        fences.append(f"<pre><code{lang_attr}>{_escape_html(code.rstrip(chr(10)))}</code></pre>")
+        return f"\x00FENCE{i}\x00"
+
+    s = re.sub(r"```([a-zA-Z0-9_-]*)\n?([\s\S]*?)```", fence_repl, s)
+    s = _escape_html(s)
+    s = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", s)
+    s = re.sub(
+        r"\[([^\]]+)\]\((https?://[^)\s]+)\)",
+        r'<a href="\2" target="_blank" rel="noopener noreferrer">\1</a>',
+        s,
+    )
+    s = re.sub(r"^(#{1,4})\s+(.+)$", lambda m: f"<h{len(m.group(1))}>{m.group(2)}</h{len(m.group(1))}>", s, flags=re.M)
+    s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
+    s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
+    parts = []
+    for para in re.split(r"\n{2,}", s):
+        p = para.strip()
+        if not p:
+            continue
+        if re.match(r"^<(?:ul|ol|pre|h[1-4]|blockquote)", p):
+            parts.append(p)
+        else:
+            parts.append(f"<p>{p.replace(chr(10), '<br>')}</p>")
+    s = "".join(parts)
+    s = re.sub(r"\x00FENCE(\d+)\x00", lambda m: fences[int(m.group(1))], s)
+    return s
+
+
+def test_raw_html_is_escaped() -> None:
+    out = render_markdown_safe('<script>alert(1)</script> **bold**')
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+    assert "<strong>bold</strong>" in out
+
+
+def test_fenced_code_escaped() -> None:
+    out = render_markdown_safe("```js\n<script>x</script>\n```")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+    assert "<pre><code" in out
+
+
+def test_link_http_only() -> None:
+    out = render_markdown_safe("[x](https://example.com/a) [bad](javascript:alert(1))")
+    assert 'href="https://example.com/a"' in out
+    assert "href=\"javascript:" not in out
+    assert "href='javascript:" not in out
+
+
+def test_escape_html_helper() -> None:
+    assert _escape_html("<a>") == html.escape("<a>", quote=True).replace("&#x27;", "&#39;")

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1088,9 +1088,226 @@
   }
 
   /* —— Admin —— */
-  /* —— AI tab —— */
-  /** Multi-turn chat history for Admin AI (user/assistant text only) */
-  let aiChatHistory = [];
+  /* —— AI / INKO tab —— */
+  const AI_HIST_KEY = "sc5_inko_chat_v1";
+  const AI_HIST_MAX = 40;
+  let aiBusy = false;
+
+  function loadAiHistory() {
+    try {
+      const raw = localStorage.getItem(AI_HIST_KEY);
+      if (!raw) return [];
+      const arr = JSON.parse(raw);
+      if (!Array.isArray(arr)) return [];
+      return arr
+        .filter((m) => m && (m.role === "user" || m.role === "assistant") && typeof m.content === "string")
+        .slice(-AI_HIST_MAX);
+    } catch (_) {
+      return [];
+    }
+  }
+
+  function persistAiHistory() {
+    try {
+      localStorage.setItem(AI_HIST_KEY, JSON.stringify(aiChatHistory.slice(-AI_HIST_MAX)));
+    } catch (_) {}
+  }
+
+  function escapeHtml(s) {
+    return String(s ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#39;");
+  }
+
+  /** Minimal safe markdown → HTML (escape first; no raw HTML passthrough). */
+  function renderMarkdownSafe(src) {
+    let s = String(src ?? "").replace(/\r\n/g, "\n");
+    const fences = [];
+    s = s.replace(/```([a-zA-Z0-9_-]*)\n?([\s\S]*?)```/g, (_, lang, code) => {
+      const i = fences.length;
+      fences.push(
+        `<pre><code${lang ? ` class="language-${escapeHtml(lang)}"` : ""}>${escapeHtml(code.replace(/\n$/, ""))}</code></pre>`
+      );
+      return `\u0000FENCE${i}\u0000`;
+    });
+    s = escapeHtml(s);
+    s = s.replace(/`([^`\n]+)`/g, "<code>$1</code>");
+    s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    s = s.replace(/^(#{1,4})\s+(.+)$/gm, (_, h, t) => `<h${h.length}>${t}</h${h.length}>`);
+    s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
+    s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
+    s = s.replace(/^&gt;\s?(.+)$/gm, "<blockquote>$1</blockquote>");
+    // unordered lists
+    s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+?/gm, (block) => {
+      const items = block.trim().split("\n").map((line) => line.replace(/^[-*+]\s+/, "").trim());
+      return `<ul>${items.map((i) => `<li>${i}</li>`).join("")}</ul>`;
+    });
+    // ordered lists
+    s = s.replace(/(?:^\d+\.\s+.+(?:\n|$))+?/gm, (block) => {
+      const items = block.trim().split("\n").map((line) => line.replace(/^\d+\.\s+/, "").trim());
+      return `<ol>${items.map((i) => `<li>${i}</li>`).join("")}</ol>`;
+    });
+    s = s
+      .split(/\n{2,}/)
+      .map((para) => {
+        if (/^<(?:ul|ol|pre|h[1-4]|blockquote)/.test(para.trim())) return para;
+        return `<p>${para.replace(/\n/g, "<br>")}</p>`;
+      })
+      .join("");
+    s = s.replace(/\u0000FENCE(\d+)\u0000/g, (_, i) => fences[Number(i)] || "");
+    return s;
+  }
+
+  // Expose for light automated checks / console
+  window.__SC5_renderMarkdownSafe = renderMarkdownSafe;
+
+  let aiChatHistory = loadAiHistory();
+
+  function setAiBusy(busy) {
+    aiBusy = !!busy;
+    document.body.classList.toggle("ai-busy", aiBusy);
+    ["aiRun", "aiSendGlobal"].forEach((id) => {
+      const n = el(id);
+      if (!n) return;
+      n.disabled = aiBusy;
+      n.classList.toggle("ai-send-busy", aiBusy);
+    });
+  }
+
+  function showAiPending() {
+    removeAiPending();
+    const make = (parent) => {
+      if (!parent) return null;
+      const div = document.createElement("div");
+      div.className = "ai-msg bot pending";
+      div.dataset.aiPending = "1";
+      div.innerHTML =
+        '<div class="who">INKO</div><div class="ai-typing"><span class="ai-typing-dots" aria-hidden="true"><span></span><span></span><span></span></span><span>Thinking…</span></div>';
+      parent.appendChild(div);
+      parent.scrollTop = parent.scrollHeight;
+      return div;
+    };
+    make(el("aiChatLog"));
+    make(el("aiPageLog"));
+  }
+
+  function removeAiPending() {
+    document.querySelectorAll('[data-ai-pending="1"]').forEach((n) => n.remove());
+  }
+
+  function appendAiChat(who, text, toolTrace) {
+    const log = el("aiChatLog");
+    const page = el("aiPageLog");
+    const make = (parent) => {
+      if (!parent) return;
+      const div = document.createElement("div");
+      div.className = "ai-msg " + (who === "user" ? "user" : "bot");
+      const w = document.createElement("div");
+      w.className = "who";
+      w.textContent = who === "user" ? "You" : "INKO";
+      const b = document.createElement("div");
+      b.className = "body";
+      if (who === "user") {
+        b.style.whiteSpace = "pre-wrap";
+        b.textContent = text;
+      } else {
+        b.innerHTML = renderMarkdownSafe(text);
+      }
+      div.appendChild(w);
+      div.appendChild(b);
+      if (toolTrace && toolTrace.length) {
+        const row = document.createElement("div");
+        row.className = "tools-used";
+        toolTrace.forEach((t) => {
+          const chip = document.createElement("span");
+          chip.className = "tool-chip " + (t.ok ? "ok" : "bad");
+          chip.textContent = (t.ok ? "✓ " : "✗ ") + (t.tool || "?") + (t.summary ? " · " + t.summary : "");
+          row.appendChild(chip);
+        });
+        div.appendChild(row);
+      }
+      parent.appendChild(div);
+      parent.scrollTop = parent.scrollHeight;
+    };
+    make(log);
+    make(page);
+  }
+
+  function rebuildAiChatDom() {
+    if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
+    if (el("aiPageLog")) el("aiPageLog").innerHTML = "";
+    aiChatHistory.forEach((m) => {
+      const who = m.role === "user" ? "user" : "bot";
+      appendAiChat(who, m.content, m.tools || null);
+    });
+  }
+
+  function clearAiChat() {
+    if (aiBusy) return showError("Wait for INKO to finish");
+    aiChatHistory = [];
+    persistAiHistory();
+    removeAiPending();
+    if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
+    if (el("aiPageLog")) el("aiPageLog").innerHTML = "";
+    showOk("Chat cleared");
+  }
+
+  function syncAiPageLog() {
+    rebuildAiChatDom();
+  }
+
+  function takeInputValue(textareaId) {
+    const node = el(textareaId);
+    if (!node) return "";
+    const v = node.value || "";
+    node.value = "";
+    return v;
+  }
+
+  async function runAiChat(message) {
+    const text = (message || "").trim();
+    if (!text) return;
+    if (aiBusy) return showError("INKO is still responding");
+    setAiBusy(true);
+    appendAiChat("user", text);
+    aiChatHistory.push({ role: "user", content: text });
+    if (aiChatHistory.length > AI_HIST_MAX) aiChatHistory = aiChatHistory.slice(-AI_HIST_MAX);
+    persistAiHistory();
+    showAiPending();
+    try {
+      const body = {
+        message: text,
+        history: aiChatHistory.slice(0, -1),
+      };
+      const llm_id = selectedLlmId();
+      if (llm_id) body.llm_id = llm_id;
+      const r = await api("POST", "/api/v1/ai/chat", body);
+      const reply = (r && r.reply) || JSON.stringify(r, null, 2);
+      const tools = (r && r.tool_trace) || [];
+      removeAiPending();
+      appendAiChat("bot", reply, tools);
+      aiChatHistory.push({ role: "assistant", content: reply, tools: tools.length ? tools : undefined });
+      if (aiChatHistory.length > AI_HIST_MAX) aiChatHistory = aiChatHistory.slice(-AI_HIST_MAX);
+      persistAiHistory();
+      if (tools.some((t) => t.ok && /listener|session|task|payload/i.test(t.tool || ""))) {
+        if (window.__SC5_refresh) try { await window.__SC5_refresh(); } catch (_) {}
+      }
+      showOk(r.mode === "offline" ? "INKO (offline)" : "INKO replied");
+      return r;
+    } catch (e) {
+      const err = String(e.message || e);
+      showError(err);
+      removeAiPending();
+      appendAiChat("bot", "Error: " + err);
+      aiChatHistory.push({ role: "assistant", content: "Error: " + err });
+      persistAiHistory();
+    } finally {
+      setAiBusy(false);
+    }
+  }
 
   function renderAiView() {
     const root = el("view-ai");
@@ -1109,7 +1326,7 @@
           <p class="muted" style="font-size:0.78rem;margin:0 0 8px">
             Chat with the op. INKO inspects sessions, listeners, events, and runs railed actions
             (e.g. <em>"setup reverse shell on 4444"</em>). Configure models under <strong>Admin</strong>.
-            Use the <strong>INKO</strong> button in the top bar for the flyout panel.
+            Use the <strong>INKO</strong> button in the top bar for the flyout panel. History is kept in this browser.
           </p>
           <label>LLM connection</label>
           <select id="aiLlmPick"><option value="">Loading…</option></select>
@@ -1140,20 +1357,17 @@
       if (el("aiLlmGlobal") && el("aiLlmPick").value) el("aiLlmGlobal").value = el("aiLlmPick").value;
     };
     const sendPage = async () => {
-      const msg = (el("aiData") && el("aiData").value) || "";
+      if (aiBusy) return;
+      const msg = takeInputValue("aiData");
       if (!msg.trim()) return showError("Enter a message");
-      el("aiRun").disabled = true;
-      try {
-        await runAiChat(msg);
-        if (el("aiData")) el("aiData").value = "";
-      } finally { el("aiRun").disabled = false; }
+      await runAiChat(msg);
     };
     if (el("aiRun")) el("aiRun").onclick = sendPage;
     if (el("aiData")) {
       el("aiData").onkeydown = (e) => {
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
-          sendPage();
+          if (!aiBusy) sendPage();
         }
       };
     }
@@ -1173,7 +1387,8 @@
       } catch (e) { showError(String(e.message || e)); }
     };
     if (el("aiOpenDrawer")) el("aiOpenDrawer").onclick = () => openAiDrawer(true);
-    syncAiPageLog();
+    rebuildAiChatDom();
+    setAiBusy(aiBusy);
   }
 
   function selectedLlmId() {
@@ -1181,83 +1396,6 @@
       || (el("aiLlmGlobal") && el("aiLlmGlobal").value)
       || loadSel("sc5_ops_llm")
       || null;
-  }
-
-  async function runAiChat(message) {
-    const text = (message || "").trim();
-    if (!text) return;
-    appendAiChat("user", text);
-    aiChatHistory.push({ role: "user", content: text });
-    // keep history bounded
-    if (aiChatHistory.length > 24) aiChatHistory = aiChatHistory.slice(-24);
-    try {
-      const body = {
-        message: text,
-        history: aiChatHistory.slice(0, -1), // prior turns only
-      };
-      const llm_id = selectedLlmId();
-      if (llm_id) body.llm_id = llm_id;
-      const r = await api("POST", "/api/v1/ai/chat", body);
-      const reply = (r && r.reply) || JSON.stringify(r, null, 2);
-      const tools = (r && r.tool_trace) || [];
-      appendAiChat("bot", reply, tools);
-      aiChatHistory.push({ role: "assistant", content: reply });
-      if (tools.some((t) => t.ok && /listener|session|task|payload/i.test(t.tool || ""))) {
-        if (window.__SC5_refresh) try { await window.__SC5_refresh(); } catch (_) {}
-      }
-      showOk(r.mode === "offline" ? "INKO (offline)" : "INKO replied");
-      return r;
-    } catch (e) {
-      const err = String(e.message || e);
-      showError(err);
-      appendAiChat("bot", "Error: " + err);
-      aiChatHistory.push({ role: "assistant", content: "Error: " + err });
-    }
-  }
-
-
-  function appendAiChat(who, text, toolTrace) {
-    const log = el("aiChatLog");
-    const page = el("aiPageLog");
-    const make = (parent) => {
-      if (!parent) return;
-      const div = document.createElement("div");
-      div.className = "ai-msg " + (who === "user" ? "user" : "bot");
-      const w = document.createElement("div");
-      w.className = "who";
-      w.textContent = who === "user" ? "You" : "INKO";
-      const b = document.createElement("div");
-      b.style.whiteSpace = "pre-wrap";
-      b.textContent = text;
-      div.appendChild(w);
-      div.appendChild(b);
-      if (toolTrace && toolTrace.length) {
-        const row = document.createElement("div");
-        row.className = "tools-used";
-        toolTrace.forEach((t) => {
-          const chip = document.createElement("span");
-          chip.className = "tool-chip " + (t.ok ? "ok" : "bad");
-          chip.textContent = (t.ok ? "✓ " : "✗ ") + (t.tool || "?") + (t.summary ? " · " + t.summary : "");
-          row.appendChild(chip);
-        });
-        div.appendChild(row);
-      }
-      parent.appendChild(div);
-      parent.scrollTop = parent.scrollHeight;
-    };
-    make(log);
-    make(page);
-  }
-
-  function clearAiChat() {
-    aiChatHistory = [];
-    if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
-    if (el("aiPageLog")) el("aiPageLog").innerHTML = "";
-    showOk("Chat cleared");
-  }
-
-  function syncAiPageLog() {
-    // page log is independent DOM; drawer keeps history via aiChatHistory display only on new msgs
   }
 
   function openAiDrawer(open) {
@@ -1279,6 +1417,7 @@
     }
     if (btn) btn.setAttribute("aria-expanded", show ? "true" : "false");
     if (show) {
+      rebuildAiChatDom();
       const ta = el("aiPromptGlobal");
       if (ta) setTimeout(() => { try { ta.focus(); } catch (_) {} }, 50);
     }
@@ -1297,6 +1436,8 @@
       openAiDrawer(false);
       return;
     }
+    if (!aiChatHistory.length) aiChatHistory = loadAiHistory();
+    rebuildAiChatDom();
     loadSavedLlms().then((llms) => {
       fillLlmSelect(el("aiLlmGlobal"), llms, loadSel("sc5_ops_llm") || "");
     });
@@ -1311,23 +1452,19 @@
       if (e.key === "Escape" && drawer.classList.contains("open")) openAiDrawer(false);
     });
     if (el("aiClearGlobal")) el("aiClearGlobal").onclick = () => clearAiChat();
-    if (el("aiSendGlobal")) el("aiSendGlobal").onclick = async () => {
-      const prompt = (el("aiPromptGlobal") && el("aiPromptGlobal").value) || "";
+    const sendGlobal = async () => {
+      if (aiBusy) return;
+      const prompt = takeInputValue("aiPromptGlobal");
       if (!prompt.trim()) return showError("Enter a message");
-      el("aiSendGlobal").disabled = true;
-      try {
-        await runAiChat(prompt);
-        if (el("aiPromptGlobal")) el("aiPromptGlobal").value = "";
-      } finally {
-        el("aiSendGlobal").disabled = false;
-      }
+      await runAiChat(prompt);
     };
-    // Enter to send (Shift+Enter newline)
+    if (el("aiSendGlobal")) el("aiSendGlobal").onclick = sendGlobal;
+    // Enter to send (Shift+Enter newline); input clears immediately via takeInputValue
     if (el("aiPromptGlobal")) {
       el("aiPromptGlobal").onkeydown = (e) => {
         if (e.key === "Enter" && !e.shiftKey) {
           e.preventDefault();
-          if (el("aiSendGlobal")) el("aiSendGlobal").click();
+          if (!aiBusy) sendGlobal();
         }
       };
     }

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -69,7 +69,8 @@
       { a: "hitl", t: "HITL queue" },
     ],
     ai: [
-      { a: "admin-ai", t: "INK" },
+      { a: "inko-intelligent-neural-kinetic-operator", t: "INKO" },
+      { a: "admin-ai", t: "Admin AI (legacy anchor)" },
       { a: "llm-connections", t: "LLM connections" },
     ],
     observe: [
@@ -1095,31 +1096,32 @@
     const root = el("view-ai");
     if (!root) return;
     if (!can("ai:use") && !can("admin")) {
-      root.innerHTML = `<div class="empty-state"><strong>INK locked</strong>Need <code>ai:use</code> scope.</div>`;
+      root.innerHTML = `<div class="empty-state"><strong>INKO locked</strong>Need <code>ai:use</code> scope.</div>`;
       return;
     }
     root.innerHTML = `
       <div class="work-panel" style="min-height:min(70vh,640px);display:flex;flex-direction:column">
-        <div class="wp-head">
-          <span class="ink-brand">◈ INK</span>
-          <span class="muted" style="margin-left:8px;font-size:0.75rem;font-weight:500;text-transform:none;letter-spacing:0">neural operator</span>
+        <div class="wp-head" style="flex-wrap:wrap;gap:6px">
+          <span class="inko-brand">◈ INKO</span>
+          <span class="muted" style="margin-left:4px;font-size:0.75rem;font-weight:600;text-transform:none;letter-spacing:0">Intelligent Neural Kinetic Operator</span>
         </div>
         <div class="wp-body" style="display:flex;flex-direction:column;flex:1;min-height:0">
           <p class="muted" style="font-size:0.78rem;margin:0 0 8px">
-            Chat with the op. INK inspects sessions, listeners, events, and runs railed actions
-            (e.g. <em>“setup reverse shell on 4444”</em>). Configure models under <strong>Admin</strong>.
+            Chat with the op. INKO inspects sessions, listeners, events, and runs railed actions
+            (e.g. <em>"setup reverse shell on 4444"</em>). Configure models under <strong>Admin</strong>.
+            Use the <strong>INKO</strong> button in the top bar for the flyout panel.
           </p>
           <label>LLM connection</label>
           <select id="aiLlmPick"><option value="">Loading…</option></select>
           <div id="aiPageLog" class="outbox" style="flex:1;max-height:none;min-height:220px;margin-top:10px"></div>
           <label style="margin-top:10px">Message</label>
-          <textarea id="aiData" rows="3" placeholder="Talk to INK… Enter to send, Shift+Enter for newline"></textarea>
+          <textarea id="aiData" rows="3" placeholder="Talk to INKO… Enter to send, Shift+Enter for newline"></textarea>
           <div class="row">
             <button type="button" class="primary" id="aiRun">Send</button>
             <button type="button" id="aiClearPage">Clear</button>
             <button type="button" id="aiStatus">Status</button>
             <button type="button" id="aiTools">Tools</button>
-            <button type="button" id="aiOpenDrawer">Pop-out</button>
+            <button type="button" id="aiOpenDrawer">Open flyout</button>
           </div>
           <div class="outbox empty hidden" id="aiOut">—</div>
         </div>
@@ -1203,7 +1205,7 @@
       if (tools.some((t) => t.ok && /listener|session|task|payload/i.test(t.tool || ""))) {
         if (window.__SC5_refresh) try { await window.__SC5_refresh(); } catch (_) {}
       }
-      showOk(r.mode === "offline" ? "INK (offline)" : "INK replied");
+      showOk(r.mode === "offline" ? "INKO (offline)" : "INKO replied");
       return r;
     } catch (e) {
       const err = String(e.message || e);
@@ -1223,7 +1225,7 @@
       div.className = "ai-msg " + (who === "user" ? "user" : "bot");
       const w = document.createElement("div");
       w.className = "who";
-      w.textContent = who === "user" ? "You" : "INK";
+      w.textContent = who === "user" ? "You" : "INKO";
       const b = document.createElement("div");
       b.style.whiteSpace = "pre-wrap";
       b.textContent = text;
@@ -1260,19 +1262,39 @@
 
   function openAiDrawer(open) {
     const d = el("aiDrawer");
+    const backdrop = el("aiBackdrop");
+    const btn = el("btnInko");
     if (!d) return;
-    if (open === false) d.classList.add("hidden");
-    else d.classList.toggle("hidden", open == null ? !d.classList.contains("hidden") : !open);
+    let show;
+    if (open === false) show = false;
+    else if (open === true) show = true;
+    else show = d.classList.contains("hidden") || !d.classList.contains("open");
+    d.classList.toggle("hidden", !show);
+    d.classList.toggle("open", show);
+    d.setAttribute("aria-hidden", show ? "false" : "true");
+    if (backdrop) {
+      backdrop.hidden = !show;
+      backdrop.classList.toggle("show", show);
+      backdrop.setAttribute("aria-hidden", show ? "false" : "true");
+    }
+    if (btn) btn.setAttribute("aria-expanded", show ? "true" : "false");
+    if (show) {
+      const ta = el("aiPromptGlobal");
+      if (ta) setTimeout(() => { try { ta.focus(); } catch (_) {} }, 50);
+    }
   }
 
   function setupGlobalAi() {
-    const fab = el("aiFab");
+    const btn = el("btnInko");
     const drawer = el("aiDrawer");
-    if (!fab || !drawer) return;
+    const backdrop = el("aiBackdrop");
+    if (!btn || !drawer) return;
     const allowed = can("ai:use") || can("admin");
-    fab.classList.toggle("hidden", !allowed);
+    btn.classList.toggle("hidden", !allowed);
+    btn.setAttribute("aria-expanded", "false");
+    btn.setAttribute("aria-controls", "aiDrawer");
     if (!allowed) {
-      drawer.classList.add("hidden");
+      openAiDrawer(false);
       return;
     }
     loadSavedLlms().then((llms) => {
@@ -1282,8 +1304,12 @@
       saveSel("sc5_ops_llm", el("aiLlmGlobal").value || "");
       if (el("aiLlmPick") && el("aiLlmGlobal").value) el("aiLlmPick").value = el("aiLlmGlobal").value;
     };
-    fab.onclick = () => openAiDrawer();
+    btn.onclick = () => openAiDrawer();
     if (el("aiDrawerClose")) el("aiDrawerClose").onclick = () => openAiDrawer(false);
+    if (backdrop) backdrop.onclick = () => openAiDrawer(false);
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "Escape" && drawer.classList.contains("open")) openAiDrawer(false);
+    });
     if (el("aiClearGlobal")) el("aiClearGlobal").onclick = () => clearAiChat();
     if (el("aiSendGlobal")) el("aiSendGlobal").onclick = async () => {
       const prompt = (el("aiPromptGlobal") && el("aiPromptGlobal").value) || "";

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -547,7 +547,31 @@
     .ai-msg { margin-bottom: 10px; padding: 8px 10px; border-radius: 8px; line-height: 1.45; }
     .ai-msg.user { background: rgba(255,255,255,0.04); border: 1px solid var(--border); }
     .ai-msg.bot { background: rgba(233,30,140,0.08); border: 1px solid rgba(233,30,140,0.25); }
+    .ai-msg.pending { opacity: 0.95; }
     .ai-msg .who { font-size: 0.65rem; color: var(--muted); text-transform: uppercase; margin-bottom: 4px; }
+    .ai-msg .body { word-break: break-word; }
+    .ai-msg .body p { margin: 0 0 0.55em; }
+    .ai-msg .body p:last-child { margin-bottom: 0; }
+    .ai-msg .body ul, .ai-msg .body ol { margin: 0.35em 0 0.55em 1.2em; padding: 0; }
+    .ai-msg .body li { margin: 0.15em 0; }
+    .ai-msg .body pre {
+      margin: 0.45em 0; padding: 8px 10px; border-radius: 8px; overflow: auto;
+      background: rgba(0,0,0,0.35); border: 1px solid var(--border);
+      font-family: var(--mono); font-size: 0.75rem; line-height: 1.4;
+    }
+    .ai-msg .body code {
+      font-family: var(--mono); font-size: 0.78em;
+      background: rgba(255,255,255,0.06); padding: 0.1em 0.35em; border-radius: 4px;
+    }
+    .ai-msg .body pre code { background: none; padding: 0; font-size: inherit; }
+    .ai-msg .body a { color: var(--pink2); }
+    .ai-msg .body h1, .ai-msg .body h2, .ai-msg .body h3, .ai-msg .body h4 {
+      margin: 0.6em 0 0.35em; font-size: 0.95em; line-height: 1.3;
+    }
+    .ai-msg .body blockquote {
+      margin: 0.4em 0; padding: 0.25em 0 0.25em 0.75em;
+      border-left: 3px solid rgba(233,30,140,0.45); color: var(--muted);
+    }
     .ai-msg .tools-used {
       margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px;
     }
@@ -557,6 +581,28 @@
     }
     .ai-msg .tool-chip.ok { color: var(--ok); border-color: rgba(52,211,153,0.35); }
     .ai-msg .tool-chip.bad { color: var(--bad); border-color: rgba(248,113,113,0.35); }
+    .ai-typing {
+      display: inline-flex; align-items: center; gap: 8px;
+      color: var(--muted); font-size: 0.8rem;
+    }
+    .ai-typing-dots {
+      display: inline-flex; gap: 4px; align-items: center;
+    }
+    .ai-typing-dots span {
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--pink2); opacity: 0.35;
+      animation: ai-bounce 1s infinite ease-in-out;
+    }
+    .ai-typing-dots span:nth-child(2) { animation-delay: 0.15s; }
+    .ai-typing-dots span:nth-child(3) { animation-delay: 0.3s; }
+    @keyframes ai-bounce {
+      0%, 80%, 100% { opacity: 0.3; transform: translateY(0); }
+      40% { opacity: 1; transform: translateY(-3px); }
+    }
+    .ai-busy .inko-top-btn,
+    button.ai-send-busy:disabled {
+      opacity: 0.65; cursor: wait;
+    }
     .ai-drawer-foot {
       border-top: 1px solid var(--border); padding: 8px; display: flex; flex-direction: column; gap: 6px;
       flex-shrink: 0;

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -325,7 +325,16 @@
       color: #c4c4d0; white-space: pre-wrap; word-break: break-word;
       min-height: 0;
     }
-    .ink-brand {
+    .inko-brand, .ink-brand {
+      background: linear-gradient(90deg, var(--pink2), var(--purple));
+      -webkit-background-clip: text; background-clip: text;
+      color: transparent; font-weight: 800; letter-spacing: 0.04em;
+    }
+    .inko-brand-full {
+      font-weight: 700; font-size: 0.78rem; letter-spacing: 0.01em;
+      color: var(--text);
+    }
+    .inko-brand-full .inko-acronym {
       background: linear-gradient(90deg, var(--pink2), var(--purple));
       -webkit-background-clip: text; background-clip: text;
       color: transparent; font-weight: 800; letter-spacing: 0.04em;
@@ -497,27 +506,41 @@
     }
     .docs-menu a:hover { background: rgba(233,30,140,0.15); color: var(--pink2); }
 
-    /* Global AI FAB + drawer */
-    .ai-fab {
-      position: fixed; right: 18px; bottom: calc(var(--bottom-h) + 16px); z-index: 40;
-      width: auto; min-width: 72px; height: 44px; border-radius: 999px;
-      background: rgba(233,30,140,0.25); border: 1px solid rgba(233,30,140,0.55);
-      color: var(--pink2); font-weight: 800; box-shadow: 0 8px 24px rgba(0,0,0,0.4);
+    /* INKO top-bar button + right flyout panel (not floating FAB) */
+    .inko-top-btn {
+      background: rgba(233,30,140,0.18); border-color: rgba(233,30,140,0.5);
+      color: var(--pink2); font-weight: 800; letter-spacing: 0.04em;
     }
-    .ai-fab:hover { background: rgba(233,30,140,0.4); }
+    .inko-top-btn:hover { background: rgba(233,30,140,0.32); }
+    .inko-top-btn.hidden { display: none !important; }
+    .ai-backdrop {
+      display: none; position: fixed; inset: 0; z-index: 58;
+      background: rgba(0,0,0,0.5);
+    }
+    .ai-backdrop.show { display: block; }
     .ai-drawer {
-      position: fixed; right: 16px; bottom: calc(var(--bottom-h) + 68px); z-index: 41;
-      width: min(440px, calc(100vw - 24px));
-      height: min(580px, calc(100dvh - var(--bottom-h) - 90px));
-      background: var(--bg2); border: 1px solid var(--border2); border-radius: 12px;
-      display: flex; flex-direction: column; box-shadow: 0 16px 48px rgba(0,0,0,0.5);
+      position: fixed; top: 0; right: 0; bottom: 0; z-index: 60;
+      width: min(440px, 100vw);
+      height: 100dvh; height: 100svh;
+      background: var(--bg2); border-left: 1px solid var(--border2); border-radius: 0;
+      display: flex; flex-direction: column;
+      box-shadow: -16px 0 48px rgba(0,0,0,0.45);
       overflow: hidden;
+      transform: translateX(100%);
+      transition: transform 0.2s ease;
+      pointer-events: none;
     }
-    .ai-drawer.hidden, .ai-fab.hidden { display: none !important; }
+    .ai-drawer.open {
+      transform: translateX(0);
+      pointer-events: auto;
+    }
+    .ai-drawer.hidden { display: none !important; }
     .ai-drawer-head {
-      display: flex; align-items: center; gap: 8px; padding: 8px 10px;
+      display: flex; align-items: flex-start; gap: 8px; padding: 12px 12px 10px;
       border-bottom: 1px solid var(--border); font-size: 0.85rem; flex-shrink: 0;
+      padding-top: calc(12px + env(safe-area-inset-top, 0px));
     }
+    .ai-drawer-head .inko-titles { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
     .ai-drawer-body {
       flex: 1; overflow: auto; padding: 10px; font-size: 0.82rem; min-height: 0;
     }
@@ -537,11 +560,14 @@
     .ai-drawer-foot {
       border-top: 1px solid var(--border); padding: 8px; display: flex; flex-direction: column; gap: 6px;
       flex-shrink: 0;
+      padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     }
     .ai-drawer-foot select, .ai-drawer-foot textarea { width: 100%; }
     @media (max-width: 900px) {
-      .ai-fab { bottom: 24px; right: 12px; }
-      .ai-drawer { bottom: 76px; right: 8px; left: 8px; width: auto; }
+      .ai-drawer {
+        width: 100vw; left: 0; right: 0;
+        border-left: none;
+      }
     }
 
     /* Mobile: fixed header + scrollable nav + context bottom-sheet */
@@ -774,11 +800,6 @@
       button, .nav-item, input, select, textarea { font-size: 16px; } /* prevent iOS zoom */
       input, select, textarea { padding: 10px; min-height: 42px; }
       label { margin-top: 10px; }
-      .ai-fab { bottom: calc(var(--bottom-h) + 12px + env(safe-area-inset-bottom, 0px)); }
-      .ai-drawer {
-        bottom: calc(var(--bottom-h) + 64px + env(safe-area-inset-bottom, 0px));
-        max-height: calc(100dvh - var(--top-h) - var(--nav-h) - 80px);
-      }
     }
 
     @media (max-width: 420px) {
@@ -801,6 +822,7 @@
       <div class="spacer"></div>
       <span class="pill" id="statusBadge">offline</span>
       <span class="pill live hidden" id="roleBadge">—</span>
+      <button type="button" id="btnInko" class="inko-top-btn hidden" title="INKO — Intelligent Neural Kinetic Operator">◈ INKO</button>
       <button type="button" id="btnPhoneQr" title="Phone QR — scan to open ops and auto-connect">Phone QR</button>
       <button type="button" id="btnConnect" title="Connection settings">Connect</button>
       <button type="button" id="btnRefresh" title="Refresh data">↻</button>
@@ -815,7 +837,7 @@
         <button type="button" class="nav-item" data-view="payloads"><span class="ico">⌘</span> Payloads</button>
         <button type="button" class="nav-item" data-view="postex"><span class="ico">⚡</span> Post-Ex</button>
         <button type="button" class="nav-item" data-view="collab"><span class="ico">⇄</span> Collab</button>
-        <button type="button" class="nav-item" data-view="ai" id="navAi"><span class="ico">◈</span> INK</button>
+        <button type="button" class="nav-item" data-view="ai" id="navAi"><span class="ico">◈</span> INKO</button>
         <button type="button" class="nav-item" data-view="observe"><span class="ico">▤</span> Observe</button>
         <button type="button" class="nav-item hidden" data-view="admin" id="navAdmin"><span class="ico">⚙</span> Admin</button>
       </div>
@@ -870,26 +892,28 @@
       </div>
     </main>
 
-    <!-- INK — SquidC5 neural operator (global) -->
-    <button type="button" id="aiFab" class="ai-fab hidden" title="INK — neural operator">◈ INK</button>
-    <div id="aiDrawer" class="ai-drawer hidden" aria-label="INK chat">
+    <!-- INKO — Intelligent Neural Kinetic Operator (top-bar flyout) -->
+    <div id="aiBackdrop" class="ai-backdrop" hidden aria-hidden="true"></div>
+    <aside id="aiDrawer" class="ai-drawer hidden" aria-label="INKO chat" aria-hidden="true">
       <div class="ai-drawer-head">
-        <strong class="ink-brand">◈ INK</strong>
-        <span class="muted" style="font-size:0.68rem;font-weight:500">neural operator</span>
-        <a class="doc-link" href="https://github.com/SquidSec/SquidC5/blob/master/docs/user-guide.md#admin-ai" target="_blank" rel="noopener noreferrer" style="font-size:0.7rem">Docs</a>
-        <button type="button" id="aiDrawerClose" style="margin-left:auto">✕</button>
+        <div class="inko-titles">
+          <strong class="inko-brand-full"><span class="inko-acronym">◈ INKO</span></strong>
+          <span class="muted" style="font-size:0.72rem;font-weight:600;line-height:1.25">Intelligent Neural Kinetic Operator</span>
+        </div>
+        <a class="doc-link" href="https://github.com/SquidSec/SquidC5/blob/master/docs/user-guide.md#inko-intelligent-neural-kinetic-operator" target="_blank" rel="noopener noreferrer" style="font-size:0.7rem;flex-shrink:0">Docs</a>
+        <button type="button" id="aiDrawerClose" style="margin-left:4px;flex-shrink:0" title="Close INKO" aria-label="Close INKO">✕</button>
       </div>
       <div class="ai-drawer-body" id="aiChatLog"></div>
       <div class="ai-drawer-foot">
         <select id="aiLlmGlobal" title="LLM connection"></select>
-        <textarea id="aiPromptGlobal" rows="3" placeholder="Ask INK anything — list sessions, spin up a listener…"></textarea>
+        <textarea id="aiPromptGlobal" rows="3" placeholder="Ask INKO anything - list sessions, spin up a listener…"></textarea>
         <div class="row" style="margin:0;gap:6px">
           <button type="button" class="primary" id="aiSendGlobal" style="flex:1">Send</button>
           <button type="button" id="aiClearGlobal" title="Clear chat">Clear</button>
         </div>
         <p class="muted" style="margin:0;font-size:0.62rem">Enter to send · Shift+Enter newline</p>
       </div>
-    </div>
+    </aside>
 
     <aside class="ctx" id="ctxRail">
       <div class="ctx-head">
@@ -1049,7 +1073,7 @@
     payloads: { title: "Payloads", sub: "Generate implants and templates", doc: "payloads-and-implants" },
     postex: { title: "Post-Ex", sub: "Files, SOCKS, modules on selected session", doc: "file-ops" },
     collab: { title: "Collab", sub: "Teams, chat, handoff, presence", doc: "multi-operator-collab" },
-    ai: { title: "INK", sub: "Neural operator — chat, inspect, and drive the C5", doc: "admin-ai" },
+    ai: { title: "INKO", sub: "Intelligent Neural Kinetic Operator — chat, inspect, and drive the C5", doc: "inko-intelligent-neural-kinetic-operator" },
     observe: { title: "Observe", sub: "Metrics, audit, timeline, reports", doc: "timeline-and-reports" },
     admin: { title: "Admin", sub: "Tokens, policy, features, LLM, MCP", doc: "feature-toggles" },
   };


### PR DESCRIPTION
## Summary
- Rebrand ops neural operator from **INK** to **INKO** (Intelligent Neural Kinetic Operator)
- Top-bar **INKO** button opens a right flyout panel (same ~440px width on desktop)
- Mobile flyout is full-screen; floating FAB removed
- Chat header spells out **Intelligent Neural Kinetic Operator**; system prompt + docs/README updated

## Test plan
- [x] `pytest tests/test_inko_branding.py`
- [x] Related AI chat tests pass
- [ ] Manual: connect ops UI, click top-bar INKO, confirm flyout + mobile full width
- [ ] Manual: Escape / backdrop closes panel