### PR TITLE
ci: disable Actions pip cache on self-hosted

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,11 +30,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: pip
-          cache-dependency-path: |
-            requirements.txt
-            requirements-dev.txt
-            pyproject.toml
+          # Self-hosted: GitHub Actions pip cache download hangs (0 MB/s). Use local pip only.
+          cache: ""
       - name: Install dependencies
         run: |
           set -euo pipefail
@@ -151,8 +148,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
-          cache: pip
-          cache-dependency-path: requirements.txt
+          # Self-hosted: GitHub Actions pip cache download hangs (0 MB/s). Use local pip only.
+          cache: ""
       - name: Install pip-audit
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- Self-hosted CI hung on `setup-python` pip cache restore (`Received 0 of ~105MB, 0.0 MBs/sec`).
- Set `cache: ""` on `test` and `security` jobs (same as binaries).

## Test plan
- [ ] CI passes without stalling on Set up Python