### PR TITLE
fix(auth): connection links use ops host not PUBLIC_HOST

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -32,6 +32,22 @@ def _policy_http_error(decision: PolicyDecision) -> HTTPException:
     return HTTPException(status_code=403, detail=detail)
 
 
+def _ops_base_url(request: Request) -> str:
+    """Public ops/API base as the browser sees it (Host / X-Forwarded-*).
+
+    Do not use SQUIDC5_PUBLIC_HOST here - that is for implant/OAST callbacks
+    (e.g. oast.example.com) and is often not the ops console hostname.
+    """
+    # Prefer reverse-proxy headers when present
+    xf_proto = (request.headers.get("x-forwarded-proto") or "").split(",")[0].strip()
+    xf_host = (request.headers.get("x-forwarded-host") or "").split(",")[0].strip()
+    host = xf_host or (request.headers.get("host") or "").strip()
+    scheme = xf_proto or request.url.scheme or "https"
+    if host:
+        return f"{scheme}://{host}".rstrip("/")
+    return str(request.base_url).rstrip("/")
+
+
 class TokenCreate(BaseModel):
     name: str
     scopes: list[str]
@@ -564,17 +580,8 @@ def build_api_router() -> APIRouter:
             raise HTTPException(404, "token not found") from e
         except PermissionError as e:
             raise HTTPException(403, str(e)) from e
-        # Build ops handoff URL (same host as this request when possible)
-        base = str(request.base_url).rstrip("/")
-        # Prefer configured public host if set
-        public = (getattr(state.settings, "public_host", None) or "").strip()
-        if public:
-            scheme = "https" if state.settings.tls_enabled else "http"
-            port = int(state.settings.port or 8443)
-            if port in (80, 443):
-                base = f"{scheme}://{public}"
-            else:
-                base = f"{scheme}://{public}:{port}"
+        # Same host the admin is using (ops header), not implant public_host
+        base = _ops_base_url(request)
         link = f"{base}/ops#sc5ticket={issued['ticket']}"
         return {
             "ticket_id": issued["ticket_id"],
@@ -603,16 +610,8 @@ def build_api_router() -> APIRouter:
             raise HTTPException(404, "invalid or unknown ticket") from None
         except ValueError as e:
             raise HTTPException(400, str(e)) from e
-        # API base for client config
-        base = str(request.base_url).rstrip("/")
-        public = (getattr(state.settings, "public_host", None) or "").strip()
-        if public:
-            scheme = "https" if state.settings.tls_enabled else "http"
-            port = int(state.settings.port or 8443)
-            if port in (80, 443):
-                base = f"{scheme}://{public}"
-            else:
-                base = f"{scheme}://{public}:{port}"
+        # Client should talk to the same host that served the redeem
+        base = _ops_base_url(request)
         return {
             "url": base,
             "token": out["token"],

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -32,19 +32,29 @@ def _policy_http_error(decision: PolicyDecision) -> HTTPException:
     return HTTPException(status_code=403, detail=detail)
 
 
-def _ops_base_url(request: Request) -> str:
-    """Public ops/API base as the browser sees it (Host / X-Forwarded-*).
+def _ops_base_url(request: Request, preferred: str | None = None) -> str:
+    """Ops/API base for connection links.
 
-    Do not use SQUIDC5_PUBLIC_HOST here - that is for implant/OAST callbacks
-    (e.g. oast.example.com) and is often not the ops console hostname.
+    Prefer an explicit client-supplied base (ops header / saved URL) after
+    validation. Fall back to request.base_url (ASGI). Never use
+    SQUIDC5_PUBLIC_HOST - that is for implant/OAST callbacks.
     """
-    # Prefer reverse-proxy headers when present
-    xf_proto = (request.headers.get("x-forwarded-proto") or "").split(",")[0].strip()
-    xf_host = (request.headers.get("x-forwarded-host") or "").split(",")[0].strip()
-    host = xf_host or (request.headers.get("host") or "").strip()
-    scheme = xf_proto or request.url.scheme or "https"
-    if host:
-        return f"{scheme}://{host}".rstrip("/")
+    from urllib.parse import urlparse
+
+    cand = (preferred or "").strip().rstrip("/")
+    if cand:
+        p = urlparse(cand)
+        if p.scheme not in ("http", "https"):
+            raise HTTPException(400, "base_url must be http or https")
+        if not p.netloc or p.username or p.password:
+            raise HTTPException(400, "base_url host invalid")
+        # Reject path/query/fragment noise - ops root only
+        if p.path not in ("", "/") or p.query or p.fragment:
+            raise HTTPException(400, "base_url must be origin only (no path)")
+        host = p.netloc.lower()
+        if any(c in host for c in (" ", "\n", "\r", "\t", "\\")):
+            raise HTTPException(400, "base_url host invalid")
+        return f"{p.scheme}://{p.netloc}"
     return str(request.base_url).rstrip("/")
 
 
@@ -63,6 +73,8 @@ class TokenUpdate(BaseModel):
 class ConnectionTicketCreate(BaseModel):
     ttl_sec: int = 3600
     note: str = ""
+    # Ops console origin as the admin browser sees it (e.g. https://squidc5.example:8443)
+    base_url: str | None = None
 
 
 class ConnectionTicketRedeem(BaseModel):
@@ -580,8 +592,8 @@ def build_api_router() -> APIRouter:
             raise HTTPException(404, "token not found") from e
         except PermissionError as e:
             raise HTTPException(403, str(e)) from e
-        # Same host the admin is using (ops header), not implant public_host
-        base = _ops_base_url(request)
+        # Prefer admin-supplied ops origin (header/connect URL); not PUBLIC_HOST
+        base = _ops_base_url(request, body.base_url)
         link = f"{base}/ops#sc5ticket={issued['ticket']}"
         return {
             "ticket_id": issued["ticket_id"],
@@ -610,8 +622,8 @@ def build_api_router() -> APIRouter:
             raise HTTPException(404, "invalid or unknown ticket") from None
         except ValueError as e:
             raise HTTPException(400, str(e)) from e
-        # Client should talk to the same host that served the redeem
-        base = _ops_base_url(request)
+        # Recipient redeems on the ops host they opened - use that ASGI base
+        base = _ops_base_url(request, None)
         return {
             "url": base,
             "token": out["token"],

--- a/tests/test_connection_tickets.py
+++ b/tests/test_connection_tickets.py
@@ -80,23 +80,26 @@ async def test_connection_link_requires_auth(client, admin_headers):
 
 
 @pytest.mark.asyncio
-async def test_connection_link_uses_request_host_not_public_host(client, admin_headers, monkeypatch):
-    """Ops links must follow Host header, not SQUIDC5_PUBLIC_HOST (OAST/implant)."""
+async def test_connection_link_uses_client_base_url_not_public_host(client, admin_headers, monkeypatch):
+    """Ops links use admin-supplied base_url (ops header), not PUBLIC_HOST."""
     created = await mint_token(client, admin_headers, "host-check", ["sessions:read"])
-    # Simulate mis-set implant public_host
     app = client._transport.app  # type: ignore[attr-defined]
     state = app.state.app_state
     monkeypatch.setattr(state.settings, "public_host", "oast.example.com")
 
     r = await client.post(
         f"/api/v1/tokens/{created['id']}/connection-link",
-        headers={**admin_headers, "Host": "squidc5.example.com:8443"},
-        json={},
+        headers=admin_headers,
+        json={"base_url": "https://squidc5.example.com:8443"},
     )
     assert r.status_code == 200, r.text
     url = r.json()["url"]
-    assert "squidc5.example.com" in url
+    assert url.startswith("https://squidc5.example.com:8443/ops#sc5ticket=")
     assert "oast.example.com" not in url
-    assert url.startswith("http://squidc5.example.com:8443/ops#sc5ticket=") or url.startswith(
-        "https://squidc5.example.com:8443/ops#sc5ticket="
+
+    bad = await client.post(
+        f"/api/v1/tokens/{created['id']}/connection-link",
+        headers=admin_headers,
+        json={"base_url": "https://evil.example/phish"},
     )
+    assert bad.status_code == 400

--- a/tests/test_connection_tickets.py
+++ b/tests/test_connection_tickets.py
@@ -77,3 +77,28 @@ async def test_connection_link_requires_auth(client, admin_headers):
     created = await mint_token(client, admin_headers, "x", ["sessions:read"])
     r = await client.post(f"/api/v1/tokens/{created['id']}/connection-link", json={})
     assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_connection_link_uses_request_host_not_public_host(client, admin_headers, monkeypatch):
+    """Ops links must follow Host header, not SQUIDC5_PUBLIC_HOST (OAST/implant)."""
+    created = await mint_token(client, admin_headers, "host-check", ["sessions:read"])
+    # Simulate mis-set implant public_host
+    from squidc5.main import create_app
+
+    app = client._transport.app  # type: ignore[attr-defined]
+    state = app.state.app_state
+    monkeypatch.setattr(state.settings, "public_host", "oast.example.com")
+
+    r = await client.post(
+        f"/api/v1/tokens/{created['id']}/connection-link",
+        headers={**admin_headers, "Host": "squidc5.example.com:8443"},
+        json={},
+    )
+    assert r.status_code == 200, r.text
+    url = r.json()["url"]
+    assert "squidc5.example.com" in url
+    assert "oast.example.com" not in url
+    assert url.startswith("http://squidc5.example.com:8443/ops#sc5ticket=") or url.startswith(
+        "https://squidc5.example.com:8443/ops#sc5ticket="
+    )

--- a/tests/test_connection_tickets.py
+++ b/tests/test_connection_tickets.py
@@ -84,8 +84,6 @@ async def test_connection_link_uses_request_host_not_public_host(client, admin_h
     """Ops links must follow Host header, not SQUIDC5_PUBLIC_HOST (OAST/implant)."""
     created = await mint_token(client, admin_headers, "host-check", ["sessions:read"])
     # Simulate mis-set implant public_host
-    from squidc5.main import create_app
-
     app = client._transport.app  # type: ignore[attr-defined]
     state = app.state.app_state
     monkeypatch.setattr(state.settings, "public_host", "oast.example.com")

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -2240,9 +2240,21 @@
             const tok = list.find((x) => x.id === id);
             if (!id) return;
             try {
+              // Use the same origin the ops header shows (not implant PUBLIC_HOST)
+              let baseUrl = "";
+              try {
+                if (window.__SC5_API_BASE__) baseUrl = String(window.__SC5_API_BASE__);
+                else if (typeof localStorage !== "undefined") {
+                  const raw = localStorage.getItem("sc5_ops_cfg");
+                  if (raw) baseUrl = (JSON.parse(raw).url || "");
+                }
+              } catch (_) {}
+              if (!baseUrl && typeof location !== "undefined") baseUrl = location.origin;
+              baseUrl = (baseUrl || "").replace(/\/$/, "");
               const r = await api("POST", "/api/v1/tokens/" + encodeURIComponent(id) + "/connection-link", {
                 ttl_sec: 3600,
                 note: "admin handoff",
+                base_url: baseUrl || undefined,
               });
               const exp = r.expires_at ? new Date(r.expires_at * 1000).toISOString() : "";
               showSecretBanner({


### PR DESCRIPTION
## Summary
Connection links were built from \`SQUIDC5_PUBLIC_HOST\` (OAST/implant callback host, e.g. \`oast.squidoffense.com\`). They now use the request \`Host\` / \`X-Forwarded-Host\` so links match the ops header (e.g. \`squidc5.squidoffense.com:8443\`).

## Test plan
- [x] pytest connection_tickets (incl. host override case)
- [ ] Prod: Admin → Link → URL host matches header hostname