### PR TITLE
feat(ops): model switcher, Artifacts, Profiles, custom templates

### DIFF
--- a/src/squidc5/ai/admin_ai.py
+++ b/src/squidc5/ai/admin_ai.py
@@ -298,14 +298,22 @@ class AdminAI:
         capabilities: list[str] | None = None,
         llm_id: str | None = None,
     ) -> str:
-        caps = [c for c in (capabilities or list(ALLOWED_CAPABILITIES)) if c in ALLOWED_CAPABILITIES]
+        if capabilities is None and llm_id:
+            caps = None  # preserve existing on update
+        else:
+            caps = [c for c in (capabilities or list(ALLOWED_CAPABILITIES)) if c in ALLOWED_CAPABILITIES]
         if base_url:
             from squidc5.security.ssrf import validate_llm_base_url
 
             base_url = validate_llm_base_url(base_url, allow_private=False)
-        stored_key = api_key
-        if api_key and self.secrets is not None:
+        # None api_key → keep existing encrypted key on update
+        stored_key: str | None
+        if api_key is None:
+            stored_key = None
+        elif api_key and self.secrets is not None:
             stored_key = self.secrets.encrypt(api_key)
+        else:
+            stored_key = api_key
         return await self.db.upsert_llm(
             name=name,
             provider=provider,
@@ -596,6 +604,7 @@ class AdminAI:
         history: list[dict[str, str]] | None = None,
         actor: str = "admin",
         llm_id: str | None = None,
+        model: str | None = None,
         state: Any = None,
         auth: Any = None,
         max_rounds: int = 6,
@@ -604,6 +613,7 @@ class AdminAI:
 
         Rails: fixed tool catalog, policy/scopes per tool, sanitized I/O,
         bounded rounds (no open-ended autonomous agent).
+        Optional model overrides the connection default for this call only.
         """
         import time as _time
 
@@ -659,6 +669,9 @@ class AdminAI:
         tool_trace: list[dict[str, Any]] = []
         try:
             llm = await self._select_llm(llm_id, "recon_assist")
+            if llm is not None and model and str(model).strip():
+                llm = dict(llm)
+                llm["model"] = str(model).strip()[:200]
             if llm is None:
                 offline = await offline_chat_intent(state, auth, safe_msg)
                 if offline:

--- a/src/squidc5/ai/ops_tools.py
+++ b/src/squidc5/ai/ops_tools.py
@@ -30,6 +30,10 @@ TOOL_GATES: dict[str, tuple[list[str], str]] = {
     "list_payload_templates": (["payloads:generate", "admin"], "payloads.generate"),
     "save_asset": (["payloads:generate", "profiles:write", "admin"], "payloads.generate"),
     "list_assets": (["payloads:generate", "profiles:read", "admin"], "payloads.generate"),
+    "register_payload_template": (["payloads:generate", "admin"], "payloads.generate"),
+    "list_profiles": (["profiles:read", "admin"], "profiles.list"),
+    "activate_profile": (["profiles:write", "admin"], "profiles.activate"),
+    "upsert_profile": (["profiles:write", "admin"], "profiles.write"),
     "get_metrics": (["metrics:read", "admin"], "metrics.read"),
     "list_recent_events": (["metrics:read", "sessions:read", "admin"], "metrics.read"),
     "list_audit": (["audit:read", "admin"], "audit.read"),
@@ -250,6 +254,62 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
     {
         "type": "function",
         "function": {
+            "name": "register_payload_template",
+            "description": "Register a custom payload template (placeholders {host} {port} {path} {interval}). Becomes usable in payloads generate.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "content": {"type": "string"},
+                    "note": {"type": "string"}
+                },
+                "required": ["name", "content"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "list_profiles",
+            "description": "List malleable C2 profiles and the active profile id.",
+            "parameters": {"type": "object", "properties": {}}
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "activate_profile",
+            "description": "Activate a C2 profile by id.",
+            "parameters": {
+                "type": "object",
+                "properties": {"profile_id": {"type": "string"}},
+                "required": ["profile_id"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "upsert_profile",
+            "description": "Create or update a simple HTTP C2 profile (name, uris, user_agent, sleep_sec, jitter_pct).",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "profile_id": {"type": "string"},
+                    "uris": {"type": "array", "items": {"type": "string"}},
+                    "user_agent": {"type": "string"},
+                    "sleep_sec": {"type": "number"},
+                    "jitter_pct": {"type": "number"},
+                    "activate": {"type": "boolean"}
+                },
+                "required": ["name"]
+            }
+        }
+    },
+    {
+        "type": "function",
+        "function": {
             "name": "get_metrics",
             "description": "Get teamserver metrics counters snapshot.",
             "parameters": {"type": "object", "properties": {}},
@@ -452,24 +512,39 @@ def _handlers(
         )
 
     async def list_payload_templates(args: dict[str, Any]) -> Any:
-        if hasattr(state.payloads, "list_templates"):
-            names = state.payloads.list_templates()
-        else:
-            names = list(getattr(state.payloads, "TEMPLATES", ()) or ())
-        return {"templates": names}
+        customs: list[str] = []
+        try:
+            rows = await state.db.list_operator_assets(kind="template", limit=200)
+            customs = [str(r.get("name") or "") for r in rows if r.get("name")]
+        except Exception:
+            customs = []
+        names = state.payloads.list_templates(customs)
+        return {"templates": names, "custom": customs}
 
     async def generate_payload(args: dict[str, Any]) -> Any:
         if not await state.features.enabled("payloads_generate"):
             raise PermissionError("Payload generation disabled")
+        customs: dict[str, str] = {}
+        try:
+            rows = await state.db.list_operator_assets(kind="template", limit=200)
+            for r in rows:
+                full = await state.db.get_operator_asset(r["id"])
+                if full and full.get("name") and full.get("content"):
+                    customs[str(full["name"])] = str(full["content"])
+        except Exception:
+            customs = {}
         result = state.payloads.generate(
             template=str(args["template"]),
             host=str(args["host"]),
             port=int(args["port"]),
             interval=int(args.get("interval") or 5),
+            custom_templates=customs,
         )
         full_payload = ""
         if isinstance(result, dict):
-            full_payload = str(result.get("payload") or result.get("body") or "")
+            full_payload = str(
+                result.get("content") or result.get("payload") or result.get("body") or ""
+            )
         saved = None
         if args.get("save") and full_payload:
             sname = str(args.get("save_name") or f"{args.get('template')}-{args.get('port')}")
@@ -486,12 +561,12 @@ def _handlers(
             )
             saved = {"id": aid, "name": sname, "kind": "payload"}
         # payloads may be large — cap script body for model context
-        if isinstance(result, dict) and "payload" in result:
-            body = str(result.get("payload") or "")
-            if len(body) > 4000:
-                result = dict(result)
-                result["payload"] = body[:4000] + "\n...[truncated]"
-                result["truncated"] = True
+        if isinstance(result, dict):
+            for key in ("content", "payload"):
+                if key in result and len(str(result.get(key) or "")) > 4000:
+                    result = dict(result)
+                    result[key] = str(result[key])[:4000] + "\n...[truncated]"
+                    result["truncated"] = True
         if saved:
             if isinstance(result, dict):
                 result = dict(result)
@@ -561,6 +636,81 @@ def _handlers(
             raise RuntimeError("No live reverse shell for session")
         return {"sent": True, "session_id": sid}
 
+    async def register_payload_template(args: dict[str, Any]) -> Any:
+        name = str(args.get("name") or "").strip().replace(" ", "_")
+        content = str(args.get("content") or "")
+        if not name or not content.strip():
+            raise ValueError("name and content required")
+        if name in getattr(state.payloads, "TEMPLATES", ()):
+            raise ValueError(f"conflicts with builtin template: {name}")
+        aid = await state.db.create_operator_asset(
+            kind="template",
+            name=name[:80],
+            content=content,
+            meta={"note": str(args.get("note") or ""), "via": "inko"},
+            created_by=auth.name,
+        )
+        return {"id": aid, "name": name, "kind": "template"}
+
+    async def list_profiles(args: dict[str, Any]) -> Any:
+        if not await state.features.enabled("malleable_profiles"):
+            raise PermissionError("Malleable profiles disabled")
+        active = state.profiles.active()
+        return {
+            "profiles": state.profiles.list_profiles(),
+            "active_id": active.id if active else None,
+        }
+
+    async def activate_profile(args: dict[str, Any]) -> Any:
+        if not await state.features.enabled("malleable_profiles"):
+            raise PermissionError("Malleable profiles disabled")
+        pid = str(args.get("profile_id") or "")
+        prof = await state.profiles.set_active(pid)
+        return {"active_id": prof.id, "name": prof.name}
+
+    async def upsert_profile(args: dict[str, Any]) -> Any:
+        if not await state.features.enabled("malleable_profiles"):
+            raise PermissionError("Malleable profiles disabled")
+        import re
+        import secrets
+
+        from squidc5.profiles.models import C2Profile, HttpProfile
+
+        name = str(args.get("name") or "inko-profile")
+        uris = args.get("uris") or ["/api/v1/implant/beacon"]
+        if not isinstance(uris, list):
+            uris = [str(uris)]
+        http = HttpProfile(
+            uris=[str(u) for u in uris][:20],
+            user_agent=str(args.get("user_agent") or "Mozilla/5.0"),
+            sleep_sec=float(args.get("sleep_sec") or 5),
+            jitter_pct=float(args.get("jitter_pct") or 20),
+        )
+        pid = str(args.get("profile_id") or "").strip()
+        if not pid:
+            slug = re.sub(r"[^a-z0-9_]+", "_", name.lower())[:24] or "prof"
+            pid = f"prof_{slug}_{secrets.token_hex(3)}"
+        prof = C2Profile(
+            id=pid,
+            name=name,
+            channel="http",
+            http=http,
+            active=bool(args.get("activate")),
+        )
+        saved = await state.profiles.upsert(prof)
+        if args.get("activate"):
+            await state.profiles.set_active(saved.id)
+        # also save as asset for artifacts page
+        await state.db.create_operator_asset(
+            kind="profile",
+            name=name[:120],
+            content=str(saved.to_dict()),
+            meta={"profile_id": saved.id, "via": "inko"},
+            created_by=auth.name,
+        )
+        return {"profile": saved.to_dict()}
+
+
     return {
         "list_sessions": list_sessions,
         "get_session": get_session,
@@ -575,6 +725,10 @@ def _handlers(
         "generate_payload": generate_payload,
         "save_asset": save_asset,
         "list_assets": list_assets,
+        "register_payload_template": register_payload_template,
+        "list_profiles": list_profiles,
+        "activate_profile": activate_profile,
+        "upsert_profile": upsert_profile,
         "get_metrics": get_metrics,
         "list_recent_events": list_recent_events,
         "list_audit": list_audit,

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -107,7 +107,12 @@ class AIChatRequest(BaseModel):
     message: str
     history: list[AIChatMessage] = Field(default_factory=list)
     llm_id: str | None = None
+    model: str | None = None  # optional override for this turn only
     max_rounds: int | None = None
+
+
+class LLMModelPatch(BaseModel):
+    model: str
 
 
 class MeUpdate(BaseModel):
@@ -126,6 +131,12 @@ class AssetCreate(BaseModel):
     name: str
     content: str
     meta: dict[str, Any] | None = None
+
+
+class PayloadTemplateCreate(BaseModel):
+    name: str
+    content: str
+    note: str = ""
 
 
 class ShellCommand(BaseModel):
@@ -815,13 +826,61 @@ def build_api_router() -> APIRouter:
 
     # ----- Payloads -----
 
+    async def _custom_payload_templates(state: Any) -> dict[str, str]:
+        rows = await state.db.list_operator_assets(kind="template", limit=200)
+        out: dict[str, str] = {}
+        for r in rows:
+            full = await state.db.get_operator_asset(r["id"])
+            if full and full.get("name") and full.get("content"):
+                out[str(full["name"])] = str(full["content"])
+        return out
+
     @api.get("/payloads/templates")
     async def payload_templates(
+        request: Request,
         auth: AuthContext = Depends(require_scope("payloads:generate", "admin")),
-    ) -> dict[str, list[str]]:
-        from squidc5.payloads.generator import PayloadGenerator
+    ) -> dict[str, Any]:
+        state = get_state(request)
+        customs = await _custom_payload_templates(state)
+        builtin = state.payloads.list_templates()
+        return {
+            "templates": state.payloads.list_templates(list(customs.keys())),
+            "builtin": builtin,
+            "custom": sorted(customs.keys()),
+        }
 
-        return {"templates": PayloadGenerator().list_templates()}
+    @api.post("/payloads/templates")
+    async def register_payload_template(
+        payload: PayloadTemplateCreate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("payloads:generate", "admin")),
+    ) -> dict[str, Any]:
+        """Register a custom payload template (placeholders: {host} {port} {path} {interval})."""
+        state = get_state(request)
+        name = (payload.name or "").strip().replace(" ", "_")
+        if not name or len(name) > 80:
+            raise HTTPException(400, "name required (max 80)")
+        if not (payload.content or "").strip():
+            raise HTTPException(400, "content required")
+        # avoid overwriting builtin names with different semantics silently
+        if name in state.payloads.TEMPLATES:
+            raise HTTPException(400, f"name conflicts with builtin template: {name}")
+        aid = await state.db.create_operator_asset(
+            kind="template",
+            name=name,
+            content=payload.content,
+            meta={"note": payload.note, "placeholders": ["{host}", "{port}", "{path}", "{interval}"]},
+            created_by=auth.name,
+        )
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="payloads.template_register",
+            resource=aid,
+            details={"name": name},
+            risk_score=4,
+        )
+        return {"id": aid, "name": name, "kind": "template"}
 
     @api.post("/payloads/generate")
     async def generate_payload(
@@ -872,6 +931,7 @@ def build_api_router() -> APIRouter:
                 template = "dns_beacon_python"
             if prof and template == "http_beacon_python" and prof.channel == "ws":
                 template = "ws_beacon_python"
+            customs = await _custom_payload_templates(state)
             result = state.payloads.generate(
                 template=template,
                 host=body.host,
@@ -879,6 +939,7 @@ def build_api_router() -> APIRouter:
                 session_path=session_path,
                 interval=interval,
                 extra=plan,
+                custom_templates=customs,
             )
         except HTTPException:
             raise
@@ -1674,14 +1735,24 @@ def build_api_router() -> APIRouter:
     async def list_llm_models(
         body: LLMModelsRequest,
         request: Request,
-        auth: AuthContext = Depends(require_scope("llm:manage", "admin")),
+        auth: AuthContext = Depends(require_scope("llm:manage", "admin", "ai:use")),
     ) -> dict[str, Any]:
-        """List models from an OpenAI-compatible provider (SSRF-guarded proxy)."""
+        """List models from an OpenAI-compatible provider (SSRF-guarded proxy).
+
+        Operators with only ai:use may pass llm_id (stored key/url only) — never raw base_url+key.
+        """
         state = get_state(request)
+        is_mgr = auth.has_scope("llm:manage") or auth.has_scope("admin")
+        if not is_mgr:
+            if not body.llm_id or body.base_url or body.api_key:
+                raise HTTPException(
+                    403,
+                    "ai:use may only list models for a saved llm_id (no base_url/api_key)",
+                )
         try:
             models = await state.admin_ai.list_remote_models(
-                base_url=body.base_url,
-                api_key=body.api_key,
+                base_url=body.base_url if is_mgr else None,
+                api_key=body.api_key if is_mgr else None,
                 provider=body.provider,
                 llm_id=body.llm_id,
             )
@@ -1700,6 +1771,41 @@ def build_api_router() -> APIRouter:
             risk_score=2,
         )
         return {"models": models}
+
+    @api.patch("/llm/{llm_id}")
+    async def patch_llm_model(
+        llm_id: str,
+        body: LLMModelPatch,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("llm:manage", "admin", "ai:use")),
+    ) -> dict[str, Any]:
+        """Update the default model on a saved LLM connection (no key change)."""
+        state = get_state(request)
+        row = await state.db.get_llm(llm_id)
+        if not row or not row.get("enabled"):
+            raise HTTPException(404, "LLM not found")
+        model = (body.model or "").strip()
+        if not model or len(model) > 200:
+            raise HTTPException(400, "model required")
+        # Direct DB update — do not re-validate base_url (avoids outbound DNS on switch)
+        await state.db.upsert_llm(
+            name=row["name"],
+            provider=row.get("provider") or "openai",
+            model=model,
+            base_url=row.get("base_url"),
+            api_key_enc=None,  # preserve existing
+            capabilities=None,
+            llm_id=llm_id,
+        )
+        await state.db.audit(
+            actor=auth.name,
+            actor_type=auth.actor_type,
+            action="llm.model_switch",
+            resource=llm_id,
+            details={"model": model, "from": row.get("model")},
+            risk_score=2,
+        )
+        return {"id": llm_id, "model": model, "name": row["name"]}
 
     @api.get("/ai/status")
     async def ai_status(
@@ -1758,6 +1864,7 @@ def build_api_router() -> APIRouter:
                 history=hist,
                 actor=auth.name,
                 llm_id=body.llm_id,
+                model=body.model,
                 state=state,
                 auth=auth,
                 max_rounds=body.max_rounds or 6,

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -564,8 +564,16 @@ class Database:
         llm_id: str | None = None,
     ) -> str:
         lid = llm_id or _uid("llm_")
-        existing = await self.fetchone("SELECT id FROM llm_connections WHERE id = ?", (lid,))
+        existing = await self.fetchone("SELECT id, api_key_enc, capabilities FROM llm_connections WHERE id = ?", (lid,))
         if existing:
+            keep_key = api_key_enc if api_key_enc is not None else existing.get("api_key_enc")
+            caps_json = (
+                json.dumps(capabilities)
+                if capabilities is not None
+                else (existing.get("capabilities") or "[]")
+            )
+            if isinstance(caps_json, list):
+                caps_json = json.dumps(caps_json)
             await self.execute(
                 """UPDATE llm_connections SET name=?, provider=?, base_url=?, model=?,
                    api_key_enc=?, capabilities=? WHERE id=?""",
@@ -574,8 +582,8 @@ class Database:
                     provider,
                     base_url,
                     model,
-                    api_key_enc,
-                    json.dumps(capabilities or []),
+                    keep_key,
+                    caps_json,
                     lid,
                 ),
             )

--- a/src/squidc5/payloads/generator.py
+++ b/src/squidc5/payloads/generator.py
@@ -23,8 +23,13 @@ class PayloadGenerator:
         "bof_c",
     )
 
-    def list_templates(self) -> list[str]:
-        return list(self.TEMPLATES)
+    def list_templates(self, custom_names: list[str] | None = None) -> list[str]:
+        names = list(self.TEMPLATES)
+        for n in custom_names or []:
+            n = (n or "").strip()
+            if n and n not in names:
+                names.append(n)
+        return names
 
     def generate(
         self,
@@ -34,10 +39,33 @@ class PayloadGenerator:
         session_path: str = "/api/v1/implant/beacon",
         interval: int = 5,
         extra: dict[str, Any] | None = None,
+        custom_templates: dict[str, str] | None = None,
     ) -> dict[str, Any]:
-        if template not in self.TEMPLATES:
-            raise ValueError(f"Unknown template: {template}. Allowed: {self.TEMPLATES}")
         extra = extra or {}
+        customs = custom_templates or {}
+        if template in customs:
+            body = self._render_custom(
+                customs[template],
+                host=host,
+                port=port,
+                path=session_path,
+                interval=interval,
+            )
+            encoded = base64.b64encode(body.encode()).decode()
+            return {
+                "template": template,
+                "host": host,
+                "port": port,
+                "content": body,
+                "content_b64": encoded,
+                "custom": True,
+                "profile_id": extra.get("profile_id"),
+                "notes": "Custom template. Authorized testing only.",
+            }
+        if template not in self.TEMPLATES:
+            raise ValueError(
+                f"Unknown template: {template}. Allowed: {self.list_templates(list(customs))}"
+            )
         if template == "http_beacon_python":
             body = self._http_beacon_python(host, port, session_path, interval, extra)
         elif template == "http_beacon_bash":
@@ -91,6 +119,29 @@ class PayloadGenerator:
             "uri": session_path if template.startswith("http_beacon") else None,
             "notes": "Authorized testing only. Use only on systems you own or have permission to test.",
         }
+
+    def _render_custom(
+        self,
+        tmpl: str,
+        *,
+        host: str,
+        port: int,
+        path: str,
+        interval: int,
+    ) -> str:
+        """Safe placeholder expansion only — no code execution."""
+        text = str(tmpl or "")
+        replacements = {
+            "{host}": str(host),
+            "{port}": str(int(port)),
+            "{path}": str(path),
+            "{interval}": str(int(interval)),
+            "{HOST}": str(host),
+            "{PORT}": str(int(port)),
+        }
+        for k, v in replacements.items():
+            text = text.replace(k, v)
+        return text
 
     def _http_beacon_python(
         self,

--- a/tests/test_ops_ux_extras.py
+++ b/tests/test_ops_ux_extras.py
@@ -134,3 +134,60 @@ async def test_tls_upload_and_activate(tmp_path):
             assert act.json().get("restart_required") is True
             lst = await client.get("/api/v1/tls/certs", headers=h)
             assert any(c["id"] == cid and c["active"] for c in lst.json()["certs"])
+
+
+
+@pytest.mark.asyncio
+async def test_custom_payload_template_register_and_generate(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            reg = await client.post(
+                "/api/v1/payloads/templates",
+                headers=h,
+                json={"name": "echo_tpl", "content": "echo {host}:{port}"},
+            )
+            assert reg.status_code == 200, reg.text
+            tpl = await client.get("/api/v1/payloads/templates", headers=h)
+            body = tpl.json()
+            assert "echo_tpl" in body["templates"]
+            assert "echo_tpl" in body.get("custom", [])
+            gen = await client.post(
+                "/api/v1/payloads/generate",
+                headers=h,
+                json={"template": "echo_tpl", "host": "10.0.0.1", "port": 99},
+            )
+            assert gen.status_code == 200, gen.text
+            assert "10.0.0.1:99" in (gen.json().get("content") or "")
+
+
+@pytest.mark.asyncio
+async def test_patch_llm_model_preserves_key(tmp_path):
+    """Model switch without re-supplying API key (no outbound network)."""
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        # bypass SSRF by writing LLM row directly
+        state = app.state.app_state
+        from squidc5.crypto.secrets import SecretBox, resolve_secrets_key
+        box = SecretBox(resolve_secrets_key(explicit=None, data_dir=tmp_path / "d"))
+        enc = box.encrypt("sk-secret-value-xyz")
+        lid = await state.db.upsert_llm(
+            name="direct",
+            provider="openai",
+            model="gpt-a",
+            base_url="https://api.openai.com/v1",
+            api_key_enc=enc,
+            capabilities=["recon_assist"],
+        )
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            pat = await client.patch(f"/api/v1/llm/{lid}", headers=h, json={"model": "gpt-b"})
+            assert pat.status_code == 200, pat.text
+            assert pat.json()["model"] == "gpt-b"
+            row = await state.db.get_llm(lid)
+            assert row["model"] == "gpt-b"
+            assert row.get("api_key_enc")
+            assert box.decrypt(row["api_key_enc"]) == "sk-secret-value-xyz"

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -58,6 +58,12 @@
       { a: "payloads-and-implants", t: "Payloads & implants" },
       { a: "c2-profiles", t: "C2 profiles" },
     ],
+    profiles: [
+      { a: "c2-profiles", t: "C2 profiles" },
+    ],
+    artifacts: [
+      { a: "payloads-and-implants", t: "Saved artifacts" },
+    ],
     postex: [
       { a: "file-ops", t: "File ops" },
       { a: "socks-pivot", t: "SOCKS pivot" },
@@ -329,6 +335,73 @@
       el(prefix + "Provider").dataset.bound = "1";
     }
     updateModelUi();
+  }
+
+
+  async function loadModelsForLlm(llmId, modelSelectId, preferred) {
+    const sel = el(modelSelectId);
+    if (!sel) return;
+    if (!llmId) {
+      sel.innerHTML = '<option value="">Select a connection first</option>';
+      sel.disabled = true;
+      return;
+    }
+    sel.disabled = true;
+    sel.innerHTML = '<option value="">Loading models…</option>';
+    try {
+      const r = await api("POST", "/api/v1/llm/models", { llm_id: llmId });
+      const models = r.models || [];
+      const pref = preferred || "";
+      if (!models.length) {
+        sel.innerHTML = pref
+          ? `<option value="${esc(pref)}">${esc(pref)}</option>`
+          : '<option value="">(no models — type via override in Admin)</option>';
+        sel.disabled = !pref;
+        if (pref) sel.value = pref;
+        return;
+      }
+      const set = new Set(models);
+      if (pref) set.add(pref);
+      const list = Array.from(set).sort((a, b) => a.localeCompare(b));
+      sel.innerHTML = list.map((m) => `<option value="${esc(m)}">${esc(m)}</option>`).join("");
+      sel.disabled = false;
+      sel.value = pref && list.includes(pref) ? pref : list[0];
+    } catch (e) {
+      const pref = preferred || "";
+      sel.innerHTML = pref
+        ? `<option value="${esc(pref)}">${esc(pref)} (offline)</option>`
+        : `<option value="">Model list failed</option>`;
+      sel.disabled = !pref;
+      if (pref) sel.value = pref;
+    }
+  }
+
+  function bindLlmModelPair(connId, modelId) {
+    const conn = el(connId);
+    const mod = el(modelId);
+    if (!conn || !mod) return;
+    const sync = async () => {
+      const id = conn.value || "";
+      saveSel("sc5_ops_llm", id || "");
+      let pref = "";
+      try {
+        const llms = await loadSavedLlms();
+        const row = (llms || []).find((L) => (L.id || L.name) === id);
+        pref = (row && row.model) || loadSel("sc5_ops_model") || "";
+      } catch (_) { pref = loadSel("sc5_ops_model") || ""; }
+      await loadModelsForLlm(id, modelId, pref);
+      if (mod.value) saveSel("sc5_ops_model", mod.value);
+    };
+    conn.onchange = () => { sync(); };
+    mod.onchange = () => {
+      if (mod.value) saveSel("sc5_ops_model", mod.value);
+      // persist model on connection for next chat default
+      const id = conn.value;
+      if (id && mod.value) {
+        api("PATCH", "/api/v1/llm/" + encodeURIComponent(id), { model: mod.value }).catch(() => {});
+      }
+    };
+    sync();
   }
 
   async function loadSavedLlms() {
@@ -865,45 +938,106 @@
           ${can("payloads:generate") ? `
             <div class="form-grid">
               <div class="full"><label>Template</label>
-                <select id="payTpl">
-                  <option value="http_beacon_python">http_beacon_python</option>
-                  <option value="http_beacon_bash">http_beacon_bash</option>
-                  <option value="reverse_shell_bash">reverse_shell_bash</option>
-                  <option value="reverse_shell_python">reverse_shell_python</option>
-                  <option value="ws_beacon_python">ws_beacon_python</option>
-                </select>
+                <select id="payTpl"><option value="">Loading…</option></select>
+              </div>
+              <div class="full"><label>C2 profile (optional)</label>
+                <select id="payProfile"><option value="">(active profile)</option></select>
               </div>
               <div><label>Host</label><input id="payHost" value="${esc(host)}" /></div>
               <div><label>Port</label><input id="payPort" type="number" value="${location.port || 8443}" /></div>
+              <div><label>Interval</label><input id="payInterval" type="number" value="5" /></div>
+              <div><label>Scheme</label>
+                <select id="payScheme"><option value="">auto</option><option value="https">https</option><option value="http">http</option></select>
+              </div>
             </div>
             <div class="row">
               <button type="button" class="primary" id="payGen">Generate</button>
               <button type="button" id="payCopy">Copy</button>
+              <button type="button" id="paySave">Save artifact</button>
             </div>
+            <details style="margin-top:12px">
+              <summary class="muted" style="cursor:pointer;font-size:0.78rem">Register custom template</summary>
+              <label>Name</label><input id="payTplName" placeholder="my_custom_beacon" />
+              <label>Body (use {host} {port} {path} {interval})</label>
+              <textarea id="payTplBody" rows="5" class="mono" style="font-size:0.75rem" placeholder="connect {host}:{port}"></textarea>
+              <div class="row"><button type="button" id="payTplReg">Register template</button></div>
+            </details>
           ` : '<p class="muted">Need payloads:generate scope</p>'}
           <div class="outbox empty" id="payOut">—</div>
         </div>
       </div>
     `;
     viewBuilt.payloads = true;
+    (async () => {
+      try {
+        const [tpl, prof] = await Promise.all([
+          api("GET", "/api/v1/payloads/templates").catch(() => ({ templates: [] })),
+          can("profiles:read") || can("admin")
+            ? api("GET", "/api/v1/profiles").catch(() => ({ profiles: [] }))
+            : Promise.resolve({ profiles: [] }),
+        ]);
+        const names = tpl.templates || [];
+        if (el("payTpl")) {
+          el("payTpl").innerHTML = names.map((n) => {
+            const custom = (tpl.custom || []).includes(n);
+            return `<option value="${esc(n)}">${esc(n)}${custom ? " (custom)" : ""}</option>`;
+          }).join("") || '<option value="">(none)</option>';
+        }
+        if (el("payProfile")) {
+          const rows = prof.profiles || [];
+          const act = prof.active_id || "";
+          el("payProfile").innerHTML = `<option value="">(active${act ? ": " + esc(act) : ""})</option>` +
+            rows.map((p) => `<option value="${esc(p.id)}">${esc(p.name || p.id)}${p.id === act ? " ★" : ""}</option>`).join("");
+        }
+      } catch (e) { /* ignore */ }
+    })();
     if (el("payGen")) el("payGen").onclick = async () => {
       try {
-        const r = await api("POST", "/api/v1/payloads/generate", {
+        const body = {
           template: el("payTpl").value,
           host: el("payHost").value.trim(),
           port: Number(el("payPort").value),
-        });
+          interval: Number(el("payInterval")?.value || 5),
+        };
+        if (el("payProfile")?.value) body.profile_id = el("payProfile").value;
+        if (el("payScheme")?.value) body.scheme = el("payScheme").value;
+        const r = await api("POST", "/api/v1/payloads/generate", body);
         const text = r.content || r.payload || JSON.stringify(r, null, 2);
         el("payOut").textContent = text;
         el("payOut").classList.remove("empty");
+        el("payOut").dataset.raw = text;
         showOk("Generated");
       } catch (e) { showError(String(e.message || e)); }
     };
     if (el("payCopy")) el("payCopy").onclick = async () => {
+      const text = el("payOut")?.dataset?.raw || el("payOut")?.textContent || "";
+      try { await navigator.clipboard.writeText(text); showOk("Copied"); }
+      catch (_) { showError("Clipboard unavailable"); }
+    };
+    if (el("paySave")) el("paySave").onclick = async () => {
       try {
-        await navigator.clipboard.writeText(el("payOut").textContent || "");
-        showOk("Copied");
-      } catch (_) { showError("Copy failed"); }
+        const text = el("payOut")?.dataset?.raw || el("payOut")?.textContent || "";
+        if (!text || text === "—") return showError("Generate first");
+        const name = (el("payTpl").value || "payload") + "-" + Date.now().toString(36);
+        await api("POST", "/api/v1/assets", {
+          kind: "payload",
+          name,
+          content: text,
+          meta: { template: el("payTpl").value, host: el("payHost").value, port: el("payPort").value },
+        });
+        showOk("Saved to Artifacts");
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("payTplReg")) el("payTplReg").onclick = async () => {
+      try {
+        const r = await api("POST", "/api/v1/payloads/templates", {
+          name: (el("payTplName").value || "").trim(),
+          content: el("payTplBody").value || "",
+        });
+        showOk("Template registered: " + (r.name || ""));
+        viewBuilt.payloads = false;
+        renderPayloadsView(true);
+      } catch (e) { showError(String(e.message || e)); }
     };
   }
 
@@ -1405,6 +1539,8 @@
       };
       const llm_id = selectedLlmId();
       if (llm_id) body.llm_id = llm_id;
+      const model = selectedModel();
+      if (model) body.model = model;
       const r = await api("POST", "/api/v1/ai/chat", body);
       const reply = (r && r.reply) || JSON.stringify(r, null, 2);
       const tools = (r && r.tool_trace) || [];
@@ -1466,8 +1602,11 @@
               <button type="button" class="primary" id="aiOpenDrawer">Open INKO chat</button>
               <button type="button" id="aiClearPage">Clear chat history</button>
             </div>
-            <label>Default LLM connection (flyout)</label>
+            <label>LLM connection</label>
             <select id="aiLlmPick"><option value="">Loading…</option></select>
+            <label>Model</label>
+            <select id="aiModelPick" disabled><option value="">Select connection…</option></select>
+            <p class="muted" style="font-size:0.72rem;margin:4px 0 0">Models load from the provider for the selected connection. Switching model updates the connection default.</p>
             <h3 style="margin:16px 0 6px;font-size:0.85rem;color:var(--text)">What INKO can do</h3>
             <div class="inko-cap-grid">
               ${CAP_CARDS.map((c) => `
@@ -1496,13 +1635,11 @@
       const prev = el("aiLlmPick")?.value || loadSel("sc5_ops_llm") || "";
       fillLlmSelect(el("aiLlmPick"), llms, prev);
       fillLlmSelect(el("aiLlmGlobal"), llms, prev);
+      bindLlmModelPair("aiLlmPick", "aiModelPick");
+      bindLlmModelPair("aiLlmGlobal", "aiModelGlobal");
     };
     window.__SC5_refreshLlms = refreshPick;
     refreshPick();
-    if (el("aiLlmPick")) el("aiLlmPick").onchange = () => {
-      saveSel("sc5_ops_llm", el("aiLlmPick").value || "");
-      if (el("aiLlmGlobal") && el("aiLlmPick").value) el("aiLlmGlobal").value = el("aiLlmPick").value;
-    };
     if (el("aiClearPage")) el("aiClearPage").onclick = () => clearAiChat();
     if (el("aiStatus")) el("aiStatus").onclick = async () => {
       try {
@@ -1532,6 +1669,12 @@
     return (el("aiLlmPick") && el("aiLlmPick").value)
       || (el("aiLlmGlobal") && el("aiLlmGlobal").value)
       || loadSel("sc5_ops_llm")
+      || null;
+  }
+  function selectedModel() {
+    return (el("aiModelPick") && el("aiModelPick").value)
+      || (el("aiModelGlobal") && el("aiModelGlobal").value)
+      || loadSel("sc5_ops_model")
       || null;
   }
 
@@ -1577,11 +1720,10 @@
     rebuildAiChatDom();
     loadSavedLlms().then((llms) => {
       fillLlmSelect(el("aiLlmGlobal"), llms, loadSel("sc5_ops_llm") || "");
+      fillLlmSelect(el("aiLlmPick"), llms, loadSel("sc5_ops_llm") || "");
+      bindLlmModelPair("aiLlmGlobal", "aiModelGlobal");
+      bindLlmModelPair("aiLlmPick", "aiModelPick");
     });
-    if (el("aiLlmGlobal")) el("aiLlmGlobal").onchange = () => {
-      saveSel("sc5_ops_llm", el("aiLlmGlobal").value || "");
-      if (el("aiLlmPick") && el("aiLlmGlobal").value) el("aiLlmPick").value = el("aiLlmGlobal").value;
-    };
     btn.onclick = () => openAiDrawer();
     if (el("aiDrawerClose")) el("aiDrawerClose").onclick = () => openAiDrawer(false);
     if (backdrop) backdrop.onclick = () => openAiDrawer(false);
@@ -1867,6 +2009,204 @@
     if (el("adTokList")) el("adTokList").onclick = () => dump("/api/v1/tokens");
   }
 
+
+  /* —— Profiles —— */
+  function renderProfilesView(force) {
+    const root = el("view-profiles");
+    if (!root) return;
+    if (!force && viewBuilt.profiles && root.querySelector("#profTbody")) return;
+    root.innerHTML = `
+      <div class="split">
+        <div class="list-panel">
+          <div class="lp-head">C2 profiles <button type="button" id="profReload" style="margin-left:auto">Reload</button></div>
+          <div class="lp-body"><table class="data"><thead><tr><th>Name</th><th>Channel</th><th>Active</th></tr></thead>
+          <tbody id="profTbody"></tbody></table></div>
+        </div>
+        <div class="work-panel">
+          <div class="wp-head">Manage</div>
+          <div class="wp-body">
+            ${(can("profiles:write") || can("admin")) ? `
+              <label>Name</label><input id="profName" placeholder="stealth-http" />
+              <label>URIs (comma-separated)</label><input id="profUris" placeholder="/api/v1/implant/beacon,/cdn/a" />
+              <label>User-Agent</label><input id="profUa" value="Mozilla/5.0" />
+              <div class="form-grid">
+                <div><label>Sleep sec</label><input id="profSleep" type="number" value="5" /></div>
+                <div><label>Jitter %</label><input id="profJitter" type="number" value="20" /></div>
+              </div>
+              <div class="row">
+                <button type="button" class="primary" id="profSave">Save profile</button>
+                <button type="button" id="profAct">Activate selected</button>
+                <button type="button" id="profPush">Push active</button>
+              </div>
+            ` : '<p class="muted">Need profiles:write</p>'}
+            <div class="outbox empty" id="profOut">—</div>
+          </div>
+        </div>
+      </div>
+    `;
+    viewBuilt.profiles = true;
+    let selectedProf = null;
+    async function loadProfs() {
+      try {
+        const r = await api("GET", "/api/v1/profiles");
+        const rows = r.profiles || [];
+        const act = r.active_id || "";
+        const tb = el("profTbody");
+        if (!tb) return;
+        tb.innerHTML = rows.map((p) => `
+          <tr data-pid="${esc(p.id)}" class="${p.id === act ? "selected" : ""}">
+            <td>${esc(p.name || p.id)}</td>
+            <td>${esc(p.channel || "http")}</td>
+            <td>${p.id === act || p.active ? "★" : ""}</td>
+          </tr>`).join("") || '<tr><td colspan="3" class="muted">No profiles</td></tr>';
+        tb.querySelectorAll("tr[data-pid]").forEach((tr) => {
+          tr.onclick = () => {
+            selectedProf = tr.getAttribute("data-pid");
+            tb.querySelectorAll("tr").forEach((x) => x.classList.toggle("selected", x === tr));
+            const row = rows.find((x) => x.id === selectedProf);
+            if (row && el("profName")) {
+              el("profName").value = row.name || "";
+              const uris = (row.http && row.http.uris) || [];
+              if (el("profUris")) el("profUris").value = uris.join(",");
+              if (el("profUa") && row.http) el("profUa").value = row.http.user_agent || "";
+              if (el("profSleep") && row.http) el("profSleep").value = row.http.sleep_sec ?? 5;
+              if (el("profJitter") && row.http) el("profJitter").value = row.http.jitter_pct ?? 20;
+            }
+          };
+        });
+        el("profOut").textContent = "active: " + (act || "none") + " · " + rows.length + " profiles";
+        el("profOut").classList.remove("empty");
+      } catch (e) { showError(String(e.message || e)); }
+    }
+    if (el("profReload")) el("profReload").onclick = () => loadProfs();
+    if (el("profSave")) el("profSave").onclick = async () => {
+      try {
+        const name = (el("profName").value || "").trim();
+        const uris = (el("profUris").value || "").split(",").map((s) => s.trim()).filter(Boolean);
+        const body = {
+          id: selectedProf || undefined,
+          name,
+          channel: "http",
+          http: {
+            uris: uris.length ? uris : ["/api/v1/implant/beacon"],
+            user_agent: el("profUa").value || "Mozilla/5.0",
+            sleep_sec: Number(el("profSleep").value || 5),
+            jitter_pct: Number(el("profJitter").value || 20),
+          },
+        };
+        const r = await api("POST", "/api/v1/profiles", body);
+        showOk("Profile saved");
+        el("profOut").textContent = JSON.stringify(r, null, 2);
+        loadProfs();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("profAct")) el("profAct").onclick = async () => {
+      if (!selectedProf) return showError("Select a profile");
+      try {
+        const r = await api("POST", `/api/v1/profiles/${encodeURIComponent(selectedProf)}/activate`);
+        showOk("Activated");
+        el("profOut").textContent = JSON.stringify(r, null, 2);
+        loadProfs();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("profPush")) el("profPush").onclick = async () => {
+      try {
+        const r = await api("GET", "/api/v1/profiles/active");
+        const id = r.id;
+        const out = await api("POST", `/api/v1/profiles/${encodeURIComponent(id)}/push`, {});
+        showOk("Push queued");
+        el("profOut").textContent = JSON.stringify(out, null, 2);
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    loadProfs();
+  }
+
+  /* —— Artifacts —— */
+  function renderArtifactsView(force) {
+    const root = el("view-artifacts");
+    if (!root) return;
+    if (!force && viewBuilt.artifacts && root.querySelector("#astTbody")) return;
+    root.innerHTML = `
+      <div class="split">
+        <div class="list-panel">
+          <div class="lp-head">Artifacts
+            <select id="astKind" style="margin-left:auto;width:auto;min-height:32px;font-size:0.75rem">
+              <option value="">all</option>
+              <option value="payload">payload</option>
+              <option value="template">template</option>
+              <option value="profile">profile</option>
+              <option value="implant">implant</option>
+              <option value="other">other</option>
+            </select>
+            <button type="button" id="astReload">Reload</button>
+          </div>
+          <div class="lp-body"><table class="data"><thead><tr><th>Name</th><th>Kind</th><th>By</th></tr></thead>
+          <tbody id="astTbody"></tbody></table></div>
+        </div>
+        <div class="work-panel">
+          <div class="wp-head">Preview</div>
+          <div class="wp-body">
+            <div class="row">
+              <button type="button" id="astCopy">Copy</button>
+              <button type="button" class="danger" id="astDel">Delete</button>
+            </div>
+            <div class="outbox empty" id="astPreview" style="max-height:min(60vh,520px);min-height:200px">Select an artifact…</div>
+          </div>
+        </div>
+      </div>
+    `;
+    viewBuilt.artifacts = true;
+    let selectedAst = null;
+    let selectedContent = "";
+    async function loadAst() {
+      try {
+        const kind = el("astKind")?.value || "";
+        const q = kind ? `?kind=${encodeURIComponent(kind)}&limit=100` : "?limit=100";
+        const r = await api("GET", "/api/v1/assets" + q);
+        const rows = r.assets || [];
+        const tb = el("astTbody");
+        tb.innerHTML = rows.map((a) => `
+          <tr data-aid="${esc(a.id)}">
+            <td>${esc(a.name)}</td>
+            <td>${esc(a.kind)}</td>
+            <td class="mono">${esc(a.created_by || "—")}</td>
+          </tr>`).join("") || '<tr><td colspan="3" class="muted">No artifacts yet — generate from Payloads or INKO</td></tr>';
+        tb.querySelectorAll("tr[data-aid]").forEach((tr) => {
+          tr.onclick = async () => {
+            selectedAst = tr.getAttribute("data-aid");
+            tb.querySelectorAll("tr").forEach((x) => x.classList.toggle("selected", x === tr));
+            try {
+              const full = await api("GET", `/api/v1/assets/${encodeURIComponent(selectedAst)}`);
+              selectedContent = full.content || "";
+              el("astPreview").textContent = selectedContent || JSON.stringify(full, null, 2);
+              el("astPreview").classList.remove("empty");
+            } catch (e) { showError(String(e.message || e)); }
+          };
+        });
+      } catch (e) { showError(String(e.message || e)); }
+    }
+    if (el("astReload")) el("astReload").onclick = () => loadAst();
+    if (el("astKind")) el("astKind").onchange = () => loadAst();
+    if (el("astCopy")) el("astCopy").onclick = async () => {
+      try { await navigator.clipboard.writeText(selectedContent || ""); showOk("Copied"); }
+      catch (_) { showError("Clipboard unavailable"); }
+    };
+    if (el("astDel")) el("astDel").onclick = async () => {
+      if (!selectedAst) return showError("Select artifact");
+      try {
+        await api("DELETE", `/api/v1/assets/${encodeURIComponent(selectedAst)}`);
+        selectedAst = null;
+        selectedContent = "";
+        el("astPreview").textContent = "Select an artifact…";
+        el("astPreview").classList.add("empty");
+        showOk("Deleted");
+        loadAst();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    loadAst();
+  }
+
+
   /* —— View router —— */
   function renderView(name) {
     // Soft by default — preserve form focus/values; only build once per view
@@ -1874,6 +2214,8 @@
       case "sessions": renderSessionsView(false); break;
       case "listeners": renderListenersView(false); break;
       case "payloads": renderPayloadsView(false); break;
+      case "profiles": renderProfilesView(false); break;
+      case "artifacts": renderArtifactsView(false); break;
       case "postex": renderPostexView(false); break;
       case "collab": renderCollabView(false); break;
       case "ai": renderAiView(false); break;

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -211,7 +211,13 @@
     }
     .main-head h2 { margin: 0; font-size: 0.95rem; font-weight: 700; }
     .main-head .sub { font-size: 0.75rem; color: var(--muted); }
-    .main-head .tools { margin-left: auto; display: flex; gap: 6px; flex-wrap: wrap; }
+    .main-head > div:first-child { min-width: 0; flex: 1; }
+    .main-head-actions {
+      margin-left: auto;
+      display: flex; align-items: center; gap: 6px; flex-shrink: 0;
+    }
+    .main-head .tools { margin-left: 0; display: flex; gap: 6px; flex-wrap: wrap; }
+    .main-head .docs-drop { margin-left: 0; }
     .main-body {
       flex: 1; min-height: 0; overflow: auto;
       padding: 12px 14px;
@@ -872,6 +878,7 @@
         font-size: 0.68rem;
         white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
       }
+      .main-head-actions { margin-left: auto; flex-shrink: 0; }
       .main-head .tools { margin-left: 0; flex-shrink: 0; }
       .docs-drop { flex-shrink: 0; }
       .docs-menu {
@@ -963,6 +970,8 @@
         <button type="button" class="nav-item" data-view="sessions"><span class="ico">◉</span> Sessions <span class="badge-n" id="navNSes">0</span></button>
         <button type="button" class="nav-item" data-view="listeners"><span class="ico">◎</span> Listeners <span class="badge-n" id="navNLis">0</span></button>
         <button type="button" class="nav-item" data-view="payloads"><span class="ico">⌘</span> Payloads</button>
+        <button type="button" class="nav-item" data-view="profiles"><span class="ico">▦</span> Profiles</button>
+        <button type="button" class="nav-item" data-view="artifacts"><span class="ico">⧉</span> Artifacts</button>
         <button type="button" class="nav-item" data-view="postex"><span class="ico">⚡</span> Post-Ex</button>
         <button type="button" class="nav-item" data-view="collab"><span class="ico">⇄</span> Collab</button>
         <button type="button" class="nav-item" data-view="ai" id="navAi"><span class="ico">◈</span> INKO</button>
@@ -981,11 +990,13 @@
           <h2 id="viewTitle">Dashboard</h2>
           <div class="sub" id="viewSub">Overview of this teamserver</div>
         </div>
-        <div class="docs-drop" id="docsDrop">
-          <button type="button" id="viewDocsBtn" title="Documentation for this page">Docs ▾</button>
-          <div class="docs-menu" id="viewDocsMenu"></div>
+        <div class="main-head-actions">
+          <div class="docs-drop" id="docsDrop">
+            <button type="button" id="viewDocsBtn" title="Documentation for this page">Docs ▾</button>
+            <div class="docs-menu" id="viewDocsMenu"></div>
+          </div>
+          <div class="tools" id="viewTools"></div>
         </div>
-        <div class="tools" id="viewTools"></div>
       </div>
       <div class="main-body" id="mainBody">
         <!-- Views filled by ops-admin.js after auth; shell shows login empty states -->
@@ -1012,6 +1023,8 @@
         <div class="view" id="view-sessions"></div>
         <div class="view" id="view-listeners"></div>
         <div class="view" id="view-payloads"></div>
+        <div class="view" id="view-profiles"></div>
+        <div class="view" id="view-artifacts"></div>
         <div class="view" id="view-postex"></div>
         <div class="view" id="view-collab"></div>
         <div class="view" id="view-ai"></div>
@@ -1036,6 +1049,7 @@
       <div class="ai-drawer-body" id="aiChatLog"></div>
       <div class="ai-drawer-foot" id="aiDrawerFoot">
         <select id="aiLlmGlobal" title="LLM connection"></select>
+        <select id="aiModelGlobal" title="Model" disabled><option value="">Model…</option></select>
         <textarea id="aiPromptGlobal" rows="3" placeholder="Ask INKO anything - list sessions, spin up a listener…"></textarea>
         <div class="row" style="margin:0;gap:6px">
           <button type="button" class="primary" id="aiSendGlobal" style="flex:1">Send</button>
@@ -1203,6 +1217,8 @@
     sessions: { title: "Sessions", sub: "Beacons and reverse shells", doc: "sessions" },
     listeners: { title: "Listeners", sub: "Bind ports and manage acceptors", doc: "listeners" },
     payloads: { title: "Payloads", sub: "Generate implants and templates", doc: "payloads-and-implants" },
+    profiles: { title: "Profiles", sub: "Malleable C2 profiles — activate, edit, push", doc: "c2-profiles" },
+    artifacts: { title: "Artifacts", sub: "Saved payloads, templates, profiles, implants", doc: "payloads-and-implants" },
     postex: { title: "Post-Ex", sub: "Files, SOCKS, modules on selected session", doc: "file-ops" },
     collab: { title: "Collab", sub: "Teams, chat, handoff, presence", doc: "multi-operator-collab" },
     ai: { title: "INKO", sub: "Capabilities, status & tools — chat opens from the top-bar flyout", doc: "inko-intelligent-neural-kinetic-operator" },


### PR DESCRIPTION
## Summary
- **Model switcher** on INKO page + flyout: pick connection, load models from provider, switch model (persists via PATCH)
- **Artifacts** page: browse/copy/delete saved payloads, templates, profiles, implants
- **Profiles** page: list, activate, create HTTP profiles, push active
- **Payloads**: all templates from API (builtin+custom), profile select, register custom template, save artifact
- **INKO tools**: register_payload_template, list/activate/upsert profiles, save_asset
- **Docs** menus right-aligned in main-head-actions

## Test plan
- [x] pytest ops_ux extras + AI tests
- [ ] INKO: switch model on configured LLM
- [ ] Profiles page activate/save
- [ ] Artifacts show INKO-saved items
- [ ] Docs button sits on the right