### PR TITLE
fix(mcp): dual-gate status so Ops does not look live when env is off

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,6 +10,7 @@ SQUIDC5_TLS_ENABLED=true
 # SQUIDC5_TLS_KEY_FILE=/path/to/privkey.pem
 # SQUIDC5_TLS_FORCE_NEW=false
 # Secure defaults
+# External MCP (/mcp/tools, /mcp/call). BOTH this env AND Admin feature mcp_enabled must be true.
 SQUIDC5_MCP_ENABLED=false
 SQUIDC5_AI_ENABLED=true
 SQUIDC5_EXPOSE_HEALTH_DETAILS=false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ Ops UI: `/ops` (admin UI loaded only after server-side admin token check)
 |---------|---------|
 | Public Swagger / OpenAPI | **OFF** (hard-locked) |
 | CORS | **empty** (no `*`) |
-| MCP external tools | **OFF** until settings/feature enable |
+| MCP external tools | **OFF** until **both** `SQUIDC5_MCP_ENABLED=true` and feature `mcp_enabled` |
 | Shell exec probe | **ON** |
 | False-shell filter | **ON** |
 | Auto stage-2 stabilize | **OFF** (manual Stabilize or feature flag) |

--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -399,6 +399,38 @@ class PluginInstall(BaseModel):
     enable: bool = True
 
 
+async def _mcp_status(state: Any) -> dict[str, Any]:
+    """Both gates must be on for external MCP (/mcp/*) to accept calls."""
+    setting = bool(getattr(state.settings, "mcp_enabled", False))
+    feature = True
+    if hasattr(state, "features"):
+        try:
+            feature = bool(await state.features.enabled("mcp_enabled"))
+        except Exception:
+            feature = False
+    active = setting and feature
+    blocked_by: list[str] = []
+    if not setting:
+        blocked_by.append("settings")  # SQUIDC5_MCP_ENABLED
+    if not feature:
+        blocked_by.append("feature_flag")  # Admin features mcp_enabled
+    return {
+        "active": active,
+        "setting": setting,
+        "feature": feature,
+        "blocked_by": blocked_by,
+        "endpoints": {
+            "tools": "/mcp/tools",
+            "call": "/mcp/call",
+        },
+        "note": (
+            "MCP requires SQUIDC5_MCP_ENABLED=true AND feature mcp_enabled=true"
+            if not active
+            else "MCP accepting authenticated tool calls"
+        ),
+    }
+
+
 def build_api_router() -> APIRouter:
     api = APIRouter(prefix="/api/v1")
 
@@ -461,10 +493,15 @@ def build_api_router() -> APIRouter:
             },
             "tls_enabled": bool(state.settings.tls_enabled),
             "mcp_enabled_setting": bool(state.settings.mcp_enabled),
+            "mcp": await _mcp_status(state),
         }
 
     @api.get("/meta")
-    async def meta(auth: AuthContext = Depends(get_auth)) -> dict[str, Any]:
+    async def meta(
+        request: Request,
+        auth: AuthContext = Depends(get_auth),
+    ) -> dict[str, Any]:
+        state = get_state(request)
         catalog = scope_catalog()
         return {
             "scopes": sorted(auth.scopes),
@@ -475,6 +512,7 @@ def build_api_router() -> APIRouter:
             "default_mcp_tools": sorted(DEFAULT_MCP_TOOLS),
             "all_mcp_tools": sorted(ALL_MCP_TOOLS),
             "mcp_tools": sorted(auth.mcp_tools),
+            "mcp": await _mcp_status(state),
             "actor": auth.name,
             "actor_type": auth.actor_type,
             "token_id": auth.token_id,
@@ -2127,6 +2165,7 @@ def build_api_router() -> APIRouter:
         return {
             "features": flags,
             "catalog": state.features.catalog(),
+            "mcp": await _mcp_status(state),
         }
 
     @api.put("/features")
@@ -2137,7 +2176,11 @@ def build_api_router() -> APIRouter:
     ) -> dict[str, Any]:
         state = get_state(request)
         flags = await state.features.set_many(body.features, auth.name)
-        return {"features": flags, "catalog": state.features.catalog()}
+        return {
+            "features": flags,
+            "catalog": state.features.catalog(),
+            "mcp": await _mcp_status(state),
+        }
 
     @api.post("/admin/factory-reset")
     async def admin_factory_reset(

--- a/src/squidc5/mcp/server.py
+++ b/src/squidc5/mcp/server.py
@@ -58,9 +58,15 @@ async def _auth(
 ) -> AuthContext:
     state: AppState = request.app.state.app_state
     if hasattr(state, "features") and not await state.features.enabled("mcp_enabled"):
-        raise HTTPException(403, "MCP disabled by feature flag")
+        raise HTTPException(
+            403,
+            "MCP disabled by feature flag (enable Admin → Features → mcp_enabled)",
+        )
     if not state.settings.mcp_enabled:
-        raise HTTPException(403, "MCP disabled in server settings")
+        raise HTTPException(
+            403,
+            "MCP disabled in server settings (set SQUIDC5_MCP_ENABLED=true and restart)",
+        )
     raw = None
     if authorization and authorization.lower().startswith("bearer "):
         raw = authorization[7:].strip()

--- a/tests/test_mcp_status_gates.py
+++ b/tests/test_mcp_status_gates.py
@@ -1,0 +1,70 @@
+"""MCP dual-gate status on meta/features + clear 403 when settings off."""
+
+from __future__ import annotations
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from squidc5.config import Settings
+from squidc5.main import create_app
+
+ADMIN = "sc5_test_admin_token_bootstrap_mcpstat01"
+
+
+@pytest.mark.asyncio
+async def test_meta_reports_mcp_blocked_when_setting_off(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "mcp_off",
+        debug=True,
+        mcp_enabled=False,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=2000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        await app.state.app_state.features.set_many({"mcp_enabled": True}, actor="test")
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            meta = (await client.get("/api/v1/meta", headers=h)).json()
+            mcp = meta.get("mcp") or {}
+            assert mcp.get("setting") is False
+            assert mcp.get("feature") is True
+            assert mcp.get("active") is False
+            assert "settings" in (mcp.get("blocked_by") or [])
+
+            feats = (await client.get("/api/v1/features", headers=h)).json()
+            assert feats.get("mcp", {}).get("active") is False
+
+            r = await client.get("/mcp/tools", headers=h)
+            assert r.status_code == 403
+            detail = r.json().get("detail") or ""
+            assert "SQUIDC5_MCP_ENABLED" in detail or "server settings" in detail.lower()
+
+
+@pytest.mark.asyncio
+async def test_meta_reports_mcp_active_when_both_on(tmp_path):
+    settings = Settings(
+        data_dir=tmp_path / "mcp_on",
+        debug=True,
+        mcp_enabled=True,
+        admin_token_bootstrap=ADMIN,
+        plugin_signing_secret="test-plugin-signing-secret-for-ci",
+        rate_limit_per_minute=2000,
+    )
+    app = create_app(settings)
+    async with app.router.lifespan_context(app):
+        await app.state.app_state.features.set_many({"mcp_enabled": True}, actor="test")
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            mcp = (await client.get("/api/v1/meta", headers=h)).json().get("mcp") or {}
+            assert mcp.get("active") is True
+            assert mcp.get("setting") is True
+            assert mcp.get("feature") is True
+            assert (mcp.get("blocked_by") or []) == []
+
+            tools = await client.get("/mcp/tools", headers=h)
+            assert tools.status_code == 200
+            assert "tools" in tools.json()

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -2659,23 +2659,38 @@
       try {
         const r = await api("GET", "/api/v1/features");
         const feats = r.features || r || {};
+        const mcp = r.mcp || {};
         const labelBy = {};
         (r.catalog || []).forEach((c) => {
           if (c && c.key) labelBy[c.key] = c.label || c.key;
         });
         const keys = Object.keys(feats).sort();
-        grid.innerHTML = keys.map((k) => {
+        let mcpWarn = "";
+        if (mcp && mcp.active === false) {
+          const why = (mcp.blocked_by || []).join(" + ") || "unknown";
+          mcpWarn = `<p class="muted" style="margin:0 0 8px;padding:8px;border-radius:8px;border:1px solid rgba(250,204,21,0.4);background:rgba(250,204,21,0.08);color:#facc15;font-size:0.75rem">
+            <strong>MCP not live</strong> (blocked by: ${esc(why)}).
+            Needs <span class="mono">SQUIDC5_MCP_ENABLED=true</span> <em>and</em> feature <span class="mono">mcp_enabled</span>.
+            ${esc(mcp.note || "")}
+          </p>`;
+        } else if (mcp && mcp.active) {
+          mcpWarn = `<p class="muted" style="margin:0 0 8px;font-size:0.72rem;color:var(--ok)">MCP live — GET/POST <span class="mono">/mcp/tools</span> · <span class="mono">/mcp/call</span></p>`;
+        }
+        grid.innerHTML = mcpWarn + keys.map((k) => {
           const lab = labelBy[k] || k;
           const on = !!feats[k];
           const locked = k === "public_docs";
+          const mcpNote = k === "mcp_enabled" && mcp.setting === false
+            ? ' <span class="chip warn" title="Process env SQUIDC5_MCP_ENABLED is false">needs env</span>'
+            : "";
           return `<label title="${esc(k)}">
             <input type="checkbox" class="ad-feat" data-feat="${esc(k)}" ${on ? "checked" : ""} ${locked ? "disabled" : ""} />
-            <span>${esc(lab)}</span>
+            <span>${esc(lab)}${mcpNote}</span>
           </label>`;
         }).join("") || '<span class="muted">No features</span>';
         if (el("adOut")) {
           el("adOut").classList.remove("empty");
-          el("adOut").textContent = JSON.stringify({ features: feats }, null, 2);
+          el("adOut").textContent = JSON.stringify({ features: feats, mcp }, null, 2);
         }
       } catch (e) { showError(String(e.message || e)); }
     }


### PR DESCRIPTION
## Summary
- Prod: set `SQUIDC5_MCP_ENABLED=true` (already applied; `/mcp/tools` 200)
- Expose `mcp: {active, setting, feature, blocked_by}` on `/api/v1/meta`, features, deep health
- Clearer 403 when settings or feature blocks MCP
- Ops Admin → Features warns when feature is on but env still off

## Test plan
- [x] `pytest tests/test_mcp_status_gates.py`
- [x] MCP tools/call against prod with operator token after env enable