### PR TITLE
feat(auth): mint banner with connect link + token roll

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,6 +179,7 @@ sc5 output <session_id>
 sc5 tokens list
 sc5 tokens create <name> --scopes "a,b,c" [--mcp-tools "t1,t2"]
 sc5 tokens update <id> [--name N] [--scopes "a,b"] [--mcp-tools "t1,t2"]
+sc5 tokens roll <id>
 sc5 tokens revoke <id>
 
 sc5 ai <capability> [--data "..."] [--llm <id>]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1117,15 +1117,18 @@ Least privilege: phone UI might only need `shell:interact` + `sessions:read`; ex
    - **MCP external AI** - MCP connect with default safe tools
    - **Token admin** - mint/update tokens within grant limits
    - **Full admin** - break-glass (admin granters only)
-3. **Mint new** - raw `sc5_...` shown **once**.
-4. **Edit** a row to change name/scopes/MCP tools (`PATCH /api/v1/tokens/{id}`), or **Revoke**.
-5. Nav hides Profiles, Post-Ex, etc. when the connected token lacks those scopes.
+3. **Mint new** - a green banner shows the secret **and a connection link** (`/ops#sc5=...`) until you **Close** it.
+4. **Edit** a row to change name/scopes/MCP tools (`PATCH /api/v1/tokens/{id}`) without rotating the secret.
+5. **Roll** rotates the secret (old stops working); new secret appears in the same banner.
+6. **Revoke** disables the token entirely.
+7. Nav hides Profiles, Post-Ex, etc. when the connected token lacks those scopes.
 
 ### Example
 
 ```bash
 sc5 tokens create phone --scopes "sessions:read,shell:interact,metrics:read,collab:use,phone:operator"
 sc5 tokens update <id> --scopes "sessions:read,shell:interact,metrics:read,listeners:read"
+sc5 tokens roll <id>
 sc5 tokens list
 sc5 tokens revoke <id>
 ```

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -494,6 +494,38 @@ def build_api_router() -> APIRouter:
         ok = await state.tokens.revoke(token_id, auth.name)
         return {"revoked": ok}
 
+    @api.post("/tokens/{token_id}/roll")
+    async def roll_token(
+        token_id: str,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tokens:manage", "admin")),
+    ) -> dict[str, Any]:
+        """Rotate token secret. Old secret stops working; new secret returned once."""
+        state = get_state(request)
+        decision = await state.policy.check_and_audit(
+            auth, "tokens.roll", resource=token_id
+        )
+        if not decision.allowed:
+            raise HTTPException(403, decision.reason)
+        try:
+            row, raw = await state.tokens.roll(
+                token_id,
+                actor=auth.name,
+                grantor_is_admin=auth.has_scope("admin"),
+            )
+        except KeyError as e:
+            raise HTTPException(404, "token not found") from e
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
+        return {
+            "id": row["id"],
+            "name": row["name"],
+            "scopes": row["scopes"],
+            "mcp_tools": row.get("mcp_tools") or [],
+            "token": raw,
+            "rolled": True,
+        }
+
     @api.patch("/tokens/{token_id}")
     async def update_token(
         token_id: str,

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -496,6 +496,43 @@ class TokenService:
         )
         return ok
 
+    async def roll(
+        self,
+        token_id: str,
+        *,
+        actor: str = "unknown",
+        grantor_is_admin: bool = False,
+    ) -> tuple[dict[str, Any], str]:
+        """Rotate the secret for an active token. Old secret stops working immediately.
+
+        Returns (token_row_without_secret, new_raw_token).
+        """
+        row = await self.db.get_token_by_id(token_id)
+        if not row or row.get("revoked"):
+            raise KeyError("token not found")
+        before = self.parse_row(row)
+        if not grantor_is_admin:
+            held_priv = set(before.get("scopes") or []) & self.PRIVILEGED_SCOPES
+            if held_priv:
+                raise PermissionError(
+                    f"Only admin may roll tokens with privileged scopes: {sorted(held_priv)}"
+                )
+        raw = generate_token()
+        ok = await self.db.update_token(token_id, token_hash=hash_token(raw))
+        if not ok:
+            raise KeyError("token not found")
+        await self.db.audit(
+            actor=actor,
+            actor_type="operator",
+            action="token.roll",
+            resource=token_id,
+            details={"name": before.get("name"), "scopes": before.get("scopes")},
+            risk_score=6,
+        )
+        updated = await self.db.get_token_by_id(token_id)
+        assert updated is not None
+        return self.parse_row(updated), raw
+
     def parse_row(self, row: dict[str, Any]) -> dict[str, Any]:
         out = dict(row)
         out["scopes"] = json.loads(row["scopes"]) if isinstance(row["scopes"], str) else row["scopes"]

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -660,6 +660,11 @@ def cmd_tokens_update(args: argparse.Namespace, client: Client) -> None:
     pp(client.patch(f"/api/v1/tokens/{args.id}", json=body))
 
 
+def cmd_tokens_roll(args: argparse.Namespace, client: Client) -> None:
+    """Rotate secret; prints new token once."""
+    pp(client.post(f"/api/v1/tokens/{args.id}/roll"))
+
+
 def cmd_ai_run(args: argparse.Namespace, client: Client) -> None:
     body: dict[str, Any] = {"capability": args.capability, "user_data": args.data or ""}
     if args.llm:
@@ -1177,6 +1182,9 @@ def build_parser() -> argparse.ArgumentParser:
     tk_upd.add_argument("--scopes", default=None, help="Comma-separated scopes (replaces full set)")
     tk_upd.add_argument("--mcp-tools", dest="mcp_tools", default=None, help="Comma-separated MCP tools")
     tk_upd.set_defaults(func=cmd_tokens_update, needs_client=True)
+    tk_roll = tok_sub.add_parser("roll", help="Rotate token secret (old secret stops working)")
+    tk_roll.add_argument("id")
+    tk_roll.set_defaults(func=cmd_tokens_roll, needs_client=True)
 
     # ai / llm
     ai = sub.add_parser("ai", help="Run Admin AI capability")

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -142,8 +142,9 @@ class Database:
         name: str | None = None,
         scopes: list[str] | None = None,
         mcp_tools: list[str] | None = None,
+        token_hash: str | None = None,
     ) -> bool:
-        """Patch token fields. Does not change token_hash (secret stays the same)."""
+        """Patch token fields. token_hash set only on roll (secret rotate)."""
         sets: list[str] = []
         args: list[Any] = []
         if name is not None:
@@ -155,6 +156,9 @@ class Database:
         if mcp_tools is not None:
             sets.append("mcp_tools = ?")
             args.append(json.dumps(mcp_tools))
+        if token_hash is not None:
+            sets.append("token_hash = ?")
+            args.append(token_hash)
         if not sets:
             return False
         args.append(token_id)

--- a/src/squidc5/policy/engine.py
+++ b/src/squidc5/policy/engine.py
@@ -88,6 +88,7 @@ DEFAULT_POLICY: dict[str, Any] = {
         "ai.admin": 3,
         "tokens.create": 6,
         "tokens.update": 6,
+        "tokens.roll": 7,
         "policy.update": 9,
     },
 }

--- a/tests/test_token_update.py
+++ b/tests/test_token_update.py
@@ -148,3 +148,48 @@ async def test_tokens_manage_cannot_modify_privileged_token(client, admin_header
         json={"scopes": ["sessions:read"]},
     )
     assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_roll_token_rotates_secret(client, admin_headers):
+    created = await mint_token(
+        client, admin_headers, "roll-me", ["sessions:read", "metrics:read"]
+    )
+    tid = created["id"]
+    old = created["token"]
+    old_h = bearer(old)
+    assert (await client.get("/api/v1/sessions", headers=old_h)).status_code == 200
+
+    r = await client.post(f"/api/v1/tokens/{tid}/roll", headers=admin_headers)
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("rolled") is True
+    assert body.get("token") and body["token"] != old
+    assert body["token"].startswith("sc5_")
+
+    # old secret dead
+    assert (await client.get("/api/v1/sessions", headers=old_h)).status_code == 401
+    # new secret works
+    new_h = bearer(body["token"])
+    assert (await client.get("/api/v1/sessions", headers=new_h)).status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_tokens_manage_cannot_roll_privileged(client, admin_headers):
+    mgr = await mint_token(
+        client,
+        admin_headers,
+        "tok-mgr-roll",
+        ["tokens:manage", "sessions:read"],
+    )
+    listed = await client.get("/api/v1/tokens", headers=admin_headers)
+    admin_tok = next(
+        (t for t in listed.json() if "admin" in (t.get("scopes") or []) and not t.get("revoked")),
+        None,
+    )
+    assert admin_tok
+    r = await client.post(
+        f"/api/v1/tokens/{admin_tok['id']}/roll",
+        headers=bearer(mgr["token"]),
+    )
+    assert r.status_code == 403

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1892,7 +1892,27 @@
           <div class="work-panel">
             <div class="wp-head">Tokens</div>
             <div class="wp-body">
-              <p class="muted" style="font-size:0.75rem;margin:0 0 8px">Mint a new token or select one below to update scopes. Updating scopes does <strong>not</strong> rotate the secret - revoke if compromised.</p>
+              <p class="muted" style="font-size:0.75rem;margin:0 0 8px">Mint or edit scopes below. <strong>Roll</strong> rotates the secret (old stops working). Scope edit does not rotate - roll or revoke if compromised.</p>
+              <div id="adSecretBanner" class="hidden" style="margin-bottom:12px;padding:12px;border-radius:10px;border:1px solid rgba(52,211,153,0.4);background:rgba(15,46,34,0.55)">
+                <div class="row" style="margin:0 0 8px;justify-content:space-between;align-items:flex-start">
+                  <div>
+                    <strong id="adSecretTitle" style="color:var(--ok)">New token secret</strong>
+                    <p class="muted" style="margin:4px 0 0;font-size:0.72rem">Shown once until you dismiss. Copy the token or connection link now.</p>
+                  </div>
+                  <button type="button" id="adSecretDismiss" title="Dismiss">Close</button>
+                </div>
+                <label style="margin-top:0">Token</label>
+                <div class="row" style="margin:4px 0 8px;gap:6px;align-items:stretch">
+                  <input id="adSecretToken" class="mono" readonly style="flex:1;font-size:0.75rem" />
+                  <button type="button" id="adSecretCopyTok">Copy token</button>
+                </div>
+                <label>Connection link (opens /ops and auto-fills)</label>
+                <div class="row" style="margin:4px 0 0;gap:6px;align-items:stretch">
+                  <input id="adSecretLink" class="mono" readonly style="flex:1;font-size:0.68rem" />
+                  <button type="button" id="adSecretCopyLink">Copy link</button>
+                </div>
+                <p class="muted" id="adSecretMeta" style="margin:8px 0 0;font-size:0.68rem"></p>
+              </div>
               <label>Name</label><input id="adName" placeholder="operator-1" />
               <input type="hidden" id="adEditId" value="" />
               <label>Presets</label>
@@ -1927,7 +1947,6 @@
                 <button type="button" id="adSaveEdit" disabled>Save changes</button>
                 <button type="button" id="adCancelEdit" class="hidden">Cancel edit</button>
               </div>
-              <div class="outbox empty" id="adMintOut">New token secret shown once after mint</div>
               <div class="row" style="margin-top:12px">
                 <button type="button" id="adTokRefresh">Refresh list</button>
               </div>
@@ -2091,6 +2110,63 @@
       if (el("adMcpBox")) el("adMcpBox").classList.toggle("hidden", !show);
       if (el("adMcpShow") && selectedScopes().includes("mcp:connect")) el("adMcpShow").checked = true;
     }
+    function b64urlEncodeObj(obj) {
+      const s = btoa(unescape(encodeURIComponent(JSON.stringify(obj))));
+      return s.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/g, "");
+    }
+    function buildTokenConnectLink(rawToken) {
+      let apiUrl = "";
+      try {
+        if (window.__SC5_API_BASE__) apiUrl = String(window.__SC5_API_BASE__);
+        else if (typeof localStorage !== "undefined") {
+          const raw = localStorage.getItem("sc5_ops_cfg");
+          if (raw) apiUrl = (JSON.parse(raw).url || "");
+        }
+      } catch (_) {}
+      if (!apiUrl && typeof location !== "undefined") apiUrl = location.origin;
+      apiUrl = (apiUrl || "").replace(/\/$/, "");
+      let opsOrigin = apiUrl;
+      try { opsOrigin = new URL(apiUrl).origin; } catch (_) {}
+      const payload = { url: apiUrl, token: rawToken, refresh: 10 };
+      return opsOrigin + "/ops#sc5=" + b64urlEncodeObj(payload);
+    }
+    function hideSecretBanner() {
+      const b = el("adSecretBanner");
+      if (b) b.classList.add("hidden");
+      if (el("adSecretToken")) el("adSecretToken").value = "";
+      if (el("adSecretLink")) el("adSecretLink").value = "";
+    }
+    function showSecretBanner({ title, token, name, id, scopes }) {
+      const b = el("adSecretBanner");
+      if (!b) return;
+      b.classList.remove("hidden");
+      if (el("adSecretTitle")) el("adSecretTitle").textContent = title || "Token secret";
+      if (el("adSecretToken")) el("adSecretToken").value = token || "";
+      if (el("adSecretLink")) el("adSecretLink").value = buildTokenConnectLink(token || "");
+      if (el("adSecretMeta")) {
+        const sc = (scopes || []).slice(0, 8).join(", ");
+        el("adSecretMeta").textContent =
+          (name ? name + " - " : "") + (id || "") + (sc ? " - " + sc : "");
+      }
+      try { b.scrollIntoView({ block: "nearest", behavior: "smooth" }); } catch (_) {}
+    }
+    async function copyField(inputId, okMsg) {
+      const n = el(inputId);
+      if (!n || !n.value) return showError("Nothing to copy");
+      try {
+        await navigator.clipboard.writeText(n.value);
+        showOk(okMsg || "Copied");
+      } catch (_) {
+        try {
+          n.focus();
+          n.select();
+          document.execCommand("copy");
+          showOk(okMsg || "Copied");
+        } catch (e2) {
+          showError("Clipboard unavailable - select and copy manually");
+        }
+      }
+    }
     function clearEditMode() {
       if (el("adEditId")) el("adEditId").value = "";
       if (el("adSaveEdit")) el("adSaveEdit").disabled = true;
@@ -2109,10 +2185,6 @@
       if (el("adSaveEdit")) el("adSaveEdit").disabled = false;
       if (el("adCancelEdit")) el("adCancelEdit").classList.remove("hidden");
       if (el("adMint")) el("adMint").disabled = true;
-      if (el("adMintOut")) {
-        el("adMintOut").textContent = "Editing " + (tok.id || "") + " - save applies scopes without rotating the secret.";
-        el("adMintOut").classList.remove("empty");
-      }
     }
     async function loadTokenTable() {
       const box = el("adTokTable");
@@ -2138,8 +2210,9 @@
             <td><strong>${esc(t.name || "")}</strong><div class="mono muted" style="font-size:0.65rem">${esc(t.id || "")}</div></td>
             <td style="font-size:0.72rem;max-width:220px">${sc}${more}</td>
             <td>${st}</td>
-            <td class="row" style="margin:0">
+            <td class="row" style="margin:0;flex-wrap:wrap">
               ${!t.revoked ? `<button type="button" data-tok-edit="${esc(t.id)}">Edit</button>` : ""}
+              ${!t.revoked ? `<button type="button" data-tok-roll="${esc(t.id)}">Roll</button>` : ""}
               ${!t.revoked ? `<button type="button" class="danger" data-tok-rev="${esc(t.id)}">Revoke</button>` : ""}
             </td>
           </tr>`;
@@ -2150,6 +2223,26 @@
             const id = b.getAttribute("data-tok-edit");
             const tok = list.find((x) => x.id === id);
             if (tok) enterEditMode(tok);
+          };
+        });
+        box.querySelectorAll("[data-tok-roll]").forEach((b) => {
+          b.onclick = async () => {
+            const id = b.getAttribute("data-tok-roll");
+            const tok = list.find((x) => x.id === id);
+            if (!id || !confirm("Roll secret for " + (tok && tok.name ? tok.name : id) + "? The old secret stops working immediately.")) return;
+            try {
+              const r = await api("POST", "/api/v1/tokens/" + encodeURIComponent(id) + "/roll");
+              showSecretBanner({
+                title: "Rolled token secret",
+                token: r.token,
+                name: r.name || (tok && tok.name),
+                id: r.id || id,
+                scopes: r.scopes || (tok && tok.scopes),
+              });
+              showOk("Token rolled - copy new secret");
+              clearEditMode();
+              loadTokenTable();
+            } catch (e) { showError(String(e.message || e)); }
           };
         });
         box.querySelectorAll("[data-tok-rev]").forEach((b) => {
@@ -2196,19 +2289,28 @@
       c.addEventListener("change", () => syncMcpVisibility());
     });
     if (el("adCancelEdit")) el("adCancelEdit").onclick = () => clearEditMode();
+    if (el("adSecretDismiss")) el("adSecretDismiss").onclick = () => hideSecretBanner();
+    if (el("adSecretCopyTok")) el("adSecretCopyTok").onclick = () => copyField("adSecretToken", "Token copied");
+    if (el("adSecretCopyLink")) el("adSecretCopyLink").onclick = () => copyField("adSecretLink", "Connection link copied");
     if (el("adMint")) el("adMint").onclick = async () => {
       try {
         const scopes = selectedScopes();
         if (!scopes.length) return showError("Select at least one scope");
-        const body = { name: (el("adName").value || "").trim() || "op", scopes };
+        const name = (el("adName").value || "").trim() || "op";
+        const body = { name, scopes };
         if (scopes.includes("mcp:connect")) {
           const tools = selectedMcp();
           if (tools.length) body.mcp_tools = tools;
         }
         const r = await api("POST", "/api/v1/tokens", body);
-        el("adMintOut").textContent = r.token || JSON.stringify(r, null, 2);
-        el("adMintOut").classList.remove("empty");
-        showOk("Token minted - copy now");
+        showSecretBanner({
+          title: "Minted token secret",
+          token: r.token,
+          name: r.name || name,
+          id: r.id,
+          scopes: r.scopes || scopes,
+        });
+        showOk("Token minted - copy secret or connection link");
         loadTokenTable();
       } catch (e) { showError(String(e.message || e)); }
     };


### PR DESCRIPTION
## Summary
- **Mint/roll banner** on Admin Tokens: secret + connection link (\`/ops#sc5=...\`) until **Close**
- Copy token / Copy link buttons
- **Roll** action (UI + \`POST /api/v1/tokens/{id}/roll\` + \`sc5 tokens roll\`) rotates secret; old stops working
- Non-admin \`tokens:manage\` cannot roll privileged tokens

## Test plan
- [x] pytest test_token_update (incl. roll)
- [ ] Admin: mint token - banner shows secret + link; Close dismisses
- [ ] Roll existing token - new secret banner; old token 401
- [ ] Connection link opens /ops and auto-connects on another browser