### PR TITLE
fix: INKO LLM collapse + live Assets always show

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -815,9 +815,15 @@ def build_api_router() -> APIRouter:
             )
         nodes = []
         for h in hosts.values():
+            live = int(h.get("active") or 0) > 0
+            # Live verified/interactive assets always surface (clear stale bulk-hide)
+            if live and h.get("hidden"):
+                await state.db.unhide_host_graph(h["id"])
+                h["hidden"] = False
+                hidden_ids.discard(h["id"])
             if h.get("hidden") and not include_hidden:
                 continue
-            if active_only and int(h.get("active") or 0) <= 0:
+            if active_only and not live:
                 continue
             kinds = sorted(h["kinds"])
             nodes.append(

--- a/src/squidc5/hosts/graph.py
+++ b/src/squidc5/hosts/graph.py
@@ -71,6 +71,11 @@ def is_asset_session(row: dict[str, Any]) -> bool:
         return False
 
     if kind in SHELL_KINDS:
+        # Live interactive channel counts (operator is on it even if probe flags lag)
+        if (row.get("status") or "") == "active" and (
+            _truthy(row.get("interactive")) or _truthy(row.get("verified"))
+        ):
+            return True
         return shell_was_real(row)
 
     if kind in IMPLANT_KINDS:

--- a/src/squidc5/listeners/manager.py
+++ b/src/squidc5/listeners/manager.py
@@ -744,10 +744,29 @@ class ListenerManager:
 
     async def mark_verified(self, session_id: str) -> None:
         self._verified.add(session_id)
-        await self.db.update_session(
-            session_id,
-            metadata={"exec_ok": True, "verified": True},
-        )
+        row = await self.db.get_session(session_id)
+        meta: dict[str, Any] = {}
+        if row:
+            raw = row.get("metadata") or {}
+            if isinstance(raw, str):
+                try:
+                    meta = json.loads(raw) if raw else {}
+                except json.JSONDecodeError:
+                    meta = {}
+            elif isinstance(raw, dict):
+                meta = dict(raw)
+        meta["exec_ok"] = True
+        meta["verified"] = True
+        await self.db.update_session(session_id, metadata=meta)
+        # Ensure host reappears on Assets if previously bulk-dismissed
+        try:
+            from squidc5.hosts.graph import host_key_for_session
+
+            if row:
+                key = host_key_for_session({**dict(row), "verified": True, "metadata": meta})
+                await self.db.unhide_host_graph(key)
+        except Exception:
+            log.debug("host unhide after verify failed", exc_info=True)
 
     async def _verify_or_drop(self, session_id: str, remote: str) -> None:
         """After connect (+ optional stabilize), require real command execution."""

--- a/tests/test_hosts_graph.py
+++ b/tests/test_hosts_graph.py
@@ -36,9 +36,13 @@ def test_is_asset_session_strict():
             "os_info": "Linux",
         }
     )
-    # interactive alone is NOT enough without verify evidence
-    assert not is_asset_session(
+    # live interactive channel is an asset (operator is on it)
+    assert is_asset_session(
         {"kind": "reverse_shell", "status": "active", "interactive": True, "verified": False}
+    )
+    # inactive interactive-looking flags without evidence are not assets
+    assert not is_asset_session(
+        {"kind": "reverse_shell", "status": "closed", "interactive": True, "verified": False}
     )
     # scanner closed shells
     assert not is_asset_session(
@@ -159,19 +163,27 @@ async def test_hosts_api_and_claim_ttl(tmp_path):
             hosts_r = await client.get("/api/v1/hosts", headers=h)
             assert "10.9.8.7" in {x["id"] for x in hosts_r.json()["hosts"]}
 
-            hide = await client.post("/api/v1/hosts/workstation-a/hide", headers=h)
+            # Historical-only host can be dismissed; live hosts auto-unhide
+            hide = await client.post("/api/v1/hosts/10.9.8.7/hide", headers=h)
             assert hide.status_code == 200
             hosts2 = await client.get("/api/v1/hosts", headers=h)
             ids2 = {x["id"] for x in hosts2.json()["hosts"]}
-            assert "workstation-a" not in ids2
+            assert "10.9.8.7" not in ids2
             assert "dc01" in ids2
+            assert "workstation-a" in ids2
 
             bulk = await client.post("/api/v1/hosts/hide-inactive", headers=h)
             assert bulk.status_code == 200
             assert bulk.json()["hidden"] >= 0
 
-            unhide = await client.delete("/api/v1/hosts/workstation-a/hide", headers=h)
-            assert unhide.status_code == 200
+            # Live implant host reappears even if previously bulk-hidden
+            await state.db.hide_host_graph("dc01", hidden_by="test", note="stale")
+            hosts_live = await client.get("/api/v1/hosts", headers=h)
+            assert "dc01" in {x["id"] for x in hosts_live.json()["hosts"]}
+
+            # restore historical
+            unhide = await client.delete("/api/v1/hosts/10.9.8.7/hide", headers=h)
+            assert unhide.status_code in (200, 404)
 
             c = await client.post(f"/api/v1/sessions/{sid1}/claim", headers=h, json={})
             assert c.status_code == 200

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -2728,19 +2728,26 @@
         </div>
         <div class="work-panel">
           <div class="wp-head">Asset graph <span class="muted" id="hostGraphMeta" style="font-weight:400;margin-left:8px;font-size:0.72rem"></span></div>
-          <div class="wp-body" style="display:flex;flex-direction:column;min-height:0;height:100%">
-            <p class="muted" style="font-size:0.75rem;margin:0 0 8px">Exec-verified shells and implants with a real hostname only. Scanner TCP noise is excluded. Drop hides a node (sessions stay under Sessions).</p>
-            <div class="chips" style="margin-bottom:8px">
-              <span class="chip ok">active shell/implant</span>
-              <span class="chip warn">locked</span>
-              <span class="chip">historical only</span>
+          <div class="wp-body hosts-work-body">
+            <div class="hosts-graph-pane">
+              <p class="muted" style="font-size:0.75rem;margin:0">Exec-verified shells and named implants. Click a host for sessions / OS / locks below.</p>
+              <div class="chips">
+                <span class="chip ok">active shell/implant</span>
+                <span class="chip warn">locked</span>
+                <span class="chip">historical only</span>
+              </div>
+              <div id="hostGraph"></div>
             </div>
-            <div id="hostGraph" style="flex:1;min-height:300px;border:1px solid var(--border);border-radius:10px;background:#0a0a10;position:relative;overflow:hidden"></div>
-            <div id="hostDetail" class="outbox empty" style="margin-top:10px;max-height:240px;overflow:auto">Select a host</div>
+            <div class="hosts-detail-split" id="hostDetailSplit" title="Drag to resize host detail" role="separator" aria-orientation="horizontal"></div>
+            <div class="hosts-detail-pane">
+              <div class="hosts-detail-head">Host detail</div>
+              <div id="hostDetail" class="hosts-detail-body empty">Select a host from the list or graph</div>
+            </div>
           </div>
         </div>
       </div>`;
     viewBuilt.hosts = true;
+    bindHostDetailResize();
     if (el("hostReload")) el("hostReload").onclick = () => loadHostsGraph();
     if (el("hostShowHidden")) {
       el("hostShowHidden").checked = !!_hostsCache.showHidden;
@@ -2844,10 +2851,13 @@
           try {
             await api("POST", "/api/v1/hosts/" + encodeURIComponent(id) + "/hide", {});
             showOk("Dropped from graph");
-            if (_hostsCache.selected === id) {
-              _hostsCache.selected = null;
-              if (detail) { detail.classList.add("empty"); detail.textContent = "Select a host"; }
-            }
+              if (_hostsCache.selected === id) {
+                _hostsCache.selected = null;
+                if (detail) {
+                  detail.classList.add("empty");
+                  detail.textContent = "Select a host from the list or graph";
+                }
+              }
             await loadHostsGraph();
           } catch (e) { showError(String(e.message || e)); }
         };
@@ -2879,6 +2889,48 @@
     }
   }
 
+  function bindHostDetailResize() {
+    const handle = el("hostDetailSplit");
+    const body = document.querySelector(".hosts-work-body");
+    if (!handle || !body || handle.dataset.bound) return;
+    handle.dataset.bound = "1";
+    try {
+      const saved = parseFloat(localStorage.getItem("sc5_hosts_detail_fr") || "");
+      if (saved >= 0.25 && saved <= 0.7) {
+        body.style.gridTemplateRows = `minmax(120px, 1fr) 6px minmax(160px, ${saved}fr)`;
+      }
+    } catch (_) {}
+    let dragging = false;
+    const onMove = (clientY) => {
+      const rect = body.getBoundingClientRect();
+      if (rect.height < 80) return;
+      // detail fraction of body height (handle ~6px)
+      const fromBottom = rect.bottom - clientY;
+      let frac = fromBottom / rect.height;
+      frac = Math.max(0.22, Math.min(0.65, frac));
+      body.style.gridTemplateRows = `minmax(120px, 1fr) 6px minmax(160px, ${frac}fr)`;
+      try { localStorage.setItem("sc5_hosts_detail_fr", String(frac)); } catch (_) {}
+    };
+    const up = () => {
+      dragging = false;
+      handle.classList.remove("dragging");
+      document.removeEventListener("pointermove", move);
+      document.removeEventListener("pointerup", up);
+    };
+    const move = (e) => {
+      if (!dragging) return;
+      onMove(e.clientY);
+    };
+    handle.addEventListener("pointerdown", (e) => {
+      dragging = true;
+      handle.classList.add("dragging");
+      handle.setPointerCapture?.(e.pointerId);
+      document.addEventListener("pointermove", move);
+      document.addEventListener("pointerup", up);
+      e.preventDefault();
+    });
+  }
+
   function showHostDetail(h, detail) {
     if (!detail || !h) return;
     detail.classList.remove("empty");
@@ -2903,19 +2955,24 @@
         : `<button type="button" class="danger sm" id="hostDetailHide">Drop from graph</button>`)
       : "";
     detail.innerHTML = `
-      <div style="margin-bottom:8px;display:flex;align-items:flex-start;gap:8px;flex-wrap:wrap">
+      <div style="margin-bottom:10px;display:flex;align-items:flex-start;gap:8px;flex-wrap:wrap">
         <div style="flex:1;min-width:160px">
-          <strong style="font-size:1rem">${esc(h.label)}</strong>
-          <div class="muted" style="font-size:0.78rem;margin-top:4px">
-            OS: ${esc(h.os_info || "-")} · Addrs: ${esc((h.addrs || []).join(", ") || "-")}<br/>
-            Users: ${esc((h.usernames || []).join(", ") || "-")} · Kinds: ${esc((h.kinds || []).join(", "))}
+          <strong style="font-size:1.05rem">${esc(h.label)}</strong>
+          <div class="muted" style="font-size:0.8rem;margin-top:6px;line-height:1.45">
+            <div><strong>OS</strong> ${esc(h.os_info || "-")}</div>
+            <div><strong>Addrs</strong> ${esc((h.addrs || []).join(", ") || "-")}</div>
+            <div><strong>Users</strong> ${esc((h.usernames || []).join(", ") || "-")}</div>
+            <div><strong>Kinds</strong> ${esc((h.kinds || []).join(", ") || "-")}</div>
+            <div><strong>Access</strong> ${esc(String(h.active_sessions || 0))}/${esc(String(h.session_count || 0))} sessions</div>
           </div>
         </div>
         ${dropBtn}
       </div>
+      <div class="muted" style="font-size:0.68rem;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:6px">Sessions on this host</div>
       <table class="data"><thead><tr>
         <th>Session</th><th>Kind</th><th>Status</th><th>User</th><th>Lock</th>
-      </tr></thead><tbody>${sess || '<tr><td colspan="5" class="muted">No sessions</td></tr>'}</tbody></table>`;
+      </tr></thead><tbody>${sess || '<tr><td colspan="5" class="muted">No sessions</td></tr>'}</tbody></table>
+      <p class="muted" style="font-size:0.72rem;margin:10px 0 0">Click a session row to open the context rail (claim / shell).</p>`;
     detail.querySelectorAll("tr[data-sid]").forEach((tr) => {
       tr.onclick = () => {
         const sid = tr.getAttribute("data-sid");
@@ -2929,6 +2986,8 @@
           await api("POST", "/api/v1/hosts/" + encodeURIComponent(h.id) + "/hide", {});
           showOk("Dropped from graph");
           _hostsCache.selected = null;
+          detail.classList.add("empty");
+          detail.textContent = "Select a host from the list or graph";
           await loadHostsGraph();
         } catch (e) { showError(String(e.message || e)); }
       };

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -388,6 +388,41 @@
     }
   }
 
+  function updateAiLlmSummary() {
+    const sum = el("aiLlmSummary");
+    if (!sum) return;
+    const conn = el("aiLlmGlobal");
+    const mod = el("aiModelGlobal");
+    const cLabel = conn && conn.selectedIndex >= 0
+      ? (conn.options[conn.selectedIndex]?.text || "").trim()
+      : "";
+    const mLabel = mod && mod.value
+      ? (mod.options[mod.selectedIndex]?.text || mod.value).trim()
+      : "";
+    if (cLabel && mLabel && !cLabel.startsWith("(") && cLabel !== "Loading...") {
+      // short: "name / model" without full provider path noise
+      const shortC = cLabel.split("/")[0].trim() || cLabel;
+      sum.textContent = shortC + " · " + mLabel;
+      return;
+    }
+    if (cLabel && !cLabel.startsWith("(") && cLabel !== "Loading...") {
+      sum.textContent = cLabel.split("/")[0].trim() || cLabel;
+      return;
+    }
+    sum.textContent = "LLM · pick connection";
+  }
+
+  function setAiLlmBarOpen(open) {
+    const bar = el("aiLlmBar");
+    const body = el("aiLlmBarBody");
+    const toggle = el("aiLlmBarToggle");
+    if (!bar) return;
+    bar.classList.toggle("open", !!open);
+    if (body) body.hidden = !open;
+    if (toggle) toggle.setAttribute("aria-expanded", open ? "true" : "false");
+    try { localStorage.setItem("sc5_inko_llm_open", open ? "1" : "0"); } catch (_) {}
+  }
+
   function bindLlmModelPair(connId, modelId) {
     const conn = el(connId);
     const mod = el(modelId);
@@ -403,6 +438,13 @@
       } catch (_) { pref = loadSel("sc5_ops_model") || ""; }
       await loadModelsForLlm(id, modelId, pref);
       if (mod.value) saveSel("sc5_ops_model", mod.value);
+      updateAiLlmSummary();
+      // Collapse settings once both connection + model are chosen (flyout only)
+      if (connId === "aiLlmGlobal" && id && mod.value) {
+        let preferOpen = false;
+        try { preferOpen = localStorage.getItem("sc5_inko_llm_open") === "1"; } catch (_) {}
+        if (!preferOpen) setAiLlmBarOpen(false);
+      }
     };
     conn.onchange = () => { sync(); };
     mod.onchange = () => {
@@ -412,6 +454,8 @@
       if (id && mod.value) {
         api("PATCH", "/api/v1/llm/" + encodeURIComponent(id), { model: mod.value }).catch(() => {});
       }
+      updateAiLlmSummary();
+      if (connId === "aiLlmGlobal" && id && mod.value) setAiLlmBarOpen(false);
     };
     sync();
   }
@@ -1809,7 +1853,21 @@
       fillLlmSelect(el("aiLlmPick"), llms, loadSel("sc5_ops_llm") || "");
       bindLlmModelPair("aiLlmGlobal", "aiModelGlobal");
       bindLlmModelPair("aiLlmPick", "aiModelPick");
+      updateAiLlmSummary();
     });
+    // Collapsible connection/model bar (collapsed when set)
+    if (el("aiLlmBarToggle") && !el("aiLlmBarToggle").dataset.bound) {
+      el("aiLlmBarToggle").dataset.bound = "1";
+      el("aiLlmBarToggle").onclick = () => {
+        const bar = el("aiLlmBar");
+        const open = !(bar && bar.classList.contains("open"));
+        setAiLlmBarOpen(open);
+      };
+      let startOpen = false;
+      try { startOpen = localStorage.getItem("sc5_inko_llm_open") === "1"; } catch (_) {}
+      const hasSel = !!(loadSel("sc5_ops_llm") && loadSel("sc5_ops_model"));
+      setAiLlmBarOpen(startOpen || !hasSel);
+    }
     btn.onclick = () => openAiDrawer();
     if (el("aiDrawerClose")) el("aiDrawerClose").onclick = () => openAiDrawer(false);
     if (backdrop) backdrop.onclick = () => openAiDrawer(false);

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -723,6 +723,57 @@
       padding-bottom: calc(8px + env(safe-area-inset-bottom, 0px));
     }
     .ai-drawer-foot select, .ai-drawer-foot textarea { width: 100%; }
+    .ai-llm-bar {
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      background: rgba(0,0,0,0.2);
+      overflow: hidden;
+    }
+    .ai-llm-bar-toggle {
+      width: 100%;
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      text-align: left;
+      padding: 6px 10px;
+      min-height: 34px;
+      border: none;
+      background: transparent;
+      color: var(--muted);
+      font-size: 0.72rem;
+      cursor: pointer;
+    }
+    .ai-llm-bar-toggle:hover { color: var(--text); background: rgba(255,255,255,0.03); }
+    .ai-llm-bar-toggle .ai-llm-summary {
+      flex: 1;
+      min-width: 0;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      color: var(--text);
+      font-weight: 600;
+    }
+    .ai-llm-bar-toggle .ai-llm-chevron {
+      flex-shrink: 0;
+      opacity: 0.7;
+      font-size: 0.65rem;
+      transition: transform 0.15s ease;
+    }
+    .ai-llm-bar.open .ai-llm-chevron { transform: rotate(90deg); }
+    .ai-llm-bar-body {
+      display: none;
+      flex-direction: column;
+      gap: 6px;
+      padding: 0 8px 8px;
+    }
+    .ai-llm-bar.open .ai-llm-bar-body { display: flex; }
+    .ai-llm-bar-body label {
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--muted);
+      margin: 0;
+    }
     @media (max-width: 900px) {
       .ai-drawer {
         width: 100vw; left: 0; right: 0;
@@ -1077,8 +1128,19 @@
       </div>
       <div class="ai-drawer-body" id="aiChatLog"></div>
       <div class="ai-drawer-foot" id="aiDrawerFoot">
-        <select id="aiLlmGlobal" title="LLM connection"></select>
-        <select id="aiModelGlobal" title="Model" disabled><option value="">Model...</option></select>
+        <div class="ai-llm-bar" id="aiLlmBar">
+          <button type="button" class="ai-llm-bar-toggle" id="aiLlmBarToggle" aria-expanded="false" title="Show or hide LLM settings">
+            <span class="ai-llm-chevron" aria-hidden="true">&#9654;</span>
+            <span class="ai-llm-summary" id="aiLlmSummary">LLM · pick connection</span>
+            <span class="muted" style="flex-shrink:0;font-size:0.65rem">change</span>
+          </button>
+          <div class="ai-llm-bar-body" id="aiLlmBarBody" hidden>
+            <label for="aiLlmGlobal">Connection</label>
+            <select id="aiLlmGlobal" title="LLM connection"></select>
+            <label for="aiModelGlobal">Model</label>
+            <select id="aiModelGlobal" title="Model" disabled><option value="">Model...</option></select>
+          </div>
+        </div>
         <textarea id="aiPromptGlobal" rows="3" placeholder="Ask INKO anything - list sessions, spin up a listener..."></textarea>
         <div class="row" style="margin:0;gap:6px">
           <button type="button" class="primary" id="aiSendGlobal" style="flex:1">Send</button>

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -472,6 +472,91 @@
       max-height: 240px; overflow: auto; white-space: pre-wrap; word-break: break-word;
       color: #d4d4de; margin-top: 8px;
     }
+    /* Assets: graph + host detail must both stay usable */
+    .hosts-work-body {
+      display: grid !important;
+      grid-template-rows: minmax(140px, 1fr) 6px minmax(200px, 0.9fr);
+      gap: 0;
+      padding: 0 !important;
+      overflow: hidden !important;
+      height: 100%;
+      min-height: 0;
+    }
+    .hosts-graph-pane {
+      min-height: 0;
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      padding: 10px 12px 6px;
+      gap: 6px;
+    }
+    .hosts-graph-pane #hostGraph {
+      flex: 1 1 auto;
+      min-height: 120px;
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: #0a0a10;
+      position: relative;
+      overflow: hidden;
+    }
+    .hosts-detail-split {
+      cursor: row-resize;
+      background: rgba(255,255,255,0.06);
+      position: relative;
+      z-index: 2;
+      touch-action: none;
+    }
+    .hosts-detail-split::after {
+      content: "";
+      position: absolute;
+      left: 50%;
+      top: 1px;
+      transform: translateX(-50%);
+      width: 36px;
+      height: 3px;
+      border-radius: 2px;
+      background: rgba(233,30,140,0.45);
+    }
+    .hosts-detail-split:hover,
+    .hosts-detail-split.dragging {
+      background: rgba(233,30,140,0.2);
+    }
+    .hosts-detail-pane {
+      min-height: 0;
+      display: flex;
+      flex-direction: column;
+      border-top: 1px solid var(--border);
+      background: #08080c;
+      overflow: hidden;
+    }
+    .hosts-detail-head {
+      flex-shrink: 0;
+      padding: 6px 12px;
+      font-size: 0.68rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--muted);
+      border-bottom: 1px solid var(--border);
+      background: var(--bg3);
+    }
+    .hosts-detail-body {
+      flex: 1 1 auto;
+      min-height: 0;
+      overflow: auto;
+      padding: 10px 12px;
+      font-size: 0.8rem;
+      color: var(--text);
+    }
+    .hosts-detail-body.empty {
+      color: var(--muted);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    .hosts-detail-body table.data { font-size: 0.78rem; }
     .outbox.empty { color: var(--muted); }
     .chips { display: flex; flex-wrap: wrap; gap: 6px; }
     .chip {


### PR DESCRIPTION
## INKO
Connection + model sit in a collapsible bar (summary when set; click to change).

## Assets empty with live shell
Prod host \`104.9.243.61\` was bulk-hidden while inactive. Live hosts now auto-unhide on list; verify merges metadata + unhides.

## Test plan
- [x] pytest tests/test_hosts_graph.py
- [ ] Hard-refresh Ops: Assets shows live shell; INKO bar collapses