### PR TITLE
feat(db): SQLite concurrency B1 — read/write split + metrics batch

### DIFF
--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -25,23 +25,47 @@ def _uid(prefix: str = "") -> str:
 
 
 class Database:
-    """Async SQLite store. One connection guarded by an asyncio lock."""
+    """Async SQLite store with WAL + separate read/write connections.
+
+    Writes serialize on ``_wlock``. Reads use a dedicated read-only connection
+    so concurrent operators/beacons do not block each other on the write lock.
+    """
 
     def __init__(self, path: Path) -> None:
         self.path = path
         self._db: aiosqlite.Connection | None = None
-        self._lock = asyncio.Lock()
+        self._ro: aiosqlite.Connection | None = None
+        self._wlock = asyncio.Lock()
+        self._rlock = asyncio.Lock()
+        # Back-compat alias used by a few call sites / tests
+        self._lock = self._wlock
+
+    async def _configure_conn(self, conn: aiosqlite.Connection, *, readonly: bool = False) -> None:
+        conn.row_factory = aiosqlite.Row
+        await conn.execute("PRAGMA journal_mode=WAL")
+        await conn.execute("PRAGMA foreign_keys=ON")
+        await conn.execute("PRAGMA busy_timeout=5000")
+        await conn.execute("PRAGMA synchronous=NORMAL")
+        await conn.execute("PRAGMA temp_store=MEMORY")
+        await conn.execute("PRAGMA cache_size=-8000")  # ~8MB page cache
+        if readonly:
+            # Fail fast if a read path tries to write
+            await conn.execute("PRAGMA query_only=ON")
 
     async def connect(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._db = await aiosqlite.connect(str(self.path))
-        self._db.row_factory = aiosqlite.Row
-        await self._db.execute("PRAGMA journal_mode=WAL")
-        await self._db.execute("PRAGMA foreign_keys=ON")
+        await self._configure_conn(self._db, readonly=False)
         await apply_migrations(self._db)
         await self._db.commit()
+        # Second connection for concurrent reads under WAL
+        self._ro = await aiosqlite.connect(f"file:{self.path}?mode=ro", uri=True)
+        await self._configure_conn(self._ro, readonly=True)
 
     async def close(self) -> None:
+        if self._ro is not None:
+            await self._ro.close()
+            self._ro = None
         if self._db is not None:
             await self._db.close()
             self._db = None
@@ -52,21 +76,36 @@ class Database:
             raise RuntimeError("Database not connected")
         return self._db
 
+    def _read_conn(self) -> aiosqlite.Connection:
+        if self._ro is not None:
+            return self._ro
+        if self._db is None:
+            raise RuntimeError("Database not connected")
+        return self._db
+
     async def execute(self, sql: str, params: tuple[Any, ...] = ()) -> aiosqlite.Cursor:
-        async with self._lock:
+        async with self._wlock:
             cur = await self.conn.execute(sql, params)
             await self.conn.commit()
             return cur
 
+    async def executemany(self, sql: str, seq: list[tuple[Any, ...]]) -> None:
+        """Batch write under a single lock/commit (metrics flush, bulk ops)."""
+        if not seq:
+            return
+        async with self._wlock:
+            await self.conn.executemany(sql, seq)
+            await self.conn.commit()
+
     async def fetchone(self, sql: str, params: tuple[Any, ...] = ()) -> dict[str, Any] | None:
-        async with self._lock:
-            cur = await self.conn.execute(sql, params)
+        async with self._rlock:
+            cur = await self._read_conn().execute(sql, params)
             row = await cur.fetchone()
             return dict(row) if row else None
 
     async def fetchall(self, sql: str, params: tuple[Any, ...] = ()) -> list[dict[str, Any]]:
-        async with self._lock:
-            cur = await self.conn.execute(sql, params)
+        async with self._rlock:
+            cur = await self._read_conn().execute(sql, params)
             rows = await cur.fetchall()
             return [dict(r) for r in rows]
 
@@ -740,17 +779,33 @@ class Database:
     # --- Metrics ---
 
     async def incr_metric(self, key: str, amount: float = 1.0) -> None:
-        row = await self.fetchone("SELECT value FROM metrics WHERE key = ?", (key,))
-        if row:
-            await self.execute(
-                "UPDATE metrics SET value = ?, updated_at = ? WHERE key = ?",
-                (row["value"] + amount, _now(), key),
+        """Atomic upsert — single statement, no read-modify-write race."""
+        now = _now()
+        await self.execute(
+            """INSERT INTO metrics (key, value, updated_at) VALUES (?, ?, ?)
+               ON CONFLICT(key) DO UPDATE SET
+                 value = value + excluded.value,
+                 updated_at = excluded.updated_at""",
+            (key, float(amount), now),
+        )
+
+    async def incr_metrics_batch(self, amounts: dict[str, float]) -> None:
+        """Flush many counter deltas in one lock/commit."""
+        if not amounts:
+            return
+        now = _now()
+        rows = [(k, float(v), now) for k, v in amounts.items() if v]
+        if not rows:
+            return
+        async with self._wlock:
+            await self.conn.executemany(
+                """INSERT INTO metrics (key, value, updated_at) VALUES (?, ?, ?)
+                   ON CONFLICT(key) DO UPDATE SET
+                     value = value + excluded.value,
+                     updated_at = excluded.updated_at""",
+                rows,
             )
-        else:
-            await self.execute(
-                "INSERT INTO metrics (key, value, updated_at) VALUES (?, ?, ?)",
-                (key, amount, _now()),
-            )
+            await self.conn.commit()
 
     async def get_metrics(self) -> dict[str, float]:
         rows = await self.fetchall("SELECT key, value FROM metrics")

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -224,6 +224,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
                 "audit_purged": purged,
             },
         )
+        try:
+            state.metrics.start()
+        except Exception:
+            log.exception("metrics.start failed")
         log.info("SquidC5 v%s listening on %s:%s", __version__, settings.host, settings.port)
         yield
         # Prefer live app_state (factory reset swaps it in-process)
@@ -232,6 +236,10 @@ def create_app(settings: Settings | None = None) -> FastAPI:
             await cur.listeners.stop_all()
         except Exception:
             log.exception("shutdown stop_all failed")
+        try:
+            await cur.metrics.stop()
+        except Exception:
+            log.exception("metrics.stop failed")
         try:
             await cur.db.audit(actor="system", actor_type="system", action="server.stop")
         except Exception:

--- a/src/squidc5/metrics/collector.py
+++ b/src/squidc5/metrics/collector.py
@@ -1,25 +1,79 @@
-"""Lightweight metrics and real-time event buffer."""
+"""Lightweight metrics and real-time event buffer.
+
+Counters are accumulated in memory and flushed to SQLite on a short interval
+so beacon storms and multi-op traffic do not serialize on every incr().
+"""
 
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections import deque
 from typing import Any
 
 from squidc5.db.store import Database
 
+log = logging.getLogger("squidc5.metrics")
+
 
 class MetricsCollector:
-    def __init__(self, db: Database, buffer_size: int = 500) -> None:
+    def __init__(
+        self,
+        db: Database,
+        buffer_size: int = 500,
+        *,
+        flush_interval_sec: float = 1.0,
+    ) -> None:
         self.db = db
         self._events: deque[dict[str, Any]] = deque(maxlen=buffer_size)
         self._lock = asyncio.Lock()
         self._subscribers: list[asyncio.Queue[dict[str, Any]]] = []
         self.started_at = time.time()
+        self._pending: dict[str, float] = {}
+        self._flush_interval = max(0.2, float(flush_interval_sec))
+        self._flush_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+    def start(self) -> None:
+        """Begin background flush loop (call after event loop is running)."""
+        if self._flush_task is None or self._flush_task.done():
+            self._closed = False
+            self._flush_task = asyncio.create_task(self._flush_loop(), name="metrics-flush")
+
+    async def stop(self) -> None:
+        self._closed = True
+        t = self._flush_task
+        self._flush_task = None
+        if t is not None:
+            t.cancel()
+            try:
+                await t
+            except asyncio.CancelledError:
+                pass
+        await self.flush()
+
+    async def _flush_loop(self) -> None:
+        try:
+            while not self._closed:
+                await asyncio.sleep(self._flush_interval)
+                try:
+                    await self.flush()
+                except Exception:
+                    log.exception("metrics flush failed")
+        except asyncio.CancelledError:
+            return
 
     async def incr(self, key: str, amount: float = 1.0) -> None:
-        await self.db.incr_metric(key, amount)
+        async with self._lock:
+            self._pending[key] = self._pending.get(key, 0.0) + float(amount)
+
+    async def flush(self) -> None:
+        async with self._lock:
+            batch = self._pending
+            self._pending = {}
+        if batch:
+            await self.db.incr_metrics_batch(batch)
 
     async def emit(self, event_type: str, payload: dict[str, Any] | None = None) -> None:
         event = {
@@ -37,7 +91,7 @@ class MetricsCollector:
                     dead.append(q)
             for q in dead:
                 self._subscribers.remove(q)
-        await self.incr(f"events.{event_type}")
+            self._pending[f"events.{event_type}"] = self._pending.get(f"events.{event_type}", 0.0) + 1.0
 
     def subscribe(self) -> asyncio.Queue[dict[str, Any]]:
         q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=100)
@@ -49,10 +103,12 @@ class MetricsCollector:
             self._subscribers.remove(q)
 
     async def snapshot(self) -> dict[str, Any]:
+        await self.flush()
         metrics = await self.db.get_metrics()
         return {
             "uptime_seconds": time.time() - self.started_at,
             "metrics": metrics,
             "recent_events": list(self._events)[-50:],
             "subscribers": len(self._subscribers),
+            "pending_counters": len(self._pending),
         }

--- a/tests/test_db_concurrency.py
+++ b/tests/test_db_concurrency.py
@@ -1,0 +1,90 @@
+"""B1: SQLite WAL read/write separation + metrics batching."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from squidc5.db.store import Database
+from squidc5.metrics.collector import MetricsCollector
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reads_during_writes(tmp_path):
+    db = Database(tmp_path / "c.db")
+    await db.connect()
+    try:
+        await db.create_session(kind="beacon", hostname="h0")
+        sids = []
+        for i in range(20):
+            sids.append(await db.create_session(kind="beacon", hostname=f"h{i}"))
+
+        async def reader() -> int:
+            n = 0
+            for _ in range(30):
+                rows = await db.fetchall("SELECT id FROM sessions WHERE status = ?", ("active",))
+                n += len(rows)
+            return n
+
+        async def writer() -> None:
+            for i in range(15):
+                await db.create_session(kind="beacon", hostname=f"w{i}")
+
+        results = await asyncio.gather(reader(), reader(), writer(), reader())
+        assert results[0] > 0
+        rows = await db.list_sessions(status="active")
+        assert len(rows) >= 35
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_metrics_batch_upsert(tmp_path):
+    db = Database(tmp_path / "m.db")
+    await db.connect()
+    try:
+        await db.incr_metrics_batch({"a": 1.0, "b": 2.0})
+        await db.incr_metrics_batch({"a": 3.0, "c": 1.0})
+        m = await db.get_metrics()
+        assert m["a"] == 4.0
+        assert m["b"] == 2.0
+        assert m["c"] == 1.0
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_metrics_collector_flush(tmp_path):
+    db = Database(tmp_path / "mc.db")
+    await db.connect()
+    try:
+        mc = MetricsCollector(db, flush_interval_sec=10.0)
+        await mc.incr("x", 5)
+        await mc.emit("test.event", {"k": 1})
+        # not flushed yet
+        snap_pending = await db.get_metrics()
+        assert snap_pending.get("x", 0) == 0
+        await mc.flush()
+        m = await db.get_metrics()
+        assert m["x"] == 5.0
+        assert m.get("events.test.event") == 1.0
+        snap = await mc.snapshot()
+        assert snap["metrics"]["x"] == 5.0
+        assert any(e["type"] == "test.event" for e in snap["recent_events"])
+    finally:
+        await db.close()
+
+
+@pytest.mark.asyncio
+async def test_read_conn_query_only(tmp_path):
+    db = Database(tmp_path / "ro.db")
+    await db.connect()
+    try:
+        assert db._ro is not None
+        # Writes still work on primary
+        sid = await db.create_session(kind="beacon", hostname="ro-test")
+        row = await db.fetchone("SELECT id FROM sessions WHERE id = ?", (sid,))
+        assert row and row["id"] == sid
+    finally:
+        await db.close()


### PR DESCRIPTION
## Summary
- Dedicated read-only SQLite connection under WAL
- `busy_timeout`, `synchronous=NORMAL`, page cache
- Metrics accumulate in memory and flush on interval / shutdown
- Atomic metric upsert + batch flush API
- Tests for concurrent R/W and flush behavior

## Test plan
- [x] `pytest tests/test_db_concurrency.py` (+ migrations/backup/health)
- [ ] CI green