### PR TITLE
feat(admin): factory reset to first-boot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,9 @@ sc5 policy hitl list|approve|deny
 
 sc5 backup [path] [--data-dir DIR]
 sc5 restore <backup.db> [--data-dir DIR]
+sc5 factory-reset --yes [--data-dir DIR] [--wipe-tls] [--keep-implant-psk]
+# API: POST /api/v1/admin/factory-reset {confirm:"FACTORY RESET", keep_tls?, ...} → new admin_token once
+# Ops Admin → Danger tab
 
 # File ops / SOCKS (API; CLI via tasks or REST)
 # POST /api/v1/files/op {session_id, op:list|read|write|delete, path, ...}

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -250,6 +250,15 @@ class FeaturesUpdate(BaseModel):
     features: dict[str, bool]
 
 
+class FactoryResetRequest(BaseModel):
+    """Wipe operator data to first-boot. confirm must be exactly FACTORY RESET."""
+
+    confirm: str
+    keep_tls: bool = True
+    keep_implant_psk: bool = False
+    regenerate_instance_tls: bool = False
+
+
 class ProfileShapeRequest(BaseModel):
     profile_id: str | None = None
     beacon: dict[str, Any] = Field(default_factory=dict)
@@ -2129,6 +2138,32 @@ def build_api_router() -> APIRouter:
         state = get_state(request)
         flags = await state.features.set_many(body.features, auth.name)
         return {"features": flags, "catalog": state.features.catalog()}
+
+    @api.post("/admin/factory-reset")
+    async def admin_factory_reset(
+        body: FactoryResetRequest,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("admin")),
+    ) -> dict[str, Any]:
+        """Wipe DB/secrets to first-boot. Returns new admin_token once. Admin only."""
+        from squidc5.db.factory_reset import CONFIRM_PHRASE, factory_reset_running
+
+        if (body.confirm or "").strip() != CONFIRM_PHRASE:
+            raise HTTPException(
+                400,
+                f'confirm must be exactly "{CONFIRM_PHRASE}"',
+            )
+        try:
+            result = await factory_reset_running(
+                request.app,
+                keep_tls=bool(body.keep_tls),
+                keep_implant_psk=bool(body.keep_implant_psk),
+                regenerate_instance_tls=bool(body.regenerate_instance_tls),
+                actor=auth.name,
+            )
+        except Exception as e:
+            raise HTTPException(500, f"factory reset failed: {e}") from e
+        return result
 
     # ----- Ops console UI -----
     # /ops/admin.js: admin scope only (never ship admin control code to non-admins).

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -145,14 +145,76 @@ def cmd_backup(args: argparse.Namespace) -> None:
     print(json.dumps({"ok": True, "source": str(src), "backup": str(out)}, indent=2))
 
 
+def cmd_factory_reset(args: argparse.Namespace) -> None:
+    """Wipe local data_dir to first-boot. Stop squidc5 before running."""
+    from squidc5.auth.tokens import TokenService
+    from squidc5.db.factory_reset import CONFIRM_PHRASE, wipe_data_dir
+    from squidc5.db.store import Database
+
+    data = Path(args.data_dir).expanduser() if args.data_dir else Path("data")
+    if not args.yes:
+        print(
+            f"This will DELETE the database and secrets under {data}.\n"
+            f'Type "{CONFIRM_PHRASE}" to continue:',
+            flush=True,
+        )
+        try:
+            typed = input().strip()
+        except EOFError:
+            typed = ""
+        if typed != CONFIRM_PHRASE:
+            print(json.dumps({"ok": False, "error": "aborted"}, indent=2))
+            raise SystemExit(1)
+
+    info = wipe_data_dir(
+        data,
+        keep_tls=not bool(args.wipe_tls),
+        keep_implant_psk=bool(args.keep_implant_psk),
+        regenerate_instance_tls=bool(args.regenerate_instance_tls),
+    )
+
+    # Recreate empty DB + bootstrap admin (same as server start)
+    import asyncio
+
+    async def _boot() -> str:
+        db = Database(data / "squidc5.db")
+        await db.connect()
+        tokens = TokenService(db)
+        raw = await tokens.bootstrap_admin(None)
+        await db.close()
+        if raw:
+            tf = data / "admin_token.txt"
+            tf.write_text(raw + "\n", encoding="utf-8")
+            try:
+                tf.chmod(0o600)
+            except OSError:
+                pass
+        return raw or ""
+
+    admin = asyncio.run(_boot())
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                **info,
+                "admin_token": admin,
+                "admin_name": "squidc5-admin",
+                "note": "Start squidc5 and login with admin_token",
+            },
+            indent=2,
+        )
+    )
+
+
 def cmd_restore(args: argparse.Namespace) -> None:
     """Restore SQLite from backup file. Stop squidc5 before restore."""
+
     from squidc5.config import Settings
     from squidc5.db.backup import restore_database
 
     settings = Settings(
         data_dir=Path(args.data_dir) if args.data_dir else Path("data"),
-        db_path=Path(args.db) if args.db else None,
+        db_path=Path(args.db) if getattr(args, "db", None) else None,
     )
     target = settings.resolve_db_path()
     out = restore_database(Path(args.backup), target)
@@ -873,6 +935,25 @@ def build_parser() -> argparse.ArgumentParser:
     cfg = sub.add_parser("config", help="Show saved config")
     cfg.add_argument("--show-token", action="store_true")
     cfg.set_defaults(func=cmd_config_show, needs_client=False)
+
+    fr = sub.add_parser(
+        "factory-reset",
+        help="Wipe local data_dir to first-boot (stop server first)",
+    )
+    fr.add_argument("--data-dir", default=None, help="Data directory (default: ./data)")
+    fr.add_argument(
+        "--yes",
+        action="store_true",
+        help='Skip interactive confirm (must type FACTORY RESET otherwise)',
+    )
+    fr.add_argument("--wipe-tls", action="store_true", help="Also delete data/tls/")
+    fr.add_argument("--keep-implant-psk", action="store_true", help="Keep implant_psk.txt")
+    fr.add_argument(
+        "--regenerate-instance-tls",
+        action="store_true",
+        help="Delete instance self-signed cert (keep library)",
+    )
+    fr.set_defaults(func=cmd_factory_reset, needs_client=False)
 
     bak = sub.add_parser("backup", help="Backup local SQLite DB (no API)")
     bak.add_argument(

--- a/src/squidc5/db/factory_reset.py
+++ b/src/squidc5/db/factory_reset.py
@@ -1,0 +1,174 @@
+"""Factory reset: wipe operator data back to first-boot shape."""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger("squidc5.db.factory_reset")
+
+CONFIRM_PHRASE = "FACTORY RESET"
+
+# Files always removed (secrets + bootstrap token)
+_ALWAYS_WIPE_FILES = (
+    "admin_token.txt",
+    "secrets.key",
+    "implant_psk.txt",
+    "plugin_signing.secret",
+)
+
+
+def _unlink(path: Path) -> bool:
+    try:
+        if path.is_file() or path.is_symlink():
+            path.unlink()
+            return True
+        if path.is_dir():
+            shutil.rmtree(path)
+            return True
+    except OSError as e:
+        log.warning("factory reset could not remove %s: %s", path, e)
+    return False
+
+
+def wipe_data_dir(
+    data_dir: Path,
+    *,
+    keep_tls: bool = True,
+    keep_implant_psk: bool = False,
+    regenerate_instance_tls: bool = False,
+) -> dict[str, Any]:
+    """Delete DB + secrets on disk. Does not touch process env."""
+    data_dir = Path(data_dir)
+    removed: list[str] = []
+    data_dir.mkdir(parents=True, exist_ok=True)
+
+    db = data_dir / "squidc5.db"
+    for p in (db, Path(str(db) + "-wal"), Path(str(db) + "-shm")):
+        if _unlink(p):
+            removed.append(p.name)
+
+    for name in _ALWAYS_WIPE_FILES:
+        if name == "implant_psk.txt" and keep_implant_psk:
+            continue
+        p = data_dir / name
+        if _unlink(p):
+            removed.append(name)
+
+    tls = data_dir / "tls"
+    if regenerate_instance_tls and tls.is_dir():
+        for name in ("server.crt", "server.key", "instance_id"):
+            p = tls / name
+            if _unlink(p):
+                removed.append(f"tls/{name}")
+    if not keep_tls and tls.exists():
+        if _unlink(tls):
+            removed.append("tls/")
+
+    return {
+        "data_dir": str(data_dir),
+        "removed": removed,
+        "keep_tls": keep_tls,
+        "keep_implant_psk": keep_implant_psk,
+        "regenerate_instance_tls": regenerate_instance_tls,
+        "ts": time.time(),
+    }
+
+
+async def factory_reset_running(
+    app: Any,
+    *,
+    keep_tls: bool = True,
+    keep_implant_psk: bool = False,
+    regenerate_instance_tls: bool = False,
+    actor: str = "admin",
+) -> dict[str, Any]:
+    """Stop listeners, wipe data_dir state, rebuild AppState in-process.
+
+    Returns dict including one-time ``admin_token`` for the new bootstrap admin.
+    """
+    from squidc5.main import build_state
+
+    old = app.state.app_state
+    settings = old.settings
+    data_dir = Path(settings.data_dir)
+
+    # Best-effort audit before wipe (chain will be destroyed)
+    try:
+        await old.db.audit(
+            actor=actor,
+            actor_type="admin",
+            action="system.factory_reset",
+            details={
+                "keep_tls": keep_tls,
+                "keep_implant_psk": keep_implant_psk,
+                "regenerate_instance_tls": regenerate_instance_tls,
+            },
+            risk_score=10,
+        )
+    except Exception:
+        log.exception("pre-reset audit failed")
+
+    try:
+        await old.listeners.stop_all(persist_status=False)
+    except Exception:
+        log.exception("stop_all during factory reset")
+
+    try:
+        if old.socks is not None and hasattr(old.socks, "close_all"):
+            await old.socks.close_all()
+    except Exception:
+        pass
+
+    await old.db.close()
+
+    wipe_info = wipe_data_dir(
+        data_dir,
+        keep_tls=keep_tls,
+        keep_implant_psk=keep_implant_psk,
+        regenerate_instance_tls=regenerate_instance_tls,
+    )
+
+    # Force fresh secrets even if env pinned empty; build_state resolves files again
+    new_state = await build_state(settings)
+    app.state.app_state = new_state
+
+    admin_token = ""
+    token_file = data_dir / "admin_token.txt"
+    if token_file.is_file():
+        admin_token = token_file.read_text(encoding="utf-8").strip()
+    elif new_state.admin_token_once:
+        admin_token = new_state.admin_token_once
+
+    # Ensure bootstrap wrote a token (build_state already does; double-check empty)
+    if not admin_token:
+        raw = await new_state.tokens.bootstrap_admin(settings.admin_token_bootstrap)
+        if raw:
+            token_file.write_text(raw + "\n", encoding="utf-8")
+            try:
+                token_file.chmod(0o600)
+            except OSError:
+                pass
+            admin_token = raw
+
+    log.warning(
+        "Factory reset complete by %s keep_tls=%s removed=%s",
+        actor,
+        keep_tls,
+        wipe_info.get("removed"),
+    )
+
+    return {
+        "status": "reset",
+        "admin_token": admin_token,
+        "admin_name": "squidc5-admin",
+        "note": "All sessions, tokens, LLMs, and audit history wiped. "
+        "Save the admin_token now — it is only returned once. "
+        "Reconnect Ops with the new token.",
+        **wipe_info,
+        "pid": os.getpid(),
+    }

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -226,9 +226,20 @@ def create_app(settings: Settings | None = None) -> FastAPI:
         )
         log.info("SquidC5 v%s listening on %s:%s", __version__, settings.host, settings.port)
         yield
-        await state.listeners.stop_all()
-        await state.db.audit(actor="system", actor_type="system", action="server.stop")
-        await state.db.close()
+        # Prefer live app_state (factory reset swaps it in-process)
+        cur = getattr(app.state, "app_state", None) or state
+        try:
+            await cur.listeners.stop_all()
+        except Exception:
+            log.exception("shutdown stop_all failed")
+        try:
+            await cur.db.audit(actor="system", actor_type="system", action="server.stop")
+        except Exception:
+            pass
+        try:
+            await cur.db.close()
+        except Exception:
+            log.exception("shutdown db.close failed")
         log.info("SquidC5 shutdown complete")
 
     # Hardened surface: no public Swagger/ReDoc/OpenAPI by default.

--- a/tests/test_factory_reset.py
+++ b/tests/test_factory_reset.py
@@ -1,0 +1,108 @@
+"""Admin factory reset API + wipe helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from squidc5.cli import main
+from squidc5.db.factory_reset import CONFIRM_PHRASE, wipe_data_dir
+
+
+@pytest.mark.asyncio
+async def test_factory_reset_requires_confirm(client, admin_headers):
+    r = await client.post(
+        "/api/v1/admin/factory-reset",
+        headers=admin_headers,
+        json={"confirm": "nope"},
+    )
+    assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_factory_reset_admin_only(client, admin_headers):
+    from tests.conftest import bearer, mint_token
+
+    op = await mint_token(client, admin_headers, "op", ["sessions:read"])
+    r = await client.post(
+        "/api/v1/admin/factory-reset",
+        headers=bearer(op["token"]),
+        json={"confirm": CONFIRM_PHRASE},
+    )
+    assert r.status_code in (401, 403)
+
+
+@pytest.mark.asyncio
+async def test_factory_reset_wipes_and_returns_token(client, admin_headers, app):
+    # create extra token so we can prove wipe
+    mint = await client.post(
+        "/api/v1/tokens",
+        headers=admin_headers,
+        json={"name": "doomed", "scopes": ["sessions:read"]},
+    )
+    assert mint.status_code == 200
+    before = await client.get("/api/v1/tokens", headers=admin_headers)
+    assert before.status_code == 200
+    before_rows = before.json()
+    assert isinstance(before_rows, list)
+    assert len(before_rows) >= 2
+
+    r = await client.post(
+        "/api/v1/admin/factory-reset",
+        headers=admin_headers,
+        json={
+            "confirm": CONFIRM_PHRASE,
+            "keep_tls": True,
+            "keep_implant_psk": False,
+            "regenerate_instance_tls": False,
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body.get("status") == "reset"
+    new_tok = body.get("admin_token") or ""
+    assert new_tok.startswith("sc5_")
+    assert body.get("admin_name") == "squidc5-admin"
+
+    # tests pin admin_token_bootstrap so secret may match bootstrap value
+    new_h = {"Authorization": f"Bearer {new_tok}"}
+    who = await client.get("/api/v1/meta", headers=new_h)
+    assert who.status_code == 200
+    tokens = await client.get("/api/v1/tokens", headers=new_h)
+    assert tokens.status_code == 200
+    names = [t.get("name") for t in (tokens.json() or [])]
+    assert "doomed" not in names
+    assert any(n == "squidc5-admin" for n in names)
+
+
+def test_wipe_data_dir_files(tmp_path: Path):
+    data = tmp_path / "data"
+    data.mkdir()
+    (data / "squidc5.db").write_bytes(b"x")
+    (data / "admin_token.txt").write_text("old\n")
+    (data / "secrets.key").write_text("k")
+    (data / "implant_psk.txt").write_text("p")
+    tls = data / "tls"
+    tls.mkdir()
+    (tls / "server.crt").write_text("c")
+    info = wipe_data_dir(data, keep_tls=True, keep_implant_psk=True)
+    assert not (data / "squidc5.db").exists()
+    assert not (data / "admin_token.txt").exists()
+    assert (data / "implant_psk.txt").exists()
+    assert (tls / "server.crt").exists()
+    assert "squidc5.db" in info["removed"]
+
+
+def test_cli_factory_reset(tmp_path: Path, capsys):
+    data = tmp_path / "d"
+    data.mkdir()
+    (data / "squidc5.db").write_bytes(b"garbage")
+    (data / "admin_token.txt").write_text("old\n")
+    main(["factory-reset", "--yes", "--data-dir", str(data)])
+    out = json.loads(capsys.readouterr().out)
+    assert out["ok"] is True
+    assert out["admin_token"].startswith("sc5_")
+    assert (data / "admin_token.txt").is_file()
+    assert (data / "squidc5.db").is_file()

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -2180,9 +2180,82 @@
               <div class="row"><button type="button" id="astRefresh">List assets</button></div>
               <div class="outbox empty" id="astOut" style="flex:1;max-height:none">-</div>
       ` : '<p class="muted">Need payloads:generate</p>'},
+      { id: "addanger", label: "Danger", html: can("admin") ? `
+              <p class="muted" style="font-size:0.78rem;margin:0 0 10px">
+                <strong style="color:var(--bad)">Factory reset</strong> wipes the database, all tokens,
+                sessions, LLMs, audit history, and secrets under the data directory.
+                Process environment (<span class="mono">SQUIDC5_*</span>) is not changed.
+                A new bootstrap admin token is returned <strong>once</strong> — save it immediately.
+              </p>
+              <label class="chk-inline"><input type="checkbox" id="frKeepTls" checked /> Keep TLS files (data/tls)</label>
+              <label class="chk-inline"><input type="checkbox" id="frKeepPsk" /> Keep implant_psk.txt</label>
+              <label class="chk-inline"><input type="checkbox" id="frRegenTls" /> Regenerate instance self-signed cert</label>
+              <label style="margin-top:10px">Type <span class="mono">FACTORY RESET</span> to enable</label>
+              <input id="frConfirm" class="mono" placeholder="FACTORY RESET" autocomplete="off" />
+              <div class="row" style="margin-top:10px">
+                <button type="button" class="danger" id="frRun" disabled>Factory reset now</button>
+              </div>
+              <div id="frResult" class="hidden" style="margin-top:12px;padding:12px;border-radius:10px;border:1px solid rgba(248,113,113,0.45);background:rgba(60,20,20,0.45)">
+                <strong style="color:var(--bad)">New admin token (copy now)</strong>
+                <div class="row" style="margin:8px 0;gap:6px;align-items:stretch">
+                  <input id="frToken" class="mono" readonly style="flex:1;font-size:0.75rem" />
+                  <button type="button" id="frCopy">Copy</button>
+                </div>
+                <p class="muted" id="frNote" style="font-size:0.72rem;margin:0"></p>
+              </div>
+      ` : '<p class="muted">Admin only</p>'},
     ], { id: "adminTabs" });
     bindPageTabs(root);
     viewBuilt.admin = true;
+    if (can("admin") && el("frConfirm")) {
+      const frSync = () => {
+        const ok = (el("frConfirm").value || "").trim() === "FACTORY RESET";
+        if (el("frRun")) el("frRun").disabled = !ok;
+      };
+      el("frConfirm").oninput = frSync;
+      frSync();
+      el("frRun").onclick = async () => {
+        const phrase = (el("frConfirm").value || "").trim();
+        if (phrase !== "FACTORY RESET") return showError('Type FACTORY RESET exactly');
+        const ok = await askConfirm(
+          "This permanently wipes all operator data on this instance. You will need the new admin token. Continue?",
+          { title: "Factory reset", okText: "Wipe everything", danger: true },
+        );
+        if (!ok) return;
+        try {
+          const r = await api("POST", "/api/v1/admin/factory-reset", {
+            confirm: "FACTORY RESET",
+            keep_tls: !!(el("frKeepTls") && el("frKeepTls").checked),
+            keep_implant_psk: !!(el("frKeepPsk") && el("frKeepPsk").checked),
+            regenerate_instance_tls: !!(el("frRegenTls") && el("frRegenTls").checked),
+          });
+          const tok = r.admin_token || "";
+          if (el("frResult")) el("frResult").classList.remove("hidden");
+          if (el("frToken")) el("frToken").value = tok;
+          if (el("frNote")) el("frNote").textContent = r.note || "Reconnect Ops with the new token.";
+          if (tok) {
+            try {
+              localStorage.setItem("sc5_token", tok);
+              state.token = tok;
+            } catch (_) {}
+          }
+          showOk("Factory reset complete — save the new admin token");
+        } catch (e) {
+          showError(String(e.message || e));
+        }
+      };
+      if (el("frCopy")) el("frCopy").onclick = async () => {
+        const t = el("frToken")?.value || "";
+        if (!t) return;
+        try {
+          await navigator.clipboard.writeText(t);
+          showOk("Token copied");
+        } catch (_) {
+          el("frToken").select();
+          showOk("Select and copy token manually");
+        }
+      };
+    }
     if (can("llm:manage") || can("admin")) {
       bindLlmForm("adLlm");
       window.__SC5_refreshLlms = async () => {


### PR DESCRIPTION
## Summary
- `POST /api/v1/admin/factory-reset` (admin): wipe DB + secrets, rebuild AppState, return new `admin_token` once
- Ops Admin **Danger** tab + `sc5 factory-reset --yes`
- Confirm phrase `FACTORY RESET`; options keep TLS / implant PSK / regen instance cert
- Lifespan shutdown uses live `app_state` after in-process swap

## Test plan
- [x] `pytest tests/test_factory_reset.py tests/test_backup_restore.py`
- [x] ruff clean on touched files