### PR TITLE
fix(ops): Admin token scopes fully visible and editable

### DIFF
--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -2246,15 +2246,16 @@
               <div class="row" style="margin:4px 0;gap:6px" id="adPresetRow">${presetBtns}</div>
               <p class="muted" id="adPresetDesc" style="font-size:0.72rem;margin:4px 0 8px;min-height:2.2em">${esc((defaultPreset && defaultPreset.description) || "Pick a preset or tick scopes manually.")}</p>
               <label>Scopes</label>
-              <div class="scope-grid" id="adScopeGrid" style="max-height:280px">
+              <p class="muted" style="font-size:0.68rem;margin:2px 0 0">Full scope ids + descriptions. Scroll inside the box to see all; tick to grant.</p>
+              <div class="scope-grid" id="adScopeGrid">
                 ${allScopes.map((s) => {
                   const priv = privileged.has(s);
                   const dis = priv && !can("admin");
-                  return `<label style="align-items:flex-start">
+                  return `<label title="${esc(s)}${priv ? " (privileged)" : ""}">
                     <input type="checkbox" class="ad-scope" value="${esc(s)}"
                       ${defaultScopes.has(s) ? "checked" : ""}
-                      ${dis ? "disabled" : ""} style="margin-top:3px" />
-                    <span>${scopeLabel(s)}</span>
+                      ${dis ? "disabled" : ""} />
+                    <span>${scopeLabel(s)}${priv ? ' <span class="chip warn" style="font-size:0.58rem;padding:1px 5px;vertical-align:middle">priv</span>' : ""}</span>
                   </label>`;
                 }).join("")}
               </div>
@@ -2263,9 +2264,9 @@
               </label>
               <div id="adMcpBox" class="hidden" style="margin-top:8px">
                 <label>MCP tools</label>
-                <div class="scope-grid" id="adMcpGrid" style="max-height:140px">
+                <div class="scope-grid" id="adMcpGrid">
                   ${(meta.all_mcp_tools || []).map((t) =>
-                    `<label><input type="checkbox" class="ad-mcp" value="${esc(t)}" /> <span class="mono" style="font-size:0.72rem">${esc(t)}</span></label>`
+                    `<label title="${esc(t)}"><input type="checkbox" class="ad-mcp" value="${esc(t)}" /> <span class="mono" style="font-size:0.74rem">${esc(t)}</span></label>`
                   ).join("") || '<span class="muted">No MCP catalog</span>'}
                 </div>
               </div>

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -649,16 +649,60 @@
     }
     .view.active > .form-grid > .work-panel { min-height: 0; height: 100%; }
     .scope-grid {
-      display: grid; grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
-      gap: 6px; margin: 8px 0; max-height: 220px; overflow: auto;
-      padding: 8px; background: #0e0e14; border: 1px solid var(--border); border-radius: 8px;
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+      gap: 8px 10px;
+      margin: 8px 0;
+      max-height: min(52vh, 480px);
+      overflow-x: hidden;
+      overflow-y: auto;
+      padding: 10px 12px;
+      background: #0e0e14;
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      align-content: start;
     }
     .scope-grid label {
-      display: flex; align-items: center; gap: 6px; margin: 0;
-      font-size: 0.72rem; text-transform: none; letter-spacing: 0; color: var(--text);
-      font-weight: 500; cursor: pointer;
+      display: flex;
+      align-items: flex-start;
+      gap: 8px;
+      margin: 0;
+      min-width: 0;
+      font-size: 0.78rem;
+      line-height: 1.35;
+      text-transform: none;
+      letter-spacing: 0;
+      color: var(--text);
+      font-weight: 500;
+      cursor: pointer;
+      white-space: normal;
+      overflow: visible;
+      word-break: break-word;
     }
-    .scope-grid input { width: auto; margin: 0; }
+    .scope-grid label span {
+      flex: 1 1 auto;
+      min-width: 0;
+      white-space: normal;
+      overflow: visible;
+      text-overflow: unset;
+    }
+    .scope-grid input {
+      width: auto;
+      min-width: 16px;
+      margin: 2px 0 0;
+      flex-shrink: 0;
+    }
+    /* Tokens admin: scopes must stay fully readable/editable */
+    #adScopeGrid {
+      max-height: min(58vh, 560px) !important;
+      min-height: 220px;
+      grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    }
+    #adMcpGrid {
+      max-height: min(36vh, 320px) !important;
+      min-height: 120px;
+      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    }
 
     table.data { width: 100%; border-collapse: collapse; font-size: 0.8rem; }
     table.data th, table.data td {
@@ -693,7 +737,8 @@
     }
     .admin-stack .work-panel .wp-body { flex: 1; }
     .admin-stack .admin-llm { flex: 0 0 auto; }
-    .admin-stack .scope-grid { max-height: 280px; }
+    .admin-stack .scope-grid { max-height: min(52vh, 480px); }
+    .admin-stack #adScopeGrid { max-height: min(58vh, 560px); }
     .admin-stack .llm-form-grid { max-width: 720px; }
     .view.active > .admin-stack { flex: 1 1 auto; min-height: 0; }
     .row { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 8px; align-items: center; }
@@ -1329,7 +1374,19 @@
       .view.active > .form-grid > .work-panel { height: auto; min-height: 180px; }
       .admin-row { grid-template-columns: 1fr; }
       .stats { grid-template-columns: repeat(2, 1fr); }
-      .scope-grid { grid-template-columns: 1fr 1fr; max-height: 180px; }
+      .scope-grid {
+        grid-template-columns: 1fr;
+        max-height: min(50vh, 420px);
+      }
+      #adScopeGrid {
+        grid-template-columns: 1fr;
+        max-height: min(55vh, 480px) !important;
+        min-height: 180px;
+      }
+      #adMcpGrid {
+        grid-template-columns: 1fr;
+        max-height: min(30vh, 240px) !important;
+      }
       button, .nav-item, input, select, textarea { font-size: 16px; } /* prevent iOS zoom */
       input, select, textarea { padding: 10px; min-height: 42px; }
       select { padding-right: 2.25rem; }


### PR DESCRIPTION
Scopes grid was clipped (narrow cols + short max-height). Expand layout so all scopes/MCP tools are readable and checkable.