### PR TITLE
feat(auth): one-time connection tickets for token handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,10 +71,12 @@ jobs:
           test "$code" -ne 0
           grep -qi config /tmp/sc5beacon_err.txt || grep -qi psk /tmp/sc5beacon_err.txt || grep -qi required /tmp/sc5beacon_err.txt
       - uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: sc5beacon-native
           path: dist/sc5beacon*
-          retention-days: 14
+          retention-days: 7
+          if-no-files-found: warn
 
   docker:
     runs-on: ubuntu-latest
@@ -179,6 +181,7 @@ jobs:
 
       - name: Upload binaries
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: squidc5-${{ matrix.artifact }}
           path: |
@@ -189,7 +192,7 @@ jobs:
             dist/binaries/README.txt
             dist/binaries/*/
           if-no-files-found: error
-          retention-days: 30
+          retention-days: 14
 
   # Publish GitHub Release with Linux + Windows binaries when main/master CI succeeds.
   release:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,6 +180,7 @@ sc5 tokens list
 sc5 tokens create <name> --scopes "a,b,c" [--mcp-tools "t1,t2"]
 sc5 tokens update <id> [--name N] [--scopes "a,b"] [--mcp-tools "t1,t2"]
 sc5 tokens roll <id>
+sc5 tokens link <id> [--ttl 3600]   # one-time connection URL (redeem rolls secret)
 sc5 tokens revoke <id>
 
 sc5 ai <capability> [--data "..."] [--llm <id>]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1118,15 +1118,18 @@ Least privilege: phone UI might only need `shell:interact` + `sessions:read`; ex
    - **Token admin** - mint/update tokens within grant limits
    - **Full admin** - break-glass (admin granters only)
 3. **Mint new** - a green banner shows the secret **and a connection link** (`/ops#sc5=...`) until you **Close** it.
-4. **Edit** a row to change name/scopes/MCP tools (`PATCH /api/v1/tokens/{id}`) without rotating the secret.
-5. **Roll** rotates the secret (old stops working); new secret appears in the same banner.
-6. **Revoke** disables the token entirely.
-7. Nav hides Profiles, Post-Ex, etc. when the connected token lacks those scopes.
+4. **Link** on an existing token issues a **one-time** URL (`/ops#sc5ticket=...`) without showing the secret. Send that URL to the operator.
+5. When they open the link, the browser redeems the ticket, **rolls** their secret once, and auto-connects. The previous secret stops working.
+6. **Edit** a row to change name/scopes/MCP tools without rotating the secret.
+7. **Roll** rotates the secret immediately (admin sees the new secret in the banner).
+8. **Revoke** disables the token entirely.
+9. Nav hides Profiles, Post-Ex, etc. when the connected token lacks those scopes.
 
 ### Example
 
 ```bash
 sc5 tokens create phone --scopes "sessions:read,shell:interact,metrics:read,collab:use,phone:operator"
+sc5 tokens link <id> --ttl 3600   # one-time URL; redeem rolls secret
 sc5 tokens update <id> --scopes "sessions:read,shell:interact,metrics:read,listeners:read"
 sc5 tokens roll <id>
 sc5 tokens list

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -44,6 +44,15 @@ class TokenUpdate(BaseModel):
     mcp_tools: list[str] | None = None
 
 
+class ConnectionTicketCreate(BaseModel):
+    ttl_sec: int = 3600
+    note: str = ""
+
+
+class ConnectionTicketRedeem(BaseModel):
+    ticket: str
+
+
 class ListenerCreate(BaseModel):
     name: str
     kind: str = "http"  # http | https | tcp | reverse_shell | dns | smtp
@@ -524,6 +533,94 @@ def build_api_router() -> APIRouter:
             "mcp_tools": row.get("mcp_tools") or [],
             "token": raw,
             "rolled": True,
+        }
+
+    @api.post("/tokens/{token_id}/connection-link")
+    async def create_connection_link(
+        token_id: str,
+        body: ConnectionTicketCreate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("tokens:manage", "admin")),
+    ) -> dict[str, Any]:
+        """Issue a one-time connection URL for an existing token (secret never returned).
+
+        Recipient opens the URL; redeem rolls the token and loads the new secret once.
+        """
+        state = get_state(request)
+        decision = await state.policy.check_and_audit(
+            auth, "tokens.connection_link", resource=token_id
+        )
+        if not decision.allowed:
+            raise HTTPException(403, decision.reason)
+        try:
+            issued = await state.tokens.create_connection_ticket(
+                token_id,
+                actor=auth.name,
+                grantor_is_admin=auth.has_scope("admin"),
+                ttl_sec=body.ttl_sec,
+                note=body.note or "",
+            )
+        except KeyError as e:
+            raise HTTPException(404, "token not found") from e
+        except PermissionError as e:
+            raise HTTPException(403, str(e)) from e
+        # Build ops handoff URL (same host as this request when possible)
+        base = str(request.base_url).rstrip("/")
+        # Prefer configured public host if set
+        public = (getattr(state.settings, "public_host", None) or "").strip()
+        if public:
+            scheme = "https" if state.settings.tls_enabled else "http"
+            port = int(state.settings.port or 8443)
+            if port in (80, 443):
+                base = f"{scheme}://{public}"
+            else:
+                base = f"{scheme}://{public}:{port}"
+        link = f"{base}/ops#sc5ticket={issued['ticket']}"
+        return {
+            "ticket_id": issued["ticket_id"],
+            "url": link,
+            "expires_at": issued["expires_at"],
+            "ttl_sec": issued["ttl_sec"],
+            "token_id": issued["token_id"],
+            "name": issued["name"],
+            "scopes": issued["scopes"],
+            "note": (
+                "One-time link. Redeeming rolls the operator secret; "
+                "the previous secret stops working."
+            ),
+        }
+
+    @api.post("/auth/redeem-ticket")
+    async def redeem_connection_ticket(
+        body: ConnectionTicketRedeem,
+        request: Request,
+    ) -> dict[str, Any]:
+        """Unauthenticated one-time ticket redeem. Returns new API token once."""
+        state = get_state(request)
+        try:
+            out = await state.tokens.redeem_connection_ticket(body.ticket or "")
+        except KeyError:
+            raise HTTPException(404, "invalid or unknown ticket") from None
+        except ValueError as e:
+            raise HTTPException(400, str(e)) from e
+        # API base for client config
+        base = str(request.base_url).rstrip("/")
+        public = (getattr(state.settings, "public_host", None) or "").strip()
+        if public:
+            scheme = "https" if state.settings.tls_enabled else "http"
+            port = int(state.settings.port or 8443)
+            if port in (80, 443):
+                base = f"{scheme}://{public}"
+            else:
+                base = f"{scheme}://{public}:{port}"
+        return {
+            "url": base,
+            "token": out["token"],
+            "id": out["id"],
+            "name": out.get("name"),
+            "scopes": out.get("scopes") or [],
+            "rolled": True,
+            "refresh": 10,
         }
 
     @api.patch("/tokens/{token_id}")

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -502,6 +502,8 @@ class TokenService:
         *,
         actor: str = "unknown",
         grantor_is_admin: bool = False,
+        skip_privilege_check: bool = False,
+        audit_action: str = "token.roll",
     ) -> tuple[dict[str, Any], str]:
         """Rotate the secret for an active token. Old secret stops working immediately.
 
@@ -511,7 +513,7 @@ class TokenService:
         if not row or row.get("revoked"):
             raise KeyError("token not found")
         before = self.parse_row(row)
-        if not grantor_is_admin:
+        if not skip_privilege_check and not grantor_is_admin:
             held_priv = set(before.get("scopes") or []) & self.PRIVILEGED_SCOPES
             if held_priv:
                 raise PermissionError(
@@ -524,7 +526,7 @@ class TokenService:
         await self.db.audit(
             actor=actor,
             actor_type="operator",
-            action="token.roll",
+            action=audit_action,
             resource=token_id,
             details={"name": before.get("name"), "scopes": before.get("scopes")},
             risk_score=6,
@@ -532,6 +534,109 @@ class TokenService:
         updated = await self.db.get_token_by_id(token_id)
         assert updated is not None
         return self.parse_row(updated), raw
+
+    async def create_connection_ticket(
+        self,
+        token_id: str,
+        *,
+        actor: str = "unknown",
+        grantor_is_admin: bool = False,
+        ttl_sec: int = 3600,
+        note: str = "",
+    ) -> dict[str, Any]:
+        """Mint a one-time connection ticket for an existing token (no secret exposed).
+
+        Recipient redeems the ticket; server rolls the token and returns the new secret once.
+        """
+        import time as _time
+
+        row = await self.db.get_token_by_id(token_id)
+        if not row or row.get("revoked"):
+            raise KeyError("token not found")
+        parsed = self.parse_row(row)
+        if not grantor_is_admin:
+            held_priv = set(parsed.get("scopes") or []) & self.PRIVILEGED_SCOPES
+            if held_priv:
+                raise PermissionError(
+                    f"Only admin may issue connection links for privileged tokens: {sorted(held_priv)}"
+                )
+        ttl = max(60, min(int(ttl_sec or 3600), 86_400))  # 1 min .. 24 h
+        # sc5t_ prefix so tickets are distinct from API secrets
+        raw_ticket = f"sc5t_{secrets.token_urlsafe(32)}"
+        expires_at = _time.time() + ttl
+        tid = await self.db.create_connection_ticket(
+            ticket_hash=hash_token(raw_ticket),
+            token_id=token_id,
+            created_by=actor,
+            expires_at=expires_at,
+            note=note,
+        )
+        await self.db.audit(
+            actor=actor,
+            actor_type="operator",
+            action="token.connection_ticket",
+            resource=token_id,
+            details={
+                "ticket_id": tid,
+                "expires_at": expires_at,
+                "ttl_sec": ttl,
+                "name": parsed.get("name"),
+            },
+            risk_score=4,
+        )
+        return {
+            "ticket_id": tid,
+            "ticket": raw_ticket,
+            "token_id": token_id,
+            "name": parsed.get("name"),
+            "scopes": parsed.get("scopes") or [],
+            "expires_at": expires_at,
+            "ttl_sec": ttl,
+        }
+
+    async def redeem_connection_ticket(self, raw_ticket: str) -> dict[str, Any]:
+        """Redeem a one-time ticket: roll target token and return new secret once."""
+        import time as _time
+
+        raw = (raw_ticket or "").strip()
+        if not raw.startswith("sc5t_"):
+            raise ValueError("invalid ticket")
+        row = await self.db.get_connection_ticket_by_hash(hash_token(raw))
+        if not row:
+            raise KeyError("ticket not found")
+        if row.get("used_at") is not None:
+            raise ValueError("ticket already used")
+        if float(row.get("expires_at") or 0) < _time.time():
+            raise ValueError("ticket expired")
+        token_id = row["token_id"]
+        # Mark used first (single-use); if roll fails, ticket stays consumed
+        marked = await self.db.mark_connection_ticket_used(row["id"])
+        if not marked:
+            raise ValueError("ticket already used")
+        try:
+            tok_row, new_raw = await self.roll(
+                token_id,
+                actor=row.get("created_by") or "ticket",
+                skip_privilege_check=True,
+                audit_action="token.roll_via_ticket",
+            )
+        except KeyError as e:
+            raise ValueError("target token missing or revoked") from e
+        await self.db.audit(
+            actor="ticket",
+            actor_type="system",
+            action="token.connection_ticket_redeem",
+            resource=token_id,
+            details={"ticket_id": row["id"], "name": tok_row.get("name")},
+            risk_score=5,
+        )
+        return {
+            "token": new_raw,
+            "id": tok_row["id"],
+            "name": tok_row.get("name"),
+            "scopes": tok_row.get("scopes") or [],
+            "rolled": True,
+        }
 
     def parse_row(self, row: dict[str, Any]) -> dict[str, Any]:
         out = dict(row)

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -665,6 +665,16 @@ def cmd_tokens_roll(args: argparse.Namespace, client: Client) -> None:
     pp(client.post(f"/api/v1/tokens/{args.id}/roll"))
 
 
+def cmd_tokens_link(args: argparse.Namespace, client: Client) -> None:
+    """Issue one-time connection URL for an existing token (no secret shown)."""
+    body: dict[str, Any] = {}
+    if args.ttl is not None:
+        body["ttl_sec"] = int(args.ttl)
+    if args.note:
+        body["note"] = args.note
+    pp(client.post(f"/api/v1/tokens/{args.id}/connection-link", json=body or {}))
+
+
 def cmd_ai_run(args: argparse.Namespace, client: Client) -> None:
     body: dict[str, Any] = {"capability": args.capability, "user_data": args.data or ""}
     if args.llm:
@@ -1185,6 +1195,14 @@ def build_parser() -> argparse.ArgumentParser:
     tk_roll = tok_sub.add_parser("roll", help="Rotate token secret (old secret stops working)")
     tk_roll.add_argument("id")
     tk_roll.set_defaults(func=cmd_tokens_roll, needs_client=True)
+    tk_link = tok_sub.add_parser(
+        "link",
+        help="One-time connection URL for an existing token (redeem rolls secret)",
+    )
+    tk_link.add_argument("id")
+    tk_link.add_argument("--ttl", type=int, default=3600, help="Seconds until expiry (default 3600)")
+    tk_link.add_argument("--note", default="")
+    tk_link.set_defaults(func=cmd_tokens_link, needs_client=True)
 
     # ai / llm
     ai = sub.add_parser("ai", help="Run Admin AI capability")

--- a/src/squidc5/db/migrate.py
+++ b/src/squidc5/db/migrate.py
@@ -231,11 +231,28 @@ CREATE INDEX IF NOT EXISTS idx_operator_assets_kind ON operator_assets(kind);
 CREATE INDEX IF NOT EXISTS idx_operator_assets_created ON operator_assets(created_at);
 """
 
+CONNECTION_TICKETS_SQL = """
+CREATE TABLE IF NOT EXISTS connection_tickets (
+    id TEXT PRIMARY KEY,
+    ticket_hash TEXT NOT NULL UNIQUE,
+    token_id TEXT NOT NULL,
+    created_by TEXT,
+    created_at REAL NOT NULL,
+    expires_at REAL NOT NULL,
+    used_at REAL,
+    note TEXT NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_conn_tickets_hash ON connection_tickets(ticket_hash);
+CREATE INDEX IF NOT EXISTS idx_conn_tickets_token ON connection_tickets(token_id);
+CREATE INDEX IF NOT EXISTS idx_conn_tickets_exp ON connection_tickets(expires_at);
+"""
+
 MIGRATIONS: Sequence[tuple[int, str, str]] = (
     (1, "baseline schema", BASELINE_SQL),
     (2, "HITL approval queue", HITL_REQUESTS_SQL),
     (3, "audit integrity chain columns", AUDIT_INTEGRITY_SQL),
     (4, "operator assets library", OPERATOR_ASSETS_SQL),
+    (5, "connection tickets for token handoff", CONNECTION_TICKETS_SQL),
 )
 
 SCHEMA_VERSION_TABLE = """

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -168,6 +168,39 @@ class Database:
         )
         return cur.rowcount > 0
 
+    # --- Connection tickets (one-time handoff links) ---
+
+    async def create_connection_ticket(
+        self,
+        *,
+        ticket_hash: str,
+        token_id: str,
+        created_by: str | None,
+        expires_at: float,
+        note: str = "",
+    ) -> str:
+        tid = _uid("ctk_")
+        await self.execute(
+            """INSERT INTO connection_tickets
+               (id, ticket_hash, token_id, created_by, created_at, expires_at, note)
+               VALUES (?, ?, ?, ?, ?, ?, ?)""",
+            (tid, ticket_hash, token_id, created_by, _now(), expires_at, (note or "")[:200]),
+        )
+        return tid
+
+    async def get_connection_ticket_by_hash(self, ticket_hash: str) -> dict[str, Any] | None:
+        return await self.fetchone(
+            "SELECT * FROM connection_tickets WHERE ticket_hash = ?",
+            (ticket_hash,),
+        )
+
+    async def mark_connection_ticket_used(self, ticket_id: str) -> bool:
+        cur = await self.execute(
+            "UPDATE connection_tickets SET used_at = ? WHERE id = ? AND used_at IS NULL",
+            (_now(), ticket_id),
+        )
+        return cur.rowcount > 0
+
     # --- Operator assets (saved payloads/profiles/implants) ---
 
     async def create_operator_asset(

--- a/src/squidc5/policy/engine.py
+++ b/src/squidc5/policy/engine.py
@@ -89,6 +89,7 @@ DEFAULT_POLICY: dict[str, Any] = {
         "tokens.create": 6,
         "tokens.update": 6,
         "tokens.roll": 7,
+        "tokens.connection_link": 5,
         "policy.update": 9,
     },
 }

--- a/tests/test_connection_tickets.py
+++ b/tests/test_connection_tickets.py
@@ -1,0 +1,79 @@
+"""One-time connection tickets for existing tokens (no secret exposure to admin)."""
+
+from __future__ import annotations
+
+import pytest
+from conftest import bearer, mint_token
+
+
+@pytest.mark.asyncio
+async def test_connection_link_and_redeem_rolls_secret(client, admin_headers):
+    created = await mint_token(
+        client, admin_headers, "handoff-op", ["sessions:read", "metrics:read"]
+    )
+    tid = created["id"]
+    old = created["token"]
+    old_h = bearer(old)
+    assert (await client.get("/api/v1/sessions", headers=old_h)).status_code == 200
+
+    r = await client.post(
+        f"/api/v1/tokens/{tid}/connection-link",
+        headers=admin_headers,
+        json={"ttl_sec": 600, "note": "test"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert "url" in body and "sc5ticket=" in body["url"]
+    assert "token" not in body  # admin never sees secret
+    ticket = body["url"].split("sc5ticket=", 1)[1]
+
+    # Redeem without auth
+    red = await client.post("/api/v1/auth/redeem-ticket", json={"ticket": ticket})
+    assert red.status_code == 200, red.text
+    out = red.json()
+    assert out.get("token", "").startswith("sc5_")
+    assert out["token"] != old
+    assert out.get("rolled") is True
+
+    # Old secret dead; new works
+    assert (await client.get("/api/v1/sessions", headers=old_h)).status_code == 401
+    assert (await client.get("/api/v1/sessions", headers=bearer(out["token"]))).status_code == 200
+
+    # Ticket single-use
+    again = await client.post("/api/v1/auth/redeem-ticket", json={"ticket": ticket})
+    assert again.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_connection_link_rejects_invalid_ticket(client):
+    r = await client.post("/api/v1/auth/redeem-ticket", json={"ticket": "sc5t_nope"})
+    assert r.status_code in (400, 404)
+
+
+@pytest.mark.asyncio
+async def test_tokens_manage_cannot_link_privileged(client, admin_headers):
+    mgr = await mint_token(
+        client,
+        admin_headers,
+        "link-mgr",
+        ["tokens:manage", "sessions:read"],
+    )
+    listed = await client.get("/api/v1/tokens", headers=admin_headers)
+    admin_tok = next(
+        (t for t in listed.json() if "admin" in (t.get("scopes") or []) and not t.get("revoked")),
+        None,
+    )
+    assert admin_tok
+    r = await client.post(
+        f"/api/v1/tokens/{admin_tok['id']}/connection-link",
+        headers=bearer(mgr["token"]),
+        json={},
+    )
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_connection_link_requires_auth(client, admin_headers):
+    created = await mint_token(client, admin_headers, "x", ["sessions:read"])
+    r = await client.post(f"/api/v1/tokens/{created['id']}/connection-link", json={})
+    assert r.status_code == 401

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1892,12 +1892,12 @@
           <div class="work-panel">
             <div class="wp-head">Tokens</div>
             <div class="wp-body">
-              <p class="muted" style="font-size:0.75rem;margin:0 0 8px">Mint or edit scopes below. <strong>Roll</strong> rotates the secret (old stops working). Scope edit does not rotate - roll or revoke if compromised.</p>
+              <p class="muted" style="font-size:0.75rem;margin:0 0 8px">Mint or edit scopes below. <strong>Link</strong> makes a one-time URL to send an existing operator (no secret shown). <strong>Roll</strong> rotates the secret now. Redeeming a link also rolls their secret once.</p>
               <div id="adSecretBanner" class="hidden" style="margin-bottom:12px;padding:12px;border-radius:10px;border:1px solid rgba(52,211,153,0.4);background:rgba(15,46,34,0.55)">
                 <div class="row" style="margin:0 0 8px;justify-content:space-between;align-items:flex-start">
                   <div>
                     <strong id="adSecretTitle" style="color:var(--ok)">New token secret</strong>
-                    <p class="muted" style="margin:4px 0 0;font-size:0.72rem">Shown once until you dismiss. Copy the token or connection link now.</p>
+                    <p class="muted" style="margin:4px 0 0;font-size:0.72rem">Shown until you dismiss. Copy the token and/or connection link.</p>
                   </div>
                   <button type="button" id="adSecretDismiss" title="Dismiss">Close</button>
                 </div>
@@ -1906,7 +1906,7 @@
                   <input id="adSecretToken" class="mono" readonly style="flex:1;font-size:0.75rem" />
                   <button type="button" id="adSecretCopyTok">Copy token</button>
                 </div>
-                <label>Connection link (opens /ops and auto-fills)</label>
+                <label>Connection link</label>
                 <div class="row" style="margin:4px 0 0;gap:6px;align-items:stretch">
                   <input id="adSecretLink" class="mono" readonly style="flex:1;font-size:0.68rem" />
                   <button type="button" id="adSecretCopyLink">Copy link</button>
@@ -2136,13 +2136,21 @@
       if (el("adSecretToken")) el("adSecretToken").value = "";
       if (el("adSecretLink")) el("adSecretLink").value = "";
     }
-    function showSecretBanner({ title, token, name, id, scopes }) {
+    function showSecretBanner({ title, token, name, id, scopes, linkOnly }) {
       const b = el("adSecretBanner");
       if (!b) return;
       b.classList.remove("hidden");
       if (el("adSecretTitle")) el("adSecretTitle").textContent = title || "Token secret";
-      if (el("adSecretToken")) el("adSecretToken").value = token || "";
-      if (el("adSecretLink")) el("adSecretLink").value = buildTokenConnectLink(token || "");
+      if (el("adSecretToken")) {
+        el("adSecretToken").value = linkOnly
+          ? "(secret not shown - recipient redeems the link once)"
+          : (token || "");
+      }
+      if (el("adSecretLink")) {
+        el("adSecretLink").value = linkOnly
+          ? (token || "") // when linkOnly, `token` arg carries the URL
+          : buildTokenConnectLink(token || "");
+      }
       if (el("adSecretMeta")) {
         const sc = (scopes || []).slice(0, 8).join(", ");
         el("adSecretMeta").textContent =
@@ -2212,6 +2220,7 @@
             <td>${st}</td>
             <td class="row" style="margin:0;flex-wrap:wrap">
               ${!t.revoked ? `<button type="button" data-tok-edit="${esc(t.id)}">Edit</button>` : ""}
+              ${!t.revoked ? `<button type="button" data-tok-link="${esc(t.id)}" title="One-time connection URL (no secret shown)">Link</button>` : ""}
               ${!t.revoked ? `<button type="button" data-tok-roll="${esc(t.id)}">Roll</button>` : ""}
               ${!t.revoked ? `<button type="button" class="danger" data-tok-rev="${esc(t.id)}">Revoke</button>` : ""}
             </td>
@@ -2223,6 +2232,36 @@
             const id = b.getAttribute("data-tok-edit");
             const tok = list.find((x) => x.id === id);
             if (tok) enterEditMode(tok);
+          };
+        });
+        box.querySelectorAll("[data-tok-link]").forEach((b) => {
+          b.onclick = async () => {
+            const id = b.getAttribute("data-tok-link");
+            const tok = list.find((x) => x.id === id);
+            if (!id) return;
+            try {
+              const r = await api("POST", "/api/v1/tokens/" + encodeURIComponent(id) + "/connection-link", {
+                ttl_sec: 3600,
+                note: "admin handoff",
+              });
+              const exp = r.expires_at ? new Date(r.expires_at * 1000).toISOString() : "";
+              showSecretBanner({
+                title: "Connection link (one-time)",
+                token: r.url || "",
+                name: r.name || (tok && tok.name),
+                id: r.token_id || id,
+                scopes: r.scopes || (tok && tok.scopes),
+                linkOnly: true,
+              });
+              if (el("adSecretMeta")) {
+                el("adSecretMeta").textContent =
+                  (r.name || (tok && tok.name) || "") +
+                  " - " + (r.token_id || id) +
+                  (exp ? " - expires " + exp : "") +
+                  " - redeem rolls their secret once";
+              }
+              showOk("Connection link ready - send to operator");
+            } catch (e) { showError(String(e.message || e)); }
           };
         });
         box.querySelectorAll("[data-tok-roll]").forEach((b) => {

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -1655,11 +1655,16 @@
     return h + "h " + m + "m";
   }
 
-  // Hash import for phone QR - auto-connect
+  // Hash import: direct secret (#sc5=) or one-time ticket (#sc5ticket=)
   let importedFromQr = false;
+  let pendingTicket = null;
   try {
-    if (location.hash && location.hash.indexOf("sc5=") >= 0) {
-      const raw = location.hash.replace(/^#/, "").replace(/^sc5=/, "");
+    const hash = (location.hash || "").replace(/^#/, "");
+    if (hash.indexOf("sc5ticket=") === 0) {
+      pendingTicket = decodeURIComponent(hash.slice("sc5ticket=".length));
+      history.replaceState(null, "", location.pathname + location.search);
+    } else if (hash.indexOf("sc5=") === 0 || hash.indexOf("sc5=") >= 0) {
+      const raw = hash.replace(/^sc5=/, "");
       let b64 = raw.replace(/-/g, "+").replace(/_/g, "/");
       while (b64.length % 4) b64 += "=";
       const json = JSON.parse(decodeURIComponent(escape(atob(b64))));
@@ -1744,14 +1749,63 @@
 
   loadForm();
   const savedView = (() => { try { return localStorage.getItem("sc5_ops_view"); } catch (_) { return null; } })();
-  if (cfg().token) {
-    connect().then(() => {
-      if (importedFromQr) showOk("Phone link applied - connected");
-      if (savedView && VIEWS[savedView]) setView(savedView);
-    }).catch(() => openModal());
-  } else {
-    openModal();
+
+  async function redeemPendingTicket() {
+    if (!pendingTicket) return false;
+    const ticket = pendingTicket;
+    pendingTicket = null;
+    try {
+      showOk("Redeeming connection link...");
+      // Unauthenticated redeem against this origin
+      const base = apiBase() || (location.origin || "");
+      const r = await fetch((base.replace(/\/$/, "")) + "/api/v1/auth/redeem-ticket", {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({ ticket }),
+      });
+      const body = await r.json().catch(() => ({}));
+      if (!r.ok) {
+        const detail = body.detail || body.message || r.statusText || "redeem failed";
+        throw new Error(typeof detail === "string" ? detail : JSON.stringify(detail));
+      }
+      if (body.url) localStorage.setItem(KEYS.url, String(body.url).replace(/\/$/, ""));
+      if (body.token) localStorage.setItem(KEYS.token, String(body.token));
+      if (body.refresh) localStorage.setItem(KEYS.refresh, String(body.refresh));
+      loadForm();
+      importedFromQr = true;
+      showOk("Connection link redeemed - secret loaded (previous secret invalidated)");
+      return true;
+    } catch (e) {
+      showError("Connection link failed: " + String(e.message || e));
+      openModal();
+      return false;
+    }
   }
+
+  (async () => {
+    if (pendingTicket) {
+      // Prefer same-origin URL for redeem
+      if (!cfg().url) {
+        try { localStorage.setItem(KEYS.url, location.origin); loadForm(); } catch (_) {}
+      }
+      const ok = await redeemPendingTicket();
+      if (ok && cfg().token) {
+        try {
+          await connect();
+          if (savedView && VIEWS[savedView]) setView(savedView);
+        } catch (_) { openModal(); }
+        return;
+      }
+    }
+    if (cfg().token) {
+      connect().then(() => {
+        if (importedFromQr) showOk("Phone link applied - connected");
+        if (savedView && VIEWS[savedView]) setView(savedView);
+      }).catch(() => openModal());
+    } else {
+      openModal();
+    }
+  })();
 
   // Expose for ops-admin
   window.__SC5_api = api;


### PR DESCRIPTION
## Summary
Admins can send a **connection URL** for any existing token without seeing the secret.

### Flow
1. Admin → Tokens → **Link** on a row (or \`sc5 tokens link <id>\`)
2. Unique one-time URL: \`/ops#sc5ticket=sc5t_...\` (TTL default 1h)
3. Recipient opens link → browser redeems ticket (no auth) → server **rolls** the token → loads new secret and connects
4. Ticket is single-use; previous secret stops working

Secrets stay hash-only at rest; tickets never contain the API token.

## Test plan
- [x] pytest connection_tickets + token_update
- [ ] Admin: Link on existing token → copy URL → open in private window → auto-connect
- [ ] Second open of same link fails
- [ ] Old secret 401 after redeem