### PR TITLE
feat(auth): token scope update, nav gates, presets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -178,6 +178,7 @@ sc5 output <session_id>
 
 sc5 tokens list
 sc5 tokens create <name> --scopes "a,b,c" [--mcp-tools "t1,t2"]
+sc5 tokens update <id> [--name N] [--scopes "a,b"] [--mcp-tools "t1,t2"]
 sc5 tokens revoke <id>
 
 sc5 ai <capability> [--data "..."] [--llm <id>]

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -210,23 +210,28 @@ sc5 tokens create ops \
  --scopes "sessions:read,sessions:write,tasks:read,tasks:write,listeners:read,listeners:write,payloads:generate,metrics:read,audit:read"
 
 sc5 tokens create ext-ai \
- --scopes "mcp:connect,sessions:read,tasks:read,tasks:write,metrics:read" \
- --mcp-tools "list_sessions,get_session,list_tasks,create_task,get_metrics"
+  --scopes "mcp:connect,sessions:read,tasks:read,tasks:write,metrics:read" \
+  --mcp-tools "list_sessions,get_session,list_tasks,create_task,get_metrics"
+
+# Update scopes without rotating the secret
+sc5 tokens update <id> --scopes "sessions:read,shell:interact,metrics:read"
 ```
 
-Raw `sc5_...` is shown **once** - store in a password manager.
+Raw `sc5_...` is shown **once** on create - store in a password manager. Ops Admin has named presets and Edit/Revoke on the token table. Nav hides pages the token cannot use.
 
 ### Verify
 
 ```bash
 sc5 tokens list
 sc5 login --url ... --token <new> --insecure && sc5 whoami
+# Ops left nav should omit Profiles if profiles:read is missing
 ```
 
 ### See also
 
 - [User guide - Tokens](user-guide.md#tokens)
 - [User guide - MCP tools](user-guide.md#mcp-tools)
+
 
 ---
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1098,22 +1098,34 @@ INKO flyout -> connection + model selects
 
 ### What
 
-Mint and revoke scoped API tokens for operators, automation, or MCP.
+Mint, **update scopes**, list, and revoke scoped API tokens for operators, automation, or MCP. Ops nav only shows pages your scopes allow.
 
 ### Why
 
-Least privilege: phone UI might only need `shell:interact` + `sessions:read`; external AI needs `mcp:connect` + tool allow-list.
+Least privilege: phone UI might only need `shell:interact` + `sessions:read`; external AI needs `mcp:connect` + tool allow-list. Editing scopes does **not** rotate the secret - revoke if compromised.
 
 ### How
 
-1. Choose preset (operator / read-only / listener / AI / admin / custom).
-2. **Mint** - raw `sc5_...` shown **once**.
-3. Revoke from list if compromised.
+1. **Admin -> Tokens** (needs `tokens:manage` or `admin`).
+2. Pick a **preset** (short description under the buttons):
+   - **Read only** - watch sessions/listeners/metrics/audit
+   - **Operator** - shells, tasks, collab, session hygiene
+   - **Listener ops** - bind/manage listeners
+   - **Payload / profiles** - generate implants and edit C2 profiles
+   - **Phone shell** - minimal phone interact
+   - **INKO operator** - AI chat + read context + payloads
+   - **MCP external AI** - MCP connect with default safe tools
+   - **Token admin** - mint/update tokens within grant limits
+   - **Full admin** - break-glass (admin granters only)
+3. **Mint new** - raw `sc5_...` shown **once**.
+4. **Edit** a row to change name/scopes/MCP tools (`PATCH /api/v1/tokens/{id}`), or **Revoke**.
+5. Nav hides Profiles, Post-Ex, etc. when the connected token lacks those scopes.
 
 ### Example
 
 ```bash
-sc5 tokens create phone --scopes "sessions:read,shell:interact,metrics:read"
+sc5 tokens create phone --scopes "sessions:read,shell:interact,metrics:read,collab:use,phone:operator"
+sc5 tokens update <id> --scopes "sessions:read,shell:interact,metrics:read,listeners:read"
 sc5 tokens list
 sc5 tokens revoke <id>
 ```
@@ -1122,6 +1134,7 @@ sc5 tokens revoke <id>
 
 - [Identity](#identity)
 - [MCP tools](#mcp-tools)
+- [Ops console layout](#ops-console-layout)
 - [Runbook - Tokens](operator-runbook.md#tokens)
 
 ---
@@ -1354,7 +1367,7 @@ sc5 profiles list|activate
 sc5 implants families|build|generate
 sc5 oast token create | tokens list | hits
 sc5 shell <session_id> "<cmd>" | sc5 shell all "<cmd>"
-sc5 tokens list|create|revoke
+sc5 tokens list|create|update|revoke
 sc5 ai <capability> [--data "..."] [--llm <id>]
 sc5 llm list|add
 sc5 mcp tools|call

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -522,6 +522,8 @@ def build_api_router() -> APIRouter:
             )
         except KeyError as e:
             raise HTTPException(404, "token not found") from e
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
         except ValueError as e:
             raise HTTPException(400, str(e)) from e
         return row

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -12,7 +12,13 @@ from fastapi.responses import PlainTextResponse, Response, StreamingResponse
 from pydantic import BaseModel, Field
 
 from squidc5.api.deps import get_auth, get_state, require_scope
-from squidc5.auth.tokens import ALL_MCP_TOOLS, DEFAULT_MCP_TOOLS, SCOPES, AuthContext
+from squidc5.auth.tokens import (
+    ALL_MCP_TOOLS,
+    DEFAULT_MCP_TOOLS,
+    SCOPES,
+    AuthContext,
+    scope_catalog,
+)
 from squidc5.paths import web_file
 from squidc5.policy.engine import PolicyDecision
 
@@ -29,6 +35,12 @@ def _policy_http_error(decision: PolicyDecision) -> HTTPException:
 class TokenCreate(BaseModel):
     name: str
     scopes: list[str]
+    mcp_tools: list[str] | None = None
+
+
+class TokenUpdate(BaseModel):
+    name: str | None = None
+    scopes: list[str] | None = None
     mcp_tools: list[str] | None = None
 
 
@@ -399,9 +411,13 @@ def build_api_router() -> APIRouter:
 
     @api.get("/meta")
     async def meta(auth: AuthContext = Depends(get_auth)) -> dict[str, Any]:
+        catalog = scope_catalog()
         return {
             "scopes": sorted(auth.scopes),
             "all_scopes": sorted(SCOPES),
+            "scope_catalog": catalog["scopes"],
+            "scope_presets": catalog["presets"],
+            "privileged_scopes": catalog["privileged_scopes"],
             "default_mcp_tools": sorted(DEFAULT_MCP_TOOLS),
             "all_mcp_tools": sorted(ALL_MCP_TOOLS),
             "mcp_tools": sorted(auth.mcp_tools),
@@ -477,6 +493,38 @@ def build_api_router() -> APIRouter:
         state = get_state(request)
         ok = await state.tokens.revoke(token_id, auth.name)
         return {"revoked": ok}
+
+    @api.patch("/tokens/{token_id}")
+    async def update_token(
+        token_id: str,
+        body: TokenUpdate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tokens:manage", "admin")),
+    ) -> dict[str, Any]:
+        """Update token name/scopes/mcp_tools. Does not rotate the secret."""
+        state = get_state(request)
+        decision = await state.policy.check_and_audit(
+            auth, "tokens.update", resource=token_id, extra={"name": body.name}
+        )
+        if not decision.allowed:
+            raise HTTPException(403, decision.reason)
+        if body.name is None and body.scopes is None and body.mcp_tools is None:
+            raise HTTPException(400, "name, scopes, or mcp_tools required")
+        try:
+            row = await state.tokens.update(
+                token_id,
+                name=body.name,
+                scopes=body.scopes,
+                mcp_tools=body.mcp_tools,
+                actor=auth.name,
+                grantor_scopes=list(auth.scopes),
+                grantor_is_admin=auth.has_scope("admin"),
+            )
+        except KeyError as e:
+            raise HTTPException(404, "token not found") from e
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        return row
 
     # ----- Sessions -----
 

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -41,6 +41,148 @@ SCOPES = frozenset(
     }
 )
 
+# Short operator-facing descriptions (UI checkboxes / docs)
+SCOPE_DESCRIPTIONS: dict[str, str] = {
+    "admin": "Full control - all scopes, admin UI module, privileged grants",
+    "sessions:read": "List and inspect beacons and shells",
+    "sessions:write": "Close and reap sessions",
+    "tasks:read": "List and inspect beacon tasks",
+    "tasks:write": "Create, edit, and cancel tasks",
+    "listeners:read": "List listeners and status",
+    "listeners:write": "Create, start, stop, and delete listeners",
+    "payloads:generate": "Generate payloads/implants and save artifacts",
+    "metrics:read": "Metrics, health details, live event counters",
+    "audit:read": "Read the audit log",
+    "shell:interact": "Run shell commands, file ops, SOCKS, BOF",
+    "ai:use": "INKO chat and Admin AI capabilities",
+    "mcp:connect": "External MCP tool bridge (plus per-token tool list)",
+    "tokens:manage": "Mint, update, list, and revoke non-privileged tokens",
+    "llm:manage": "Configure BYO LLM connections",
+    "policy:manage": "View and edit policy rules",
+    "files:read": "Reserved for file-read least privilege",
+    "files:write": "Reserved for file-write least privilege",
+    "phone:operator": "Phone-oriented operator profile marker",
+    "profiles:read": "List and view malleable C2 profiles",
+    "profiles:write": "Create, edit, activate, and push profiles",
+    "plugins:manage": "Install and enable server plugins",
+    "collab:use": "Teams, claim/handoff, chat, presence",
+    "oast:read": "List OAST tokens and poll hits",
+    "oast:write": "Mint and delete OAST tokens",
+}
+
+# Named presets for mint/edit UI (scopes only; MCP tools optional)
+SCOPE_PRESETS: list[dict[str, Any]] = [
+    {
+        "id": "read_only",
+        "label": "Read only",
+        "description": "Watch sessions, listeners, metrics, and audit - no writes.",
+        "scopes": [
+            "sessions:read",
+            "tasks:read",
+            "listeners:read",
+            "metrics:read",
+            "audit:read",
+            "profiles:read",
+            "oast:read",
+        ],
+    },
+    {
+        "id": "operator",
+        "label": "Operator",
+        "description": "Day-to-day shells, tasks, collab, and session hygiene.",
+        "scopes": [
+            "sessions:read",
+            "sessions:write",
+            "tasks:read",
+            "tasks:write",
+            "shell:interact",
+            "listeners:read",
+            "collab:use",
+            "metrics:read",
+        ],
+    },
+    {
+        "id": "listener_ops",
+        "label": "Listener ops",
+        "description": "Bind and manage listeners only.",
+        "scopes": ["listeners:read", "listeners:write", "metrics:read"],
+    },
+    {
+        "id": "payload_dev",
+        "label": "Payload / profiles",
+        "description": "Generate implants, edit profiles, and save artifacts.",
+        "scopes": [
+            "payloads:generate",
+            "profiles:read",
+            "profiles:write",
+            "listeners:read",
+            "sessions:read",
+            "metrics:read",
+        ],
+    },
+    {
+        "id": "phone_shell",
+        "label": "Phone shell",
+        "description": "Minimal phone console: sessions, shell, metrics, collab.",
+        "scopes": [
+            "sessions:read",
+            "shell:interact",
+            "metrics:read",
+            "collab:use",
+            "phone:operator",
+        ],
+    },
+    {
+        "id": "ai_operator",
+        "label": "INKO operator",
+        "description": "INKO chat plus read context and payload generation.",
+        "scopes": [
+            "ai:use",
+            "sessions:read",
+            "tasks:read",
+            "listeners:read",
+            "metrics:read",
+            "payloads:generate",
+            "profiles:read",
+        ],
+    },
+    {
+        "id": "mcp_external",
+        "label": "MCP external AI",
+        "description": "External model via MCP with default safe tools only.",
+        "scopes": [
+            "mcp:connect",
+            "sessions:read",
+            "tasks:read",
+            "tasks:write",
+            "metrics:read",
+            "audit:read",
+        ],
+        "mcp_tools": [
+            "list_sessions",
+            "get_session",
+            "list_tasks",
+            "create_task",
+            "list_listeners",
+            "get_metrics",
+            "list_audit",
+        ],
+    },
+    {
+        "id": "token_admin",
+        "label": "Token admin",
+        "description": "Mint and update tokens within grant limits (not full admin).",
+        "scopes": ["tokens:manage", "sessions:read", "metrics:read"],
+    },
+    {
+        "id": "full_admin",
+        "label": "Full admin",
+        "description": "Break-glass admin scope (all capabilities).",
+        "scopes": ["admin"],
+        "admin_only": True,
+    },
+]
+
 # Default MCP tools an external AI may call (strict allow-list)
 DEFAULT_MCP_TOOLS = frozenset(
     {
@@ -70,6 +212,37 @@ ALL_MCP_TOOLS = frozenset(
         "interact_shell",
     }
 )
+
+
+def scope_catalog() -> dict[str, Any]:
+    """UI/API catalog: scopes with descriptions + named presets."""
+    priv = frozenset(
+        {"admin", "tokens:manage", "policy:manage", "llm:manage", "plugins:manage"}
+    )
+    scopes = [
+        {
+            "id": s,
+            "description": SCOPE_DESCRIPTIONS.get(s, s),
+            "privileged": s in priv,
+        }
+        for s in sorted(SCOPES)
+    ]
+    presets = [
+        {
+            "id": p["id"],
+            "label": p["label"],
+            "description": p["description"],
+            "scopes": list(p["scopes"]),
+            "mcp_tools": list(p["mcp_tools"]) if p.get("mcp_tools") else None,
+            "admin_only": bool(p.get("admin_only")),
+        }
+        for p in SCOPE_PRESETS
+    ]
+    return {
+        "scopes": scopes,
+        "presets": presets,
+        "privileged_scopes": sorted(priv),
+    }
 
 
 def generate_token() -> str:
@@ -139,6 +312,40 @@ class TokenService:
             raise ValueError("name must not contain control characters")
         return await self.db.rename_token(token_id, clean)
 
+    def _validate_grant(
+        self,
+        scopes: list[str],
+        mcp_tools: list[str] | None,
+        *,
+        grantor_scopes: list[str] | frozenset[str] | None,
+        grantor_is_admin: bool,
+    ) -> tuple[list[str], list[str]]:
+        """Validate scopes/tools a grantor may assign. Returns (scopes, tools)."""
+        invalid = set(scopes) - SCOPES
+        if invalid:
+            raise ValueError(f"Invalid scopes: {sorted(invalid)}")
+        if not grantor_is_admin:
+            priv = set(scopes) & self.PRIVILEGED_SCOPES
+            if priv:
+                raise ValueError(f"Only admin may grant privileged scopes: {sorted(priv)}")
+            if grantor_scopes is not None:
+                missing = set(scopes) - set(grantor_scopes)
+                if missing:
+                    raise ValueError(f"Cannot grant scopes you lack: {sorted(missing)}")
+        tools = list(mcp_tools) if mcp_tools is not None else []
+        if "admin" in scopes and not tools and mcp_tools is None:
+            tools = list(ALL_MCP_TOOLS)
+        elif not tools and "mcp:connect" in scopes and mcp_tools is None:
+            tools = list(DEFAULT_MCP_TOOLS)
+        bad_tools = set(tools) - ALL_MCP_TOOLS
+        if bad_tools:
+            raise ValueError(f"Invalid MCP tools: {sorted(bad_tools)}")
+        if not grantor_is_admin and tools:
+            danger = {"interact_shell", "create_listener", "start_listener", "stop_listener"}
+            if set(tools) & danger:
+                raise ValueError(f"Only admin may grant MCP tools: {sorted(set(tools) & danger)}")
+        return list(scopes), tools
+
     async def create(
         self,
         name: str,
@@ -150,32 +357,12 @@ class TokenService:
         grantor_scopes: list[str] | frozenset[str] | None = None,
         grantor_is_admin: bool = False,
     ) -> tuple[str, str]:
-        invalid = set(scopes) - SCOPES
-        if invalid:
-            raise ValueError(f"Invalid scopes: {sorted(invalid)}")
-        # C01: cannot mint privileges you lack
-        if not grantor_is_admin:
-            priv = set(scopes) & self.PRIVILEGED_SCOPES
-            if priv:
-                raise ValueError(f"Only admin may grant privileged scopes: {sorted(priv)}")
-            if grantor_scopes is not None:
-                missing = set(scopes) - set(grantor_scopes)
-                if missing:
-                    raise ValueError(f"Cannot grant scopes you lack: {sorted(missing)}")
-        tools = list(mcp_tools) if mcp_tools is not None else []
-        if "admin" in scopes and not tools:
-            tools = list(ALL_MCP_TOOLS)
-        elif not tools and "mcp:connect" in scopes:
-            tools = list(DEFAULT_MCP_TOOLS)
-        bad_tools = set(tools) - ALL_MCP_TOOLS
-        if bad_tools:
-            raise ValueError(f"Invalid MCP tools: {sorted(bad_tools)}")
-        # Non-admin cannot grant dangerous MCP tools beyond their own list
-        if not grantor_is_admin and mcp_tools:
-            # strip interact_shell / listener mutators unless grantor is admin
-            danger = {"interact_shell", "create_listener", "start_listener", "stop_listener"}
-            if set(tools) & danger:
-                raise ValueError(f"Only admin may grant MCP tools: {sorted(set(tools) & danger)}")
+        scopes, tools = self._validate_grant(
+            scopes,
+            mcp_tools,
+            grantor_scopes=grantor_scopes,
+            grantor_is_admin=grantor_is_admin,
+        )
         raw = generate_token()
         tid = await self.db.create_token(
             name=name,
@@ -194,6 +381,81 @@ class TokenService:
             risk_score=5,
         )
         return tid, raw
+
+    async def update(
+        self,
+        token_id: str,
+        *,
+        name: str | None = None,
+        scopes: list[str] | None = None,
+        mcp_tools: list[str] | None = None,
+        actor: str = "unknown",
+        grantor_scopes: list[str] | frozenset[str] | None = None,
+        grantor_is_admin: bool = False,
+    ) -> dict[str, Any]:
+        """Update name/scopes/mcp_tools. Does not rotate the secret."""
+        row = await self.db.get_token_by_id(token_id)
+        if not row or row.get("revoked"):
+            raise KeyError("token not found")
+        before = self.parse_row(row)
+        new_name = before["name"]
+        if name is not None:
+            clean = name.strip()
+            if not clean or len(clean) > 64:
+                raise ValueError("name must be 1-64 characters")
+            if any(c in clean for c in "\n\r\t"):
+                raise ValueError("name must not contain control characters")
+            new_name = clean
+        new_scopes = list(before["scopes"])
+        new_tools = list(before.get("mcp_tools") or [])
+        if scopes is not None:
+            new_scopes, validated_tools = self._validate_grant(
+                scopes,
+                mcp_tools if mcp_tools is not None else new_tools,
+                grantor_scopes=grantor_scopes,
+                grantor_is_admin=grantor_is_admin,
+            )
+            if mcp_tools is not None:
+                new_tools = validated_tools
+            elif "mcp:connect" not in new_scopes:
+                new_tools = []
+            else:
+                # keep existing tools if still valid; else default
+                keep = [t for t in new_tools if t in ALL_MCP_TOOLS]
+                new_tools = keep or (
+                    list(DEFAULT_MCP_TOOLS) if "mcp:connect" in new_scopes else []
+                )
+        elif mcp_tools is not None:
+            _, new_tools = self._validate_grant(
+                new_scopes,
+                mcp_tools,
+                grantor_scopes=grantor_scopes,
+                grantor_is_admin=grantor_is_admin,
+            )
+        if scopes is None and mcp_tools is None and name is None:
+            raise ValueError("nothing to update")
+        ok = await self.db.update_token(
+            token_id,
+            name=new_name if name is not None else None,
+            scopes=new_scopes if scopes is not None else None,
+            mcp_tools=new_tools if (scopes is not None or mcp_tools is not None) else None,
+        )
+        if not ok:
+            raise KeyError("token not found")
+        await self.db.audit(
+            actor=actor,
+            actor_type="operator",
+            action="token.update",
+            resource=token_id,
+            details={
+                "from": {"name": before["name"], "scopes": before["scopes"], "mcp_tools": before.get("mcp_tools")},
+                "to": {"name": new_name, "scopes": new_scopes, "mcp_tools": new_tools},
+            },
+            risk_score=5,
+        )
+        updated = await self.db.get_token_by_id(token_id)
+        assert updated is not None
+        return self.parse_row(updated)
 
     async def authenticate(self, raw: str) -> AuthContext | None:
         # sc5_ current; ss2_ accepted for legacy tokens from pre-rebrand installs

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -398,6 +398,13 @@ class TokenService:
         if not row or row.get("revoked"):
             raise KeyError("token not found")
         before = self.parse_row(row)
+        # tokens:manage must not touch tokens that already hold privileged scopes
+        if not grantor_is_admin:
+            held_priv = set(before.get("scopes") or []) & self.PRIVILEGED_SCOPES
+            if held_priv:
+                raise PermissionError(
+                    f"Only admin may modify tokens with privileged scopes: {sorted(held_priv)}"
+                )
         new_name = before["name"]
         if name is not None:
             clean = name.strip()

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -123,6 +123,9 @@ class Client:
     def put(self, path: str, **kwargs: Any) -> Any:
         return self.request("PUT", path, **kwargs)
 
+    def patch(self, path: str, **kwargs: Any) -> Any:
+        return self.request("PATCH", path, **kwargs)
+
     def delete(self, path: str, **kwargs: Any) -> Any:
         return self.request("DELETE", path, **kwargs)
 
@@ -644,6 +647,19 @@ def cmd_tokens_revoke(args: argparse.Namespace, client: Client) -> None:
     pp(client.delete(f"/api/v1/tokens/{args.id}"))
 
 
+def cmd_tokens_update(args: argparse.Namespace, client: Client) -> None:
+    body: dict[str, Any] = {}
+    if args.name:
+        body["name"] = args.name
+    if args.scopes:
+        body["scopes"] = [s.strip() for s in args.scopes.split(",") if s.strip()]
+    if args.mcp_tools is not None:
+        body["mcp_tools"] = [t.strip() for t in args.mcp_tools.split(",") if t.strip()]
+    if not body:
+        raise SystemExit("provide --name and/or --scopes and/or --mcp-tools")
+    pp(client.patch(f"/api/v1/tokens/{args.id}", json=body))
+
+
 def cmd_ai_run(args: argparse.Namespace, client: Client) -> None:
     body: dict[str, Any] = {"capability": args.capability, "user_data": args.data or ""}
     if args.llm:
@@ -1155,6 +1171,12 @@ def build_parser() -> argparse.ArgumentParser:
     tk_rev = tok_sub.add_parser("revoke")
     tk_rev.add_argument("id")
     tk_rev.set_defaults(func=cmd_tokens_revoke, needs_client=True)
+    tk_upd = tok_sub.add_parser("update", help="Update token name/scopes (does not rotate secret)")
+    tk_upd.add_argument("id")
+    tk_upd.add_argument("--name", default=None)
+    tk_upd.add_argument("--scopes", default=None, help="Comma-separated scopes (replaces full set)")
+    tk_upd.add_argument("--mcp-tools", dest="mcp_tools", default=None, help="Comma-separated MCP tools")
+    tk_upd.set_defaults(func=cmd_tokens_update, needs_client=True)
 
     # ai / llm
     ai = sub.add_parser("ai", help="Run Admin AI capability")

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -128,6 +128,42 @@ class Database:
         )
         return cur.rowcount > 0
 
+    async def get_token_by_id(self, token_id: str) -> dict[str, Any] | None:
+        return await self.fetchone(
+            "SELECT id, name, scopes, mcp_tools, created_at, created_by, expires_at, "
+            "revoked, last_used_at FROM tokens WHERE id = ?",
+            (token_id,),
+        )
+
+    async def update_token(
+        self,
+        token_id: str,
+        *,
+        name: str | None = None,
+        scopes: list[str] | None = None,
+        mcp_tools: list[str] | None = None,
+    ) -> bool:
+        """Patch token fields. Does not change token_hash (secret stays the same)."""
+        sets: list[str] = []
+        args: list[Any] = []
+        if name is not None:
+            sets.append("name = ?")
+            args.append(name)
+        if scopes is not None:
+            sets.append("scopes = ?")
+            args.append(json.dumps(scopes))
+        if mcp_tools is not None:
+            sets.append("mcp_tools = ?")
+            args.append(json.dumps(mcp_tools))
+        if not sets:
+            return False
+        args.append(token_id)
+        cur = await self.execute(
+            f"UPDATE tokens SET {', '.join(sets)} WHERE id = ? AND revoked = 0",
+            tuple(args),
+        )
+        return cur.rowcount > 0
+
     # --- Operator assets (saved payloads/profiles/implants) ---
 
     async def create_operator_asset(

--- a/src/squidc5/policy/engine.py
+++ b/src/squidc5/policy/engine.py
@@ -87,6 +87,7 @@ DEFAULT_POLICY: dict[str, Any] = {
         "files.upload": 7,
         "ai.admin": 3,
         "tokens.create": 6,
+        "tokens.update": 6,
         "policy.update": 9,
     },
 }

--- a/tests/test_token_update.py
+++ b/tests/test_token_update.py
@@ -1,0 +1,124 @@
+"""PATCH /api/v1/tokens/{id} - update scopes without rotating secret."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import bearer, mint_token
+
+
+@pytest.mark.asyncio
+async def test_meta_includes_scope_presets(client, admin_headers):
+    r = await client.get("/api/v1/meta", headers=admin_headers)
+    assert r.status_code == 200
+    body = r.json()
+    assert "scope_catalog" in body
+    assert "scope_presets" in body
+    ids = {p["id"] for p in body["scope_presets"]}
+    assert "operator" in ids
+    assert "read_only" in ids
+    assert "full_admin" in ids
+    assert any(s["id"] == "sessions:read" and s.get("description") for s in body["scope_catalog"])
+
+
+@pytest.mark.asyncio
+async def test_patch_token_scopes_preserves_auth(client, admin_headers):
+    created = await mint_token(
+        client, admin_headers, "patch-me", ["sessions:read", "metrics:read"]
+    )
+    tid = created["id"]
+    raw = created["token"]
+    h = bearer(raw)
+
+    # works with original scopes
+    assert (await client.get("/api/v1/sessions", headers=h)).status_code == 200
+    assert (await client.get("/api/v1/listeners", headers=h)).status_code == 403
+
+    r = await client.patch(
+        f"/api/v1/tokens/{tid}",
+        headers=admin_headers,
+        json={"scopes": ["sessions:read", "listeners:read", "metrics:read"]},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert set(body["scopes"]) == {"sessions:read", "listeners:read", "metrics:read"}
+    assert "token" not in body  # secret not re-issued
+
+    # same raw secret still authenticates with new scopes
+    assert (await client.get("/api/v1/listeners", headers=h)).status_code == 200
+    meta = await client.get("/api/v1/meta", headers=h)
+    assert meta.status_code == 200
+    assert "listeners:read" in meta.json()["scopes"]
+
+
+@pytest.mark.asyncio
+async def test_patch_token_name(client, admin_headers):
+    created = await mint_token(client, admin_headers, "old-name", ["sessions:read"])
+    tid = created["id"]
+    r = await client.patch(
+        f"/api/v1/tokens/{tid}",
+        headers=admin_headers,
+        json={"name": "new-name"},
+    )
+    assert r.status_code == 200
+    assert r.json()["name"] == "new-name"
+
+
+@pytest.mark.asyncio
+async def test_tokens_manage_cannot_grant_admin_via_patch(client, admin_headers):
+    mgr = await mint_token(
+        client,
+        admin_headers,
+        "tok-mgr",
+        ["tokens:manage", "sessions:read", "metrics:read"],
+    )
+    target = await mint_token(client, admin_headers, "target", ["sessions:read"])
+    mh = bearer(mgr["token"])
+    r = await client.patch(
+        f"/api/v1/tokens/{target['id']}",
+        headers=mh,
+        json={"scopes": ["admin"]},
+    )
+    assert r.status_code == 400
+    assert "admin" in r.text.lower() or "privileged" in r.text.lower()
+
+
+@pytest.mark.asyncio
+async def test_tokens_manage_cannot_grant_missing_scope(client, admin_headers):
+    mgr = await mint_token(
+        client,
+        admin_headers,
+        "tok-mgr2",
+        ["tokens:manage", "sessions:read"],
+    )
+    target = await mint_token(client, admin_headers, "target2", ["sessions:read"])
+    mh = bearer(mgr["token"])
+    r = await client.patch(
+        f"/api/v1/tokens/{target['id']}",
+        headers=mh,
+        json={"scopes": ["sessions:read", "shell:interact"]},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_patch_revoked_token_404(client, admin_headers):
+    created = await mint_token(client, admin_headers, "gone", ["sessions:read"])
+    tid = created["id"]
+    assert (await client.delete(f"/api/v1/tokens/{tid}", headers=admin_headers)).status_code == 200
+    r = await client.patch(
+        f"/api/v1/tokens/{tid}",
+        headers=admin_headers,
+        json={"scopes": ["metrics:read"]},
+    )
+    assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_patch_empty_body_400(client, admin_headers):
+    created = await mint_token(client, admin_headers, "empty", ["sessions:read"])
+    r = await client.patch(
+        f"/api/v1/tokens/{created['id']}",
+        headers=admin_headers,
+        json={},
+    )
+    assert r.status_code == 400

--- a/tests/test_token_update.py
+++ b/tests/test_token_update.py
@@ -122,3 +122,29 @@ async def test_patch_empty_body_400(client, admin_headers):
         json={},
     )
     assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_tokens_manage_cannot_modify_privileged_token(client, admin_headers):
+    """tokens:manage must not demote/edit tokens that already hold admin/etc."""
+    mgr = await mint_token(
+        client,
+        admin_headers,
+        "tok-mgr3",
+        ["tokens:manage", "sessions:read", "metrics:read"],
+    )
+    # Find bootstrap/admin token id via list
+    listed = await client.get("/api/v1/tokens", headers=admin_headers)
+    assert listed.status_code == 200
+    admin_tok = next(
+        (t for t in listed.json() if "admin" in (t.get("scopes") or []) and not t.get("revoked")),
+        None,
+    )
+    assert admin_tok is not None
+    mh = bearer(mgr["token"])
+    r = await client.patch(
+        f"/api/v1/tokens/{admin_tok['id']}",
+        headers=mh,
+        json={"scopes": ["sessions:read"]},
+    )
+    assert r.status_code == 403

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1851,43 +1851,87 @@
     const root = el("view-admin");
     if (!root) return;
     if (!force && viewBuilt.admin && root.children.length) return;
-    if (!can("admin") && !can("tokens:manage") && !can("policy:manage")) {
+    if (!can("admin") && !can("tokens:manage") && !can("policy:manage") && !can("llm:manage")) {
       root.innerHTML = '<div class="empty-state"><strong>Admin area</strong>Requires admin or manage scopes.</div>';
       return;
     }
-    const defaultScopes = new Set([
+    const meta = state.meta || {};
+    const catalog = meta.scope_catalog || [];
+    const presets = (meta.scope_presets || []).filter((p) => !p.admin_only || can("admin"));
+    const privileged = new Set(meta.privileged_scopes || ["admin", "tokens:manage", "policy:manage", "llm:manage", "plugins:manage"]);
+    const allScopes = catalog.length
+      ? catalog.map((c) => c.id)
+      : [
+          "sessions:read", "sessions:write", "tasks:read", "tasks:write",
+          "listeners:read", "listeners:write", "payloads:generate", "shell:interact",
+          "metrics:read", "audit:read", "ai:use", "collab:use", "profiles:read", "profiles:write",
+          "files:read", "files:write", "oast:read", "oast:write", "mcp:connect", "phone:operator",
+          "tokens:manage", "llm:manage", "policy:manage", "plugins:manage", "admin",
+        ];
+    const descMap = {};
+    catalog.forEach((c) => { descMap[c.id] = c.description || ""; });
+    const defaultPreset = presets.find((p) => p.id === "operator") || presets[0];
+    const defaultScopes = new Set((defaultPreset && defaultPreset.scopes) || [
       "sessions:read", "sessions:write", "tasks:read", "tasks:write",
       "shell:interact", "listeners:read", "collab:use", "metrics:read",
     ]);
-    const allScopes = [
-      "sessions:read", "sessions:write", "tasks:read", "tasks:write",
-      "listeners:read", "listeners:write", "payloads:generate", "shell:interact",
-      "metrics:read", "audit:read", "ai:use", "collab:use", "profiles:read", "profiles:write",
-      "files:read", "files:write", "oast:read", "oast:write", "mcp:connect",
-      "tokens:manage", "llm:manage", "policy:manage", "plugins:manage", "admin",
-    ];
+    const scopeLabel = (s) => {
+      const d = descMap[s] || "";
+      return d
+        ? `<span class="mono" style="font-size:0.72rem">${esc(s)}</span><span class="muted" style="display:block;font-size:0.65rem;line-height:1.25;margin-top:2px;text-transform:none;letter-spacing:0;font-weight:400">${esc(d)}</span>`
+        : `<span class="mono" style="font-size:0.72rem">${esc(s)}</span>`;
+    };
+    const presetBtns = presets.map((p) =>
+      `<button type="button" class="ad-preset" data-preset="${esc(p.id)}" title="${esc(p.description || "")}">${esc(p.label || p.id)}</button>`
+    ).join("") +
+      `<button type="button" id="adScopeNone">Clear</button>` +
+      (can("admin") ? `<button type="button" id="adScopeAll">All non-admin</button>` : "");
     root.innerHTML = `
       <div class="admin-stack">
         <div class="admin-row">
           <div class="work-panel">
-            <div class="wp-head">Mint token</div>
+            <div class="wp-head">Tokens</div>
             <div class="wp-body">
+              <p class="muted" style="font-size:0.75rem;margin:0 0 8px">Mint a new token or select one below to update scopes. Updating scopes does <strong>not</strong> rotate the secret - revoke if compromised.</p>
               <label>Name</label><input id="adName" placeholder="operator-1" />
+              <input type="hidden" id="adEditId" value="" />
+              <label>Presets</label>
+              <div class="row" style="margin:4px 0;gap:6px" id="adPresetRow">${presetBtns}</div>
+              <p class="muted" id="adPresetDesc" style="font-size:0.72rem;margin:4px 0 8px;min-height:2.2em">${esc((defaultPreset && defaultPreset.description) || "Pick a preset or tick scopes manually.")}</p>
               <label>Scopes</label>
-              <div class="row" style="margin:4px 0">
-                <button type="button" id="adScopeOp">Operator preset</button>
-                <button type="button" id="adScopeNone">Clear</button>
-                <button type="button" id="adScopeAll">All non-admin</button>
+              <div class="scope-grid" id="adScopeGrid" style="max-height:320px">
+                ${allScopes.map((s) => {
+                  const priv = privileged.has(s);
+                  const dis = priv && !can("admin");
+                  return `<label style="align-items:flex-start">
+                    <input type="checkbox" class="ad-scope" value="${esc(s)}"
+                      ${defaultScopes.has(s) ? "checked" : ""}
+                      ${dis ? "disabled" : ""} style="margin-top:3px" />
+                    <span>${scopeLabel(s)}</span>
+                  </label>`;
+                }).join("")}
               </div>
-              <div class="scope-grid" id="adScopeGrid">
-                ${allScopes.map((s) => `
-                  <label><input type="checkbox" class="ad-scope" value="${esc(s)}"
-                    ${defaultScopes.has(s) ? "checked" : ""}
-                    ${s === "admin" && !can("admin") ? "disabled" : ""} /> ${esc(s)}</label>
-                `).join("")}
+              <label class="chk-inline" style="margin-top:10px">
+                <input type="checkbox" id="adMcpShow" /> Show MCP tool allow-list (when mcp:connect)
+              </label>
+              <div id="adMcpBox" class="hidden" style="margin-top:8px">
+                <label>MCP tools</label>
+                <div class="scope-grid" id="adMcpGrid" style="max-height:140px">
+                  ${(meta.all_mcp_tools || []).map((t) =>
+                    `<label><input type="checkbox" class="ad-mcp" value="${esc(t)}" /> <span class="mono" style="font-size:0.72rem">${esc(t)}</span></label>`
+                  ).join("") || '<span class="muted">No MCP catalog</span>'}
+                </div>
               </div>
-              <div class="row"><button type="button" class="primary" id="adMint">Mint</button></div>
-              <div class="outbox empty" id="adMintOut">Token shown once</div>
+              <div class="row" style="margin-top:10px">
+                <button type="button" class="primary" id="adMint">Mint new</button>
+                <button type="button" id="adSaveEdit" disabled>Save changes</button>
+                <button type="button" id="adCancelEdit" class="hidden">Cancel edit</button>
+              </div>
+              <div class="outbox empty" id="adMintOut">New token secret shown once after mint</div>
+              <div class="row" style="margin-top:12px">
+                <button type="button" id="adTokRefresh">Refresh list</button>
+              </div>
+              <div id="adTokTable" style="margin-top:8px;overflow:auto;max-height:280px"></div>
             </div>
           </div>
           <div class="work-panel">
@@ -1896,7 +1940,6 @@
               <div class="row">
                 <button type="button" id="adPolGet">Get policy</button>
                 <button type="button" id="adFeat">Features</button>
-                <button type="button" id="adTokList">List tokens</button>
               </div>
               <div class="outbox empty" id="adOut" style="max-height:min(420px,50vh);flex:1">-</div>
             </div>
@@ -2027,27 +2070,169 @@
     function selectedScopes() {
       return Array.from(document.querySelectorAll(".ad-scope:checked")).map((c) => c.value);
     }
+    function selectedMcp() {
+      return Array.from(document.querySelectorAll(".ad-mcp:checked")).map((c) => c.value);
+    }
     function setScopes(set) {
       document.querySelectorAll(".ad-scope").forEach((c) => {
         if (c.disabled) return;
         c.checked = set.has(c.value);
       });
+      syncMcpVisibility();
     }
-    if (el("adScopeOp")) el("adScopeOp").onclick = () => setScopes(defaultScopes);
-    if (el("adScopeNone")) el("adScopeNone").onclick = () => setScopes(new Set());
+    function setMcp(list) {
+      const want = new Set(list || []);
+      document.querySelectorAll(".ad-mcp").forEach((c) => {
+        c.checked = want.has(c.value);
+      });
+    }
+    function syncMcpVisibility() {
+      const show = !!(el("adMcpShow") && el("adMcpShow").checked) || selectedScopes().includes("mcp:connect");
+      if (el("adMcpBox")) el("adMcpBox").classList.toggle("hidden", !show);
+      if (el("adMcpShow") && selectedScopes().includes("mcp:connect")) el("adMcpShow").checked = true;
+    }
+    function clearEditMode() {
+      if (el("adEditId")) el("adEditId").value = "";
+      if (el("adSaveEdit")) el("adSaveEdit").disabled = true;
+      if (el("adCancelEdit")) el("adCancelEdit").classList.add("hidden");
+      if (el("adMint")) el("adMint").disabled = false;
+      if (el("adName")) el("adName").value = "";
+      setScopes(defaultScopes);
+      setMcp([]);
+    }
+    function enterEditMode(tok) {
+      if (!tok || tok.revoked) return;
+      if (el("adEditId")) el("adEditId").value = tok.id || "";
+      if (el("adName")) el("adName").value = tok.name || "";
+      setScopes(new Set(tok.scopes || []));
+      setMcp(tok.mcp_tools || []);
+      if (el("adSaveEdit")) el("adSaveEdit").disabled = false;
+      if (el("adCancelEdit")) el("adCancelEdit").classList.remove("hidden");
+      if (el("adMint")) el("adMint").disabled = true;
+      if (el("adMintOut")) {
+        el("adMintOut").textContent = "Editing " + (tok.id || "") + " - save applies scopes without rotating the secret.";
+        el("adMintOut").classList.remove("empty");
+      }
+    }
+    async function loadTokenTable() {
+      const box = el("adTokTable");
+      if (!box || !can("tokens:manage") && !can("admin")) {
+        if (box) box.innerHTML = '<p class="muted">tokens:manage required to list tokens</p>';
+        return;
+      }
+      try {
+        const rows = await api("GET", "/api/v1/tokens");
+        const list = Array.isArray(rows) ? rows : [];
+        if (!list.length) {
+          box.innerHTML = '<p class="muted">No tokens yet.</p>';
+          return;
+        }
+        box.innerHTML = `<table class="data"><thead><tr>
+          <th>Name</th><th>Scopes</th><th>Status</th><th></th>
+        </tr></thead><tbody>
+        ${list.map((t) => {
+          const sc = (t.scopes || []).slice(0, 6).map((s) => esc(s)).join(", ");
+          const more = (t.scopes || []).length > 6 ? " +" + ((t.scopes || []).length - 6) : "";
+          const st = t.revoked ? '<span class="chip">revoked</span>' : '<span class="chip ok">active</span>';
+          return `<tr data-tid="${esc(t.id)}">
+            <td><strong>${esc(t.name || "")}</strong><div class="mono muted" style="font-size:0.65rem">${esc(t.id || "")}</div></td>
+            <td style="font-size:0.72rem;max-width:220px">${sc}${more}</td>
+            <td>${st}</td>
+            <td class="row" style="margin:0">
+              ${!t.revoked ? `<button type="button" data-tok-edit="${esc(t.id)}">Edit</button>` : ""}
+              ${!t.revoked ? `<button type="button" class="danger" data-tok-rev="${esc(t.id)}">Revoke</button>` : ""}
+            </td>
+          </tr>`;
+        }).join("")}
+        </tbody></table>`;
+        box.querySelectorAll("[data-tok-edit]").forEach((b) => {
+          b.onclick = () => {
+            const id = b.getAttribute("data-tok-edit");
+            const tok = list.find((x) => x.id === id);
+            if (tok) enterEditMode(tok);
+          };
+        });
+        box.querySelectorAll("[data-tok-rev]").forEach((b) => {
+          b.onclick = async () => {
+            const id = b.getAttribute("data-tok-rev");
+            if (!id || !confirm("Revoke token " + id + "?")) return;
+            try {
+              await api("DELETE", "/api/v1/tokens/" + encodeURIComponent(id));
+              showOk("Revoked");
+              if (el("adEditId") && el("adEditId").value === id) clearEditMode();
+              loadTokenTable();
+            } catch (e) { showError(String(e.message || e)); }
+          };
+        });
+      } catch (e) {
+        box.innerHTML = '<p class="muted">Failed to load tokens</p>';
+        showError(String(e.message || e));
+      }
+    }
+    document.querySelectorAll(".ad-preset").forEach((b) => {
+      b.onclick = () => {
+        const id = b.getAttribute("data-preset");
+        const p = presets.find((x) => x.id === id);
+        if (!p) return;
+        if (el("adPresetDesc")) el("adPresetDesc").textContent = p.description || "";
+        setScopes(new Set(p.scopes || []));
+        if (p.mcp_tools) {
+          setMcp(p.mcp_tools);
+          if (el("adMcpShow")) el("adMcpShow").checked = true;
+          syncMcpVisibility();
+        }
+      };
+    });
+    if (el("adScopeNone")) el("adScopeNone").onclick = () => {
+      if (el("adPresetDesc")) el("adPresetDesc").textContent = "No scopes selected.";
+      setScopes(new Set());
+    };
     if (el("adScopeAll")) el("adScopeAll").onclick = () => {
+      if (el("adPresetDesc")) el("adPresetDesc").textContent = "All non-admin scopes.";
       setScopes(new Set(allScopes.filter((s) => s !== "admin" || can("admin"))));
     };
+    if (el("adMcpShow")) el("adMcpShow").onchange = () => syncMcpVisibility();
+    document.querySelectorAll(".ad-scope").forEach((c) => {
+      c.addEventListener("change", () => syncMcpVisibility());
+    });
+    if (el("adCancelEdit")) el("adCancelEdit").onclick = () => clearEditMode();
     if (el("adMint")) el("adMint").onclick = async () => {
       try {
         const scopes = selectedScopes();
         if (!scopes.length) return showError("Select at least one scope");
-        const r = await api("POST", "/api/v1/tokens", { name: el("adName").value.trim() || "op", scopes });
+        const body = { name: (el("adName").value || "").trim() || "op", scopes };
+        if (scopes.includes("mcp:connect")) {
+          const tools = selectedMcp();
+          if (tools.length) body.mcp_tools = tools;
+        }
+        const r = await api("POST", "/api/v1/tokens", body);
         el("adMintOut").textContent = r.token || JSON.stringify(r, null, 2);
         el("adMintOut").classList.remove("empty");
         showOk("Token minted - copy now");
+        loadTokenTable();
       } catch (e) { showError(String(e.message || e)); }
     };
+    if (el("adSaveEdit")) el("adSaveEdit").onclick = async () => {
+      try {
+        const id = (el("adEditId") && el("adEditId").value) || "";
+        if (!id) return showError("No token selected");
+        const scopes = selectedScopes();
+        if (!scopes.length) return showError("Select at least one scope");
+        const body = {
+          name: (el("adName").value || "").trim() || undefined,
+          scopes,
+        };
+        if (scopes.includes("mcp:connect")) body.mcp_tools = selectedMcp();
+        else body.mcp_tools = [];
+        await api("PATCH", "/api/v1/tokens/" + encodeURIComponent(id), body);
+        showOk("Token updated (secret unchanged)");
+        clearEditMode();
+        loadTokenTable();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("adTokRefresh")) el("adTokRefresh").onclick = () => loadTokenTable();
+    syncMcpVisibility();
+    if (can("tokens:manage") || can("admin")) loadTokenTable();
     const dump = async (path) => {
       try {
         const r = await api("GET", path);
@@ -2057,7 +2242,6 @@
     };
     if (el("adPolGet")) el("adPolGet").onclick = () => dump("/api/v1/policy");
     if (el("adFeat")) el("adFeat").onclick = () => dump("/api/v1/features");
-    if (el("adTokList")) el("adTokList").onclick = () => dump("/api/v1/tokens");
   }
 
 

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -1205,6 +1205,48 @@
     if (state.scopes.indexOf("admin") >= 0) return true;
     return state.scopes.indexOf(scope) >= 0;
   }
+  function canAny(list) {
+    if (!list || !list.length) return true;
+    return list.some((s) => can(s));
+  }
+  /* Nav data-view -> any-of scopes (dashboard always shown when connected) */
+  const NAV_GATES = {
+    sessions: ["sessions:read"],
+    listeners: ["listeners:read"],
+    payloads: ["payloads:generate"],
+    profiles: ["profiles:read"],
+    artifacts: ["payloads:generate", "profiles:read"],
+    postex: ["shell:interact"],
+    collab: ["collab:use"],
+    ai: ["ai:use"],
+    observe: ["metrics:read", "audit:read"],
+    admin: ["admin", "tokens:manage", "policy:manage", "llm:manage"],
+  };
+  function applyNavGates() {
+    document.querySelectorAll(".nav-item[data-view]").forEach((b) => {
+      const v = b.getAttribute("data-view");
+      if (v === "dashboard") {
+        b.classList.remove("hidden");
+        return;
+      }
+      const need = NAV_GATES[v];
+      if (!need) return;
+      b.classList.toggle("hidden", !canAny(need));
+    });
+  }
+  function firstAllowedView(preferred) {
+    if (!preferred || preferred === "dashboard") return "dashboard";
+    const need = NAV_GATES[preferred];
+    if (!need || canAny(need)) return preferred;
+    const order = [
+      "sessions", "listeners", "payloads", "profiles", "artifacts",
+      "postex", "collab", "ai", "observe", "admin",
+    ];
+    for (const v of order) {
+      if (canAny(NAV_GATES[v] || [])) return v;
+    }
+    return "dashboard";
+  }
   async function api(method, path, body) {
     const base = apiBase();
     const token = cfg().token;
@@ -1269,8 +1311,10 @@
   if ($("navBackdrop")) $("navBackdrop").onclick = () => closeNavDrawer();
 
   function setView(name) {
-    if (name === "admin" && !can("admin") && !can("tokens:manage") && !can("policy:manage")) name = "dashboard";
-    if (name === "ai" && !can("ai:use") && !can("admin")) name = "dashboard";
+    if (name !== "dashboard") {
+      const need = NAV_GATES[name];
+      if (need && !canAny(need)) name = firstAllowedView("dashboard");
+    }
     currentView = name;
     document.querySelectorAll(".nav-item").forEach((b) => {
       b.classList.toggle("active", b.getAttribute("data-view") === name);
@@ -1444,8 +1488,7 @@
       $("hostLine").textContent = apiBase();
       $("roleBadge").textContent = state.scopes.indexOf("admin") >= 0 ? "admin" : (state.actor || "op");
       $("roleBadge").classList.remove("hidden");
-      $("navAdmin").classList.toggle("hidden", !(can("admin") || can("tokens:manage") || can("policy:manage")));
-      if ($("navAi")) $("navAi").classList.toggle("hidden", !(can("ai:use") || can("admin")));
+      applyNavGates();
       $("dashEmpty").classList.add("hidden");
       $("dashContent").classList.remove("hidden");
       await loadAdminModule();
@@ -1453,6 +1496,9 @@
       if (timer) clearInterval(timer);
       timer = setInterval(() => refresh().catch(() => {}), c.refresh * 1000);
       showOk("Connected as " + state.actor);
+      // Drop onto a view the token may open
+      const want = currentView || "dashboard";
+      setView(firstAllowedView(want));
 
     const wantActor = ($("actorName") && $("actorName").value || "").trim();
     if (wantActor && wantActor !== state.actor) {


### PR DESCRIPTION
## Summary
- **Update token permissions** via \`PATCH /api/v1/tokens/{id}\` and \`sc5 tokens update\` (does not rotate secret)
- **Nav gating**: hide Sessions/Listeners/Profiles/Post-Ex/etc. when the connected token lacks scopes
- **Named presets** with short descriptions (read-only, operator, listener ops, payload/profiles, phone shell, INKO, MCP, token admin, full admin)
- Admin Tokens UI: preset buttons, scope descriptions, edit/revoke table, optional MCP tools

## Test plan
- [x] pytest token_update + permissions + security hardening
- [ ] Admin: mint with Operator preset; Edit scopes; Revoke
- [ ] Login as phone-shell token - Profiles/Listeners hidden
- [ ] \`sc5 tokens update <id> --scopes "..."\`