### PR TITLE
ci: fix self-hosted release + binary smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,15 @@ jobs:
       - name: Install pip-audit
         run: pip install pip-audit
       - name: Audit dependencies
-        run: pip-audit -r requirements.txt
+        run: |
+          set -euo pipefail
+          # Self-hosted can hit transient PyPI timeouts
+          for i in 1 2 3; do
+            pip-audit -r requirements.txt && exit 0
+            echo "pip-audit attempt $i failed; retrying..."
+            sleep $((i * 5))
+          done
+          exit 1
 
   # Standalone operator CLI + server binaries (no venv required).
   binaries:
@@ -334,66 +342,54 @@ jobs:
           EOF
           ls -lah release/
 
-      - name: Ensure gh CLI
+      - name: Release metadata
+        id: relmeta
         run: |
           set -euo pipefail
-          if command -v gh >/dev/null 2>&1; then
-            gh --version
-            exit 0
-          fi
-          # Self-hosted runners may lack gh; install portable binary to PATH
-          VER=2.67.0
-          curl -fsSL "https://github.com/cli/cli/releases/download/v${VER}/gh_${VER}_linux_amd64.tar.gz" -o /tmp/gh.tgz
-          tar -xzf /tmp/gh.tgz -C /tmp
-          mkdir -p "$HOME/.local/bin"
-          cp "/tmp/gh_${VER}_linux_amd64/bin/gh" "$HOME/.local/bin/gh"
-          chmod +x "$HOME/.local/bin/gh"
-          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
-          "$HOME/.local/bin/gh" --version
-
-      - name: Create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PATH: ${{ env.PATH }}
-        run: |
-          set -euo pipefail
-          export PATH="${HOME}/.local/bin:${PATH}"
           SHORT_SHA="${GITHUB_SHA::7}"
           TAG="v0.1.${{ github.run_number }}-${SHORT_SHA}"
-          TITLE="SquidC5 ${TAG}"
-          NOTES="$(cat <<EOF
-          ## SquidC5 release \`${TAG}\`
+          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "title=SquidC5 ${TAG}" >> "$GITHUB_OUTPUT"
+          echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
-          Built from \`${GITHUB_REF_NAME}\` @ \`${SHORT_SHA}\` after CI tests passed.
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.relmeta.outputs.tag }}
+          name: ${{ steps.relmeta.outputs.title }}
+          target_commitish: ${{ github.sha }}
+          make_latest: true
+          body: |
+            ## SquidC5 release `${{ steps.relmeta.outputs.tag }}`
 
-          ### Assets
-          | File | Platform | Role |
-          |------|----------|------|
-          | \`sc5-linux-x64\` | Linux x64 | Operator CLI |
-          | \`squidc5-linux-x64\` | Linux x64 | C2 server |
-          | \`sc5-windows-x64.exe\` | Windows x64 | Operator CLI (when available) |
-          | \`squidc5-windows-x64.exe\` | Windows x64 | C2 server (when available) |
-          | \`SHA256SUMS.txt\` | - | Checksums |
+            Built from `${{ github.ref_name }}` @ `${{ steps.relmeta.outputs.short_sha }}` after CI tests passed.
 
-          ### Server (Linux)
-          \`\`\`bash
-          chmod +x squidc5-linux-x64
-          ./squidc5-linux-x64
-          # token: ./data/admin_token.txt
-          # console: https://HOST:8443/ops
-          \`\`\`
+            ### Assets
+            | File | Platform | Role |
+            |------|----------|------|
+            | `sc5-linux-x64` | Linux x64 | Operator CLI |
+            | `squidc5-linux-x64` | Linux x64 | C2 server |
+            | `sc5-windows-x64.exe` | Windows x64 | Operator CLI (when available) |
+            | `squidc5-windows-x64.exe` | Windows x64 | C2 server (when available) |
+            | `SHA256SUMS.txt` | - | Checksums |
 
-          Authorized red-team / pen-test use only.
-          EOF
-          )"
-          ASSETS=(release/sc5-linux-x64 release/squidc5-linux-x64 release/SHA256SUMS.txt release/README.txt release/sbom.cdx.json)
-          [[ -f release/sc5-windows-x64.exe ]] && ASSETS+=(release/sc5-windows-x64.exe)
-          [[ -f release/squidc5-windows-x64.exe ]] && ASSETS+=(release/squidc5-windows-x64.exe)
-          gh release create "$TAG" \
-            --repo "${{ github.repository }}" \
-            --target "${{ github.sha }}" \
-            --title "$TITLE" \
-            --notes "$NOTES" \
-            --latest \
-            "${ASSETS[@]}"
-          echo "Published release: $TAG"
+            ### Server (Linux)
+            ```bash
+            chmod +x squidc5-linux-x64
+            ./squidc5-linux-x64
+            # token: ./data/admin_token.txt
+            # console: https://HOST:8443/ops
+            ```
+
+            Authorized red-team / pen-test use only.
+          files: |
+            release/sc5-linux-x64
+            release/squidc5-linux-x64
+            release/SHA256SUMS.txt
+            release/README.txt
+            release/sbom.cdx.json
+            release/sc5-windows-x64.exe
+            release/squidc5-windows-x64.exe
+          fail_on_unmatched_files: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,8 +175,8 @@ jobs:
           python-version: "3.12"
           cache: ""
 
-      - name: Install package + PyInstaller
-        shell: bash
+      - name: Install package + PyInstaller (Linux)
+        if: matrix.is_windows == false
         run: |
           set -euo pipefail
           python -m pip install --upgrade pip
@@ -184,25 +184,40 @@ jobs:
           pip install -e .
           pip install "pyinstaller>=6.3"
 
-      - name: Build binaries
-        shell: bash
+      - name: Install package + PyInstaller (Windows)
+        if: matrix.is_windows == true
+        shell: pwsh
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -e .
+          pip install "pyinstaller>=6.3"
+
+      - name: Build binaries (Linux)
+        if: matrix.is_windows == false
         run: python packaging/build_binaries.py
 
-      - name: Smoke-test CLI
-        shell: bash
+      - name: Build binaries (Windows)
+        if: matrix.is_windows == true
+        shell: pwsh
+        run: python packaging/build_binaries.py
+
+      - name: Smoke-test CLI (Linux)
+        if: matrix.is_windows == false
         run: |
           set -euo pipefail
-          if [[ "${{ matrix.is_windows }}" == "true" ]]; then
-            ./dist/binaries/sc5.exe --help
-            ./dist/binaries/sc5.exe --url http://127.0.0.1:9 health || true
-          else
-            ./dist/binaries/sc5 --help
-            ./dist/binaries/sc5 --url http://127.0.0.1:9 health || true
-          fi
+          ./dist/binaries/sc5 --help
+          ./dist/binaries/sc5 --url http://127.0.0.1:9 health || true
+
+      - name: Smoke-test CLI (Windows)
+        if: matrix.is_windows == true
+        shell: pwsh
+        run: |
+          ./dist/binaries/sc5.exe --help
+          ./dist/binaries/sc5.exe --url http://127.0.0.1:9 health; exit 0
 
       - name: Smoke-test server (Linux)
         if: matrix.is_windows == false
-        shell: bash
         run: |
           set -euo pipefail
           export SQUIDC5_PORT=$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')
@@ -215,8 +230,8 @@ jobs:
           for i in $(seq 1 50); do
             if curl -skf "https://127.0.0.1:${SQUIDC5_PORT}/api/v1/health"; then
               echo
-              curl -skf "https://127.0.0.1:${SQUIDC5_PORT}/ops" | head -c 200
-              echo
+              # Avoid curl|head SIGPIPE (exit 23) under pipefail
+              curl -skf -o /dev/null -w "ops_http=%{http_code}\n" "https://127.0.0.1:${SQUIDC5_PORT}/ops"
               exit 0
             fi
             sleep 1
@@ -319,12 +334,30 @@ jobs:
           EOF
           ls -lah release/
 
+      - name: Ensure gh CLI
+        run: |
+          set -euo pipefail
+          if command -v gh >/dev/null 2>&1; then
+            gh --version
+            exit 0
+          fi
+          # Self-hosted runners may lack gh; install portable binary to PATH
+          VER=2.67.0
+          curl -fsSL "https://github.com/cli/cli/releases/download/v${VER}/gh_${VER}_linux_amd64.tar.gz" -o /tmp/gh.tgz
+          tar -xzf /tmp/gh.tgz -C /tmp
+          mkdir -p "$HOME/.local/bin"
+          cp "/tmp/gh_${VER}_linux_amd64/bin/gh" "$HOME/.local/bin/gh"
+          chmod +x "$HOME/.local/bin/gh"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/gh" --version
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        shell: bash
+          PATH: ${{ env.PATH }}
         run: |
           set -euo pipefail
+          export PATH="${HOME}/.local/bin:${PATH}"
           SHORT_SHA="${GITHUB_SHA::7}"
           TAG="v0.1.${{ github.run_number }}-${SHORT_SHA}"
           TITLE="SquidC5 ${TAG}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -353,7 +353,8 @@ jobs:
           echo "short_sha=${SHORT_SHA}" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        # pin commit for supply-chain (tag v2 -> 3bb1273)
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           tag_name: ${{ steps.relmeta.outputs.tag }}
           name: ${{ steps.relmeta.outputs.title }}


### PR DESCRIPTION
## Summary
Master CI after #84 failed release/binaries on self-hosted:
1. `gh` missing on runner
2. Linux smoke: `curl|head` SIGPIPE under `pipefail` (server was healthy)
3. Windows: bash shell broke temp script paths

## Test plan
- [x] PR CI green
- [ ] Master release publishes `squidc5-linux-x64`
- [ ] Deploy that binary to prod