### PR TITLE
fix(ops): INKO catalog page, tables, copy, active beacons

### DIFF
--- a/tests/test_inko_md_render.py
+++ b/tests/test_inko_md_render.py
@@ -40,16 +40,62 @@ def render_markdown_safe(src: str) -> str:
     s = re.sub(r"^(#{1,4})\s+(.+)$", lambda m: f"<h{len(m.group(1))}>{m.group(2)}</h{len(m.group(1))}>", s, flags=re.M)
     s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
     s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
+    tables: list[str] = []
+
+    def _split_row(line: str) -> list[str]:
+        t = line.strip()
+        if t.startswith("|"):
+            t = t[1:]
+        if t.endswith("|"):
+            t = t[:-1]
+        return [c.strip() for c in t.split("|")]
+
+    def _is_sep(line: str) -> bool:
+        cells = _split_row(line)
+        return bool(cells) and all(re.fullmatch(r":?-{1,}:?", c or "") for c in cells)
+
+    def _table_repl(m: re.Match[str]) -> str:
+        lines = [ln.strip() for ln in m.group(0).strip().split("\n") if ln.strip()]
+        if len(lines) < 2:
+            return m.group(0)
+        header = _split_row(lines[0])
+        body_start = 2 if _is_sep(lines[1]) else 1
+        rows = [_split_row(ln) for ln in lines[body_start:] if not _is_sep(ln)]
+        if not header or not rows:
+            return m.group(0)
+        coln = len(header)
+
+        def norm(row: list[str]) -> list[str]:
+            r = row[:coln]
+            while len(r) < coln:
+                r.append("")
+            return r
+
+        th = "".join(f"<th>{c}</th>" for c in norm(header))
+        trs = "".join(
+            "<tr>" + "".join(f"<td>{c}</td>" for c in norm(r)) + "</tr>" for r in rows
+        )
+        i = len(tables)
+        tables.append(
+            f'<div class="md-table-wrap"><table class="md-table"><thead><tr>{th}</tr></thead>'
+            f"<tbody>{trs}</tbody></table></div>"
+        )
+        return f"\x00TABLE{i}\x00\n\n"
+
+    s = re.sub(r"(?:^[ \t]*\|.+\|[ \t]*\n){2,}", _table_repl, s, flags=re.M)
     parts = []
     for para in re.split(r"\n{2,}", s):
         p = para.strip()
         if not p:
             continue
-        if re.match(r"^<(?:ul|ol|pre|h[1-4]|blockquote)", p):
+        if re.match(r"^<(?:ul|ol|pre|h[1-4]|blockquote|div)", p):
+            parts.append(p)
+        elif re.fullmatch(r"\x00TABLE\d+\x00", p):
             parts.append(p)
         else:
             parts.append(f"<p>{p.replace(chr(10), '<br>')}</p>")
     s = "".join(parts)
+    s = re.sub(r"\x00TABLE(\d+)\x00", lambda m: tables[int(m.group(1))], s)
     s = re.sub(r"\x00FENCE(\d+)\x00", lambda m: fences[int(m.group(1))], s)
     return s
 
@@ -77,3 +123,19 @@ def test_link_http_only() -> None:
 
 def test_escape_html_helper() -> None:
     assert _escape_html("<a>") == html.escape("<a>", quote=True).replace("&#x27;", "&#39;")
+
+
+def test_gfm_table_renders() -> None:
+    md = (
+        "| What | Count |\n"
+        "|------|-------|\n"
+        "| Active beacons | 0 |\n"
+        "| Total closed | 6 |\n"
+    )
+    out = render_markdown_safe(md)
+    assert '<table class="md-table">' in out
+    assert "<th>What</th>" in out
+    assert "<th>Count</th>" in out
+    assert "<td>Active beacons</td>" in out
+    assert "<td>0</td>" in out
+    assert "|------|" not in out

--- a/tests/test_inko_md_render.py
+++ b/tests/test_inko_md_render.py
@@ -30,16 +30,6 @@ def render_markdown_safe(src: str) -> str:
         return f"\x00FENCE{i}\x00"
 
     s = re.sub(r"```([a-zA-Z0-9_-]*)\n?([\s\S]*?)```", fence_repl, s)
-    s = _escape_html(s)
-    s = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", s)
-    s = re.sub(
-        r"\[([^\]]+)\]\((https?://[^)\s]+)\)",
-        r'<a href="\2" target="_blank" rel="noopener noreferrer">\1</a>',
-        s,
-    )
-    s = re.sub(r"^(#{1,4})\s+(.+)$", lambda m: f"<h{len(m.group(1))}>{m.group(2)}</h{len(m.group(1))}>", s, flags=re.M)
-    s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
-    s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
     tables: list[str] = []
 
     def _split_row(line: str) -> list[str]:
@@ -53,6 +43,12 @@ def render_markdown_safe(src: str) -> str:
     def _is_sep(line: str) -> bool:
         cells = _split_row(line)
         return bool(cells) and all(re.fullmatch(r":?-{1,}:?", c or "") for c in cells)
+
+    def _cell_html(raw: str) -> str:
+        c = _escape_html(raw)
+        c = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", c)
+        c = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", c)
+        return c
 
     def _table_repl(m: re.Match[str]) -> str:
         lines = [ln.strip() for ln in m.group(0).strip().split("\n") if ln.strip()]
@@ -71,9 +67,9 @@ def render_markdown_safe(src: str) -> str:
                 r.append("")
             return r
 
-        th = "".join(f"<th>{c}</th>" for c in norm(header))
+        th = "".join(f"<th>{_cell_html(c)}</th>" for c in norm(header))
         trs = "".join(
-            "<tr>" + "".join(f"<td>{c}</td>" for c in norm(r)) + "</tr>" for r in rows
+            "<tr>" + "".join(f"<td>{_cell_html(c)}</td>" for c in norm(r)) + "</tr>" for r in rows
         )
         i = len(tables)
         tables.append(
@@ -83,6 +79,16 @@ def render_markdown_safe(src: str) -> str:
         return f"\x00TABLE{i}\x00\n\n"
 
     s = re.sub(r"(?:^[ \t]*\|.+\|[ \t]*\n){2,}", _table_repl, s, flags=re.M)
+    s = _escape_html(s)
+    s = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", s)
+    s = re.sub(
+        r"\[([^\]]+)\]\((https?://[^)\s]+)\)",
+        r'<a href="\2" target="_blank" rel="noopener noreferrer">\1</a>',
+        s,
+    )
+    s = re.sub(r"^(#{1,4})\s+(.+)$", lambda m: f"<h{len(m.group(1))}>{m.group(2)}</h{len(m.group(1))}>", s, flags=re.M)
+    s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
+    s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
     parts = []
     for para in re.split(r"\n{2,}", s):
         p = para.strip()
@@ -139,3 +145,10 @@ def test_gfm_table_renders() -> None:
     assert "<td>Active beacons</td>" in out
     assert "<td>0</td>" in out
     assert "|------|" not in out
+
+
+def test_table_cells_escape_html() -> None:
+    md = "| A | B |\n|---|---|\n| <script>x</script> | ok |\n"
+    out = render_markdown_safe(md)
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1126,6 +1126,7 @@
   function renderMarkdownSafe(src) {
     let s = String(src ?? "").replace(/\r\n/g, "\n");
     const fences = [];
+    const tables = [];
     s = s.replace(/```([a-zA-Z0-9_-]*)\n?([\s\S]*?)```/g, (_, lang, code) => {
       const i = fences.length;
       fences.push(
@@ -1140,6 +1141,38 @@
     s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
     s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
     s = s.replace(/^&gt;\s?(.+)$/gm, "<blockquote>$1</blockquote>");
+    // GFM tables (must run before list/paragraph splitting)
+    s = s.replace(/(?:^[ \t]*\|.+\|[ \t]*\n){2,}/gm, (block) => {
+      const lines = block.trim().split("\n").map((l) => l.trim()).filter(Boolean);
+      if (lines.length < 2) return block;
+      const splitRow = (line) => {
+        let t = line.trim();
+        if (t.startsWith("|")) t = t.slice(1);
+        if (t.endsWith("|")) t = t.slice(0, -1);
+        return t.split("|").map((c) => c.trim());
+      };
+      const isSep = (line) => {
+        const cells = splitRow(line);
+        return cells.length > 0 && cells.every((c) => /^:?-{1,}:?$/.test(c));
+      };
+      let header = splitRow(lines[0]);
+      let bodyStart = 1;
+      if (isSep(lines[1])) bodyStart = 2;
+      else if (lines.length >= 2 && isSep(lines[0])) return block;
+      const rows = lines.slice(bodyStart).filter((l) => !isSep(l)).map(splitRow);
+      if (!header.length || !rows.length) return block;
+      const coln = header.length;
+      const norm = (row) => {
+        const r = row.slice(0, coln);
+        while (r.length < coln) r.push("");
+        return r;
+      };
+      const th = norm(header).map((c) => `<th>${c}</th>`).join("");
+      const trs = rows.map((r) => `<tr>${norm(r).map((c) => `<td>${c}</td>`).join("")}</tr>`).join("");
+      const i = tables.length;
+      tables.push(`<div class="md-table-wrap"><table class="md-table"><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table></div>`);
+      return `\u0000TABLE${i}\u0000\n\n`;
+    });
     // unordered lists
     s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+?/gm, (block) => {
       const items = block.trim().split("\n").map((line) => line.replace(/^[-*+]\s+/, "").trim());
@@ -1153,10 +1186,14 @@
     s = s
       .split(/\n{2,}/)
       .map((para) => {
-        if (/^<(?:ul|ol|pre|h[1-4]|blockquote)/.test(para.trim())) return para;
+        const t = para.trim();
+        if (!t) return "";
+        if (/^<(?:ul|ol|pre|h[1-4]|blockquote|div)/.test(t)) return t;
+        if (/^\u0000TABLE\d+\u0000$/.test(t)) return t;
         return `<p>${para.replace(/\n/g, "<br>")}</p>`;
       })
       .join("");
+    s = s.replace(/\u0000TABLE(\d+)\u0000/g, (_, i) => tables[Number(i)] || "");
     s = s.replace(/\u0000FENCE(\d+)\u0000/g, (_, i) => fences[Number(i)] || "");
     return s;
   }
@@ -1179,19 +1216,16 @@
 
   function showAiPending() {
     removeAiPending();
-    const make = (parent) => {
-      if (!parent) return null;
-      const div = document.createElement("div");
-      div.className = "ai-msg bot pending";
-      div.dataset.aiPending = "1";
-      div.innerHTML =
-        '<div class="who">INKO</div><div class="ai-typing"><span class="ai-typing-dots" aria-hidden="true"><span></span><span></span><span></span></span><span>Thinking…</span></div>';
-      parent.appendChild(div);
-      parent.scrollTop = parent.scrollHeight;
-      return div;
-    };
-    make(el("aiChatLog"));
-    make(el("aiPageLog"));
+    const parent = el("aiChatLog");
+    if (!parent) return null;
+    const div = document.createElement("div");
+    div.className = "ai-msg bot pending";
+    div.dataset.aiPending = "1";
+    div.innerHTML =
+      '<div class="who">INKO</div><div class="ai-typing"><span class="ai-typing-dots" aria-hidden="true"><span></span><span></span><span></span></span><span>Thinking…</span></div>';
+    parent.appendChild(div);
+    parent.scrollTop = parent.scrollHeight;
+    return div;
   }
 
   function removeAiPending() {
@@ -1199,46 +1233,65 @@
   }
 
   function appendAiChat(who, text, toolTrace) {
-    const log = el("aiChatLog");
-    const page = el("aiPageLog");
-    const make = (parent) => {
-      if (!parent) return;
-      const div = document.createElement("div");
-      div.className = "ai-msg " + (who === "user" ? "user" : "bot");
-      const w = document.createElement("div");
-      w.className = "who";
-      w.textContent = who === "user" ? "You" : "INKO";
-      const b = document.createElement("div");
-      b.className = "body";
-      if (who === "user") {
-        b.style.whiteSpace = "pre-wrap";
-        b.textContent = text;
-      } else {
-        b.innerHTML = renderMarkdownSafe(text);
-      }
-      div.appendChild(w);
-      div.appendChild(b);
-      if (toolTrace && toolTrace.length) {
-        const row = document.createElement("div");
-        row.className = "tools-used";
-        toolTrace.forEach((t) => {
-          const chip = document.createElement("span");
-          chip.className = "tool-chip " + (t.ok ? "ok" : "bad");
-          chip.textContent = (t.ok ? "✓ " : "✗ ") + (t.tool || "?") + (t.summary ? " · " + t.summary : "");
-          row.appendChild(chip);
-        });
-        div.appendChild(row);
-      }
-      parent.appendChild(div);
-      parent.scrollTop = parent.scrollHeight;
-    };
-    make(log);
-    make(page);
+    const parent = el("aiChatLog");
+    if (!parent) return;
+    const div = document.createElement("div");
+    div.className = "ai-msg " + (who === "user" ? "user" : "bot");
+    const w = document.createElement("div");
+    w.className = "who";
+    w.textContent = who === "user" ? "You" : "INKO";
+    const b = document.createElement("div");
+    b.className = "body";
+    if (who === "user") {
+      b.style.whiteSpace = "pre-wrap";
+      b.textContent = text;
+    } else {
+      b.innerHTML = renderMarkdownSafe(text);
+    }
+    div.appendChild(w);
+    div.appendChild(b);
+    if (toolTrace && toolTrace.length) {
+      const row = document.createElement("div");
+      row.className = "tools-used";
+      toolTrace.forEach((t) => {
+        const chip = document.createElement("span");
+        chip.className = "tool-chip " + (t.ok ? "ok" : "bad");
+        chip.textContent = (t.ok ? "✓ " : "✗ ") + (t.tool || "?") + (t.summary ? " · " + t.summary : "");
+        row.appendChild(chip);
+      });
+      div.appendChild(row);
+    }
+    if (who !== "user") {
+      const actions = document.createElement("div");
+      actions.className = "ai-msg-actions";
+      const copyBtn = document.createElement("button");
+      copyBtn.type = "button";
+      copyBtn.className = "ai-copy-btn";
+      copyBtn.textContent = "Copy";
+      copyBtn.title = "Copy response to clipboard";
+      copyBtn.onclick = async (e) => {
+        e.stopPropagation();
+        try {
+          await navigator.clipboard.writeText(String(text || ""));
+          copyBtn.textContent = "Copied";
+          copyBtn.classList.add("copied");
+          setTimeout(() => {
+            copyBtn.textContent = "Copy";
+            copyBtn.classList.remove("copied");
+          }, 1600);
+        } catch (_) {
+          showError("Clipboard unavailable");
+        }
+      };
+      actions.appendChild(copyBtn);
+      div.appendChild(actions);
+    }
+    parent.appendChild(div);
+    parent.scrollTop = parent.scrollHeight;
   }
 
   function rebuildAiChatDom() {
     if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
-    if (el("aiPageLog")) el("aiPageLog").innerHTML = "";
     aiChatHistory.forEach((m) => {
       const who = m.role === "user" ? "user" : "bot";
       appendAiChat(who, m.content, m.tools || null);
@@ -1251,12 +1304,7 @@
     persistAiHistory();
     removeAiPending();
     if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
-    if (el("aiPageLog")) el("aiPageLog").innerHTML = "";
     showOk("Chat cleared");
-  }
-
-  function syncAiPageLog() {
-    rebuildAiChatDom();
   }
 
   function takeInputValue(textareaId) {
@@ -1316,31 +1364,55 @@
       root.innerHTML = `<div class="empty-state"><strong>INKO locked</strong>Need <code>ai:use</code> scope.</div>`;
       return;
     }
+    const CAP_CARDS = [
+      { t: "Sessions", d: "List / get beacons & reverse shells; triage live inventory." },
+      { t: "Listeners", d: "Create, start, stop reverse_shell / http / dns / smtp acceptors." },
+      { t: "Tasks", d: "Queue commands on beacons; inspect pending work." },
+      { t: "Payloads", d: "List templates and generate implants for authorized targets." },
+      { t: "Metrics & events", d: "Snapshot counters and recent live event buffer." },
+      { t: "Audit", d: "Pull recent audit trail entries for the engagement." },
+      { t: "Shell (HITL)", d: "Send to verified reverse shells when policy allows." },
+      { t: "General ops Q&A", d: "Explain C5 concepts, ROE-safe guidance, and results." },
+    ];
     root.innerHTML = `
-      <div class="work-panel" style="min-height:min(70vh,640px);display:flex;flex-direction:column">
-        <div class="wp-head" style="flex-wrap:wrap;gap:6px">
-          <span class="inko-brand">◈ INKO</span>
-          <span class="muted" style="margin-left:4px;font-size:0.75rem;font-weight:600;text-transform:none;letter-spacing:0">Intelligent Neural Kinetic Operator</span>
-        </div>
-        <div class="wp-body" style="display:flex;flex-direction:column;flex:1;min-height:0">
-          <p class="muted" style="font-size:0.78rem;margin:0 0 8px">
-            Chat with the op. INKO inspects sessions, listeners, events, and runs railed actions
-            (e.g. <em>"setup reverse shell on 4444"</em>). Configure models under <strong>Admin</strong>.
-            Use the <strong>INKO</strong> button in the top bar for the flyout panel. History is kept in this browser.
-          </p>
-          <label>LLM connection</label>
-          <select id="aiLlmPick"><option value="">Loading…</option></select>
-          <div id="aiPageLog" class="outbox" style="flex:1;max-height:none;min-height:220px;margin-top:10px"></div>
-          <label style="margin-top:10px">Message</label>
-          <textarea id="aiData" rows="3" placeholder="Talk to INKO… Enter to send, Shift+Enter for newline"></textarea>
-          <div class="row">
-            <button type="button" class="primary" id="aiRun">Send</button>
-            <button type="button" id="aiClearPage">Clear</button>
-            <button type="button" id="aiStatus">Status</button>
-            <button type="button" id="aiTools">Tools</button>
-            <button type="button" id="aiOpenDrawer">Open flyout</button>
+      <div class="form-grid" style="align-items:stretch">
+        <div class="work-panel">
+          <div class="wp-head" style="flex-wrap:wrap;gap:6px">
+            <span class="inko-brand">◈ INKO</span>
+            <span class="muted" style="margin-left:4px;font-size:0.75rem;font-weight:600;text-transform:none;letter-spacing:0">Intelligent Neural Kinetic Operator</span>
           </div>
-          <div class="outbox empty hidden" id="aiOut">—</div>
+          <div class="wp-body">
+            <p class="muted" style="font-size:0.82rem;margin:0 0 10px;line-height:1.45">
+              Chat lives in the top-bar <strong>INKO</strong> flyout — not on this page.
+              Here you pick the default LLM, review what INKO can do, and inspect status / tool catalog.
+              Configure providers under <strong>Admin</strong>.
+            </p>
+            <div class="row" style="margin-bottom:12px">
+              <button type="button" class="primary" id="aiOpenDrawer">Open INKO chat</button>
+              <button type="button" id="aiClearPage">Clear chat history</button>
+            </div>
+            <label>Default LLM connection (flyout)</label>
+            <select id="aiLlmPick"><option value="">Loading…</option></select>
+            <h3 style="margin:16px 0 6px;font-size:0.85rem;color:var(--text)">What INKO can do</h3>
+            <div class="inko-cap-grid">
+              ${CAP_CARDS.map((c) => `
+                <div class="inko-cap-card"><h4>${esc(c.t)}</h4><p>${esc(c.d)}</p></div>
+              `).join("")}
+            </div>
+            <p class="muted" style="font-size:0.75rem;margin:8px 0 0">
+              Example: <em>“setup reverse shell on 4444”</em> · <em>“list active sessions”</em> · <em>“show recent events”</em>
+            </p>
+          </div>
+        </div>
+        <div class="work-panel">
+          <div class="wp-head">Status &amp; tools</div>
+          <div class="wp-body" style="display:flex;flex-direction:column;min-height:0;flex:1">
+            <div class="row">
+              <button type="button" class="primary" id="aiStatus">AI status</button>
+              <button type="button" id="aiTools">Tool catalog</button>
+            </div>
+            <div class="outbox empty inko-outbox" id="aiOut">Run Status or Tools — output appears here (scrollable).</div>
+          </div>
         </div>
       </div>
     `;
@@ -1356,39 +1428,29 @@
       saveSel("sc5_ops_llm", el("aiLlmPick").value || "");
       if (el("aiLlmGlobal") && el("aiLlmPick").value) el("aiLlmGlobal").value = el("aiLlmPick").value;
     };
-    const sendPage = async () => {
-      if (aiBusy) return;
-      const msg = takeInputValue("aiData");
-      if (!msg.trim()) return showError("Enter a message");
-      await runAiChat(msg);
-    };
-    if (el("aiRun")) el("aiRun").onclick = sendPage;
-    if (el("aiData")) {
-      el("aiData").onkeydown = (e) => {
-        if (e.key === "Enter" && !e.shiftKey) {
-          e.preventDefault();
-          if (!aiBusy) sendPage();
-        }
-      };
-    }
     if (el("aiClearPage")) el("aiClearPage").onclick = () => clearAiChat();
     if (el("aiStatus")) el("aiStatus").onclick = async () => {
       try {
         const r = await api("GET", "/api/v1/ai/status");
-        el("aiOut").classList.remove("hidden", "empty");
+        el("aiOut").classList.remove("empty");
         el("aiOut").textContent = JSON.stringify(r, null, 2);
       } catch (e) { showError(String(e.message || e)); }
     };
     if (el("aiTools")) el("aiTools").onclick = async () => {
       try {
         const r = await api("GET", "/api/v1/ai/tools");
-        el("aiOut").classList.remove("hidden", "empty");
-        el("aiOut").textContent = JSON.stringify(r, null, 2);
+        el("aiOut").classList.remove("empty");
+        const tools = (r && r.tools) || [];
+        if (tools.length) {
+          el("aiOut").textContent = tools.map((t) =>
+            `${t.name}\n  ${t.description || ""}\n  scopes: ${(t.scopes || []).join(", ") || "—"}\n  policy: ${t.policy_action || "—"}`
+          ).join("\n\n") + (r.note ? `\n\n—\n${r.note}` : "");
+        } else {
+          el("aiOut").textContent = JSON.stringify(r, null, 2);
+        }
       } catch (e) { showError(String(e.message || e)); }
     };
     if (el("aiOpenDrawer")) el("aiOpenDrawer").onclick = () => openAiDrawer(true);
-    rebuildAiChatDom();
-    setAiBusy(aiBusy);
   }
 
   function selectedLlmId() {

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1134,14 +1134,7 @@
       );
       return `\u0000FENCE${i}\u0000`;
     });
-    s = escapeHtml(s);
-    s = s.replace(/`([^`\n]+)`/g, "<code>$1</code>");
-    s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
-    s = s.replace(/^(#{1,4})\s+(.+)$/gm, (_, h, t) => `<h${h.length}>${t}</h${h.length}>`);
-    s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
-    s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
-    s = s.replace(/^&gt;\s?(.+)$/gm, "<blockquote>$1</blockquote>");
-    // GFM tables (must run before list/paragraph splitting)
+    // GFM tables on raw text — escape each cell at HTML build time (XSS-safe)
     s = s.replace(/(?:^[ \t]*\|.+\|[ \t]*\n){2,}/gm, (block) => {
       const lines = block.trim().split("\n").map((l) => l.trim()).filter(Boolean);
       if (lines.length < 2) return block;
@@ -1155,10 +1148,10 @@
         const cells = splitRow(line);
         return cells.length > 0 && cells.every((c) => /^:?-{1,}:?$/.test(c));
       };
-      let header = splitRow(lines[0]);
+      const header = splitRow(lines[0]);
       let bodyStart = 1;
       if (isSep(lines[1])) bodyStart = 2;
-      else if (lines.length >= 2 && isSep(lines[0])) return block;
+      else if (isSep(lines[0])) return block;
       const rows = lines.slice(bodyStart).filter((l) => !isSep(l)).map(splitRow);
       if (!header.length || !rows.length) return block;
       const coln = header.length;
@@ -1167,12 +1160,27 @@
         while (r.length < coln) r.push("");
         return r;
       };
-      const th = norm(header).map((c) => `<th>${c}</th>`).join("");
-      const trs = rows.map((r) => `<tr>${norm(r).map((c) => `<td>${c}</td>`).join("")}</tr>`).join("");
+      // Inline md in cells (bold/code only) after escape
+      const cellHtml = (raw) => {
+        let c = escapeHtml(raw);
+        c = c.replace(/`([^`\n]+)`/g, "<code>$1</code>");
+        c = c.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
+        return c;
+      };
+      const th = norm(header).map((c) => `<th>${cellHtml(c)}</th>`).join("");
+      const trs = rows.map((r) => `<tr>${norm(r).map((c) => `<td>${cellHtml(c)}</td>`).join("")}</tr>`).join("");
       const i = tables.length;
       tables.push(`<div class="md-table-wrap"><table class="md-table"><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table></div>`);
       return `\u0000TABLE${i}\u0000\n\n`;
     });
+    s = escapeHtml(s);
+    // Restore table/fence placeholders swallowed by escapeHtml (\u0000 stays)
+    s = s.replace(/`([^`\n]+)`/g, "<code>$1</code>");
+    s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
+    s = s.replace(/^(#{1,4})\s+(.+)$/gm, (_, h, t) => `<h${h.length}>${t}</h${h.length}>`);
+    s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
+    s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
+    s = s.replace(/^&gt;\s?(.+)$/gm, "<blockquote>$1</blockquote>");
     // unordered lists
     s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+?/gm, (block) => {
       const items = block.trim().split("\n").map((line) => line.replace(/^[-*+]\s+/, "").trim());

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -572,6 +572,55 @@
       margin: 0.4em 0; padding: 0.25em 0 0.25em 0.75em;
       border-left: 3px solid rgba(233,30,140,0.45); color: var(--muted);
     }
+    .ai-msg .body .md-table-wrap {
+      overflow-x: auto; margin: 0.5em 0 0.65em;
+      border: 1px solid var(--border); border-radius: 8px;
+    }
+    .ai-msg .body table.md-table {
+      width: 100%; border-collapse: collapse; font-size: 0.78rem;
+      min-width: 200px;
+    }
+    .ai-msg .body table.md-table th,
+    .ai-msg .body table.md-table td {
+      border: 1px solid rgba(255,255,255,0.08);
+      padding: 6px 10px; text-align: left; vertical-align: top;
+    }
+    .ai-msg .body table.md-table th {
+      background: rgba(233,30,140,0.12); color: var(--pink2);
+      font-weight: 700; font-size: 0.68rem; text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .ai-msg .body table.md-table tr:nth-child(even) td {
+      background: rgba(255,255,255,0.02);
+    }
+    .ai-msg-actions {
+      margin-top: 8px; display: flex; justify-content: flex-end; gap: 6px;
+    }
+    .ai-copy-btn {
+      font-size: 0.68rem; padding: 4px 10px; min-height: 28px;
+      color: var(--muted); border-color: var(--border);
+    }
+    .ai-copy-btn:hover { color: var(--pink2); border-color: rgba(233,30,140,0.4); }
+    .ai-copy-btn.copied { color: var(--ok); border-color: rgba(52,211,153,0.35); }
+    .inko-cap-grid {
+      display: grid; grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 10px; margin: 10px 0;
+    }
+    .inko-cap-card {
+      background: var(--bg3); border: 1px solid var(--border); border-radius: 10px;
+      padding: 12px; min-height: 88px;
+    }
+    .inko-cap-card h4 {
+      margin: 0 0 6px; font-size: 0.82rem; color: var(--pink2); font-weight: 700;
+    }
+    .inko-cap-card p {
+      margin: 0; font-size: 0.75rem; color: var(--muted); line-height: 1.4;
+    }
+    .inko-outbox {
+      margin-top: 10px; min-height: 220px; max-height: min(50vh, 420px);
+      overflow: auto; font-family: var(--mono); font-size: 0.75rem;
+      white-space: pre-wrap; word-break: break-word;
+    }
     .ai-msg .tools-used {
       margin-top: 6px; display: flex; flex-wrap: wrap; gap: 4px;
     }
@@ -1119,7 +1168,7 @@
     payloads: { title: "Payloads", sub: "Generate implants and templates", doc: "payloads-and-implants" },
     postex: { title: "Post-Ex", sub: "Files, SOCKS, modules on selected session", doc: "file-ops" },
     collab: { title: "Collab", sub: "Teams, chat, handoff, presence", doc: "multi-operator-collab" },
-    ai: { title: "INKO", sub: "Intelligent Neural Kinetic Operator — chat, inspect, and drive the C5", doc: "inko-intelligent-neural-kinetic-operator" },
+    ai: { title: "INKO", sub: "Capabilities, status & tools — chat opens from the top-bar flyout", doc: "inko-intelligent-neural-kinetic-operator" },
     observe: { title: "Observe", sub: "Metrics, audit, timeline, reports", doc: "timeline-and-reports" },
     admin: { title: "Admin", sub: "Tokens, policy, features, LLM, MCP", doc: "feature-toggles" },
   };
@@ -1380,29 +1429,38 @@
     const lis = Array.isArray(listeners) ? listeners : (listeners.listeners || []);
     state.sessions = ses;
     state.listeners = lis;
-    const verified = ses.filter((s) => s.verified || s.kind === "beacon");
+    const isActive = (s) => {
+      const st = String(s.status || "active").toLowerCase();
+      return st === "active" || st === "live" || st === "";
+    };
+    const activeSes = ses.filter(isActive);
+    const activeBeacons = activeSes.filter((s) => {
+      const k = String(s.kind || "").toLowerCase();
+      return k === "beacon" || k.includes("beacon");
+    });
+    const shells = activeSes.filter((s) => s.verified || s.kind === "reverse_shell");
     const running = lis.filter((l) => l.status === "running");
-    $("navNSes").textContent = String(ses.length);
+    $("navNSes").textContent = String(activeSes.length);
     $("navNLis").textContent = String(running.length);
 
-    // Dashboard stats
+    // Dashboard stats — live inventory only (never cumulative closed beacons)
     const m = metrics.metrics || metrics || {};
     const stats = [
-      { n: verified.filter((s) => s.kind === "reverse_shell" || s.verified).length, l: "Shells", c: "ok" },
+      { n: shells.length, l: "Shells", c: "ok" },
       { n: running.length, l: "Listeners", c: "pink" },
-      { n: ses.length, l: "Sessions", c: "cyan" },
-      { n: m["tasks.created"] || m["tasks.pending"] || "—", l: "Tasks", c: "purple" },
-      { n: m["implant.beacon"] || m["http.beacon"] || "—", l: "Beacons", c: "ok" },
+      { n: activeSes.length, l: "Sessions", c: "cyan" },
+      { n: m["tasks.pending"] != null ? m["tasks.pending"] : (m["tasks.created"] || "—"), l: "Tasks", c: "purple" },
+      { n: activeBeacons.length, l: "Beacons", c: "ok" },
       { n: formatUptime(metrics.uptime_seconds), l: "Uptime", c: "cyan" },
     ];
     $("dashStats").innerHTML = stats.map((s) =>
       `<div class="stat ${s.c}"><div class="n">${esc(s.n)}</div><div class="l">${esc(s.l)}</div></div>`
     ).join("");
 
-    // Recent sessions table
-    $("dashSes").innerHTML = ses.length
+    // Recent sessions table (active only)
+    $("dashSes").innerHTML = activeSes.length
       ? `<table class="data"><thead><tr><th>ID</th><th>Kind</th><th>Host</th><th>Claim</th></tr></thead><tbody>` +
-        ses.slice(0, 12).map((s) => {
+        activeSes.slice(0, 12).map((s) => {
           const meta = s.metadata || {};
           return `<tr data-sid="${esc(s.id)}">
             <td class="mono">${esc((s.id || "").slice(0, 12))}…</td>
@@ -1457,7 +1515,7 @@
         }).join("\n")
       : "No recent events";
 
-    $("sideFoot").textContent = (state.actor || "op") + " · " + (ses.length) + " sessions";
+    $("sideFoot").textContent = (state.actor || "op") + " · " + (activeSes.length) + " sessions";
     if (window.__SC5_onRefresh) window.__SC5_onRefresh({ sessions: ses, listeners: lis, metrics });
   }
 


### PR DESCRIPTION
## Summary
- **INKO page**: capability catalog + status/tools (large scrollable outbox) — **chat stays in top-bar flyout only**
- **Markdown tables** render as HTML tables in INKO replies
- **Copy** button on each assistant response
- **Dashboard Beacons** counts **active** beacon sessions only (not closed / cumulative metrics)

## Test plan
- [x] `pytest tests/test_inko_md_render.py tests/test_inko_branding.py`
- [ ] Ask INKO a table-formatted answer → proper grid
- [ ] Copy button copies plain text
- [ ] Dashboard shows 0 beacons when all closed
- [ ] INKO nav page has no full-page chat