### PR TITLE
feat(mcp): OAST mint/revoke/hits and operator tool parity

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ sc5 listeners start|stop|delete <id>
 
 sc5 --insecure ... # skip TLS verify (self-signed teamserver)
 sc5 oast token create [--note "..."]
+sc5 oast token delete|revoke <token_id>
 sc5 oast tokens list
 sc5 oast hits --token T [--protocol dns|http|smtp]
 # aliases: oast mint | oast poll

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1299,6 +1299,8 @@ sc5 mcp tools
 sc5 mcp call list_sessions --args-json '{}'
 ```
 
+Admin tokens see the full catalog, including OAST: `oast_mint`, `oast_list_tokens`, `oast_get_token`, `oast_revoke`, `oast_hits` (count + hit details). Restricted MCP tokens still need those names in `mcp_tools`.
+
 OpenCode snippet shape (auto-generated on mint):
 
 ```json

--- a/src/squidc5/auth/tokens.py
+++ b/src/squidc5/auth/tokens.py
@@ -245,16 +245,27 @@ ALL_MCP_TOOLS = frozenset(
     {
         "list_sessions",
         "get_session",
+        "close_session",
         "list_tasks",
+        "get_task",
         "create_task",
         "list_listeners",
         "create_listener",
         "start_listener",
         "stop_listener",
+        "delete_listener",
         "generate_payload",
+        "list_payload_templates",
         "get_metrics",
         "list_audit",
         "interact_shell",
+        "whoami",
+        "get_platform_status",
+        "oast_mint",
+        "oast_list_tokens",
+        "oast_get_token",
+        "oast_revoke",
+        "oast_hits",
     }
 )
 

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -8,6 +8,7 @@ import os
 import sys
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 import httpx
 
@@ -675,7 +676,8 @@ def cmd_oast_tokens_list(args: argparse.Namespace, client: Client) -> None:
 
 
 def cmd_oast_token_delete(args: argparse.Namespace, client: Client) -> None:
-    pp(client.delete(f"/api/v1/oast/tokens/{args.token_id}"))
+    tid = quote(str(args.token_id), safe="")
+    pp(client.delete(f"/api/v1/oast/tokens/{tid}"))
 
 
 def cmd_oast_hits(args: argparse.Namespace, client: Client) -> None:

--- a/src/squidc5/cli.py
+++ b/src/squidc5/cli.py
@@ -674,6 +674,10 @@ def cmd_oast_tokens_list(args: argparse.Namespace, client: Client) -> None:
     pp(client.get("/api/v1/oast/tokens"))
 
 
+def cmd_oast_token_delete(args: argparse.Namespace, client: Client) -> None:
+    pp(client.delete(f"/api/v1/oast/tokens/{args.token_id}"))
+
+
 def cmd_oast_hits(args: argparse.Namespace, client: Client) -> None:
     q: dict[str, Any] = {"limit": getattr(args, "limit", 100)}
     if getattr(args, "token", None):
@@ -1360,6 +1364,12 @@ def build_parser() -> argparse.ArgumentParser:
     o_tok_c = o_tok_sub.add_parser("create", help="Mint unique OAST payloads")
     o_tok_c.add_argument("--note", default="", help="Operator note")
     o_tok_c.set_defaults(func=cmd_oast_token_create, needs_client=True)
+    o_tok_d = o_tok_sub.add_parser("delete", help="Revoke OAST token")
+    o_tok_d.add_argument("token_id")
+    o_tok_d.set_defaults(func=cmd_oast_token_delete, needs_client=True)
+    o_tok_r = o_tok_sub.add_parser("revoke", help="Alias: token delete")
+    o_tok_r.add_argument("token_id")
+    o_tok_r.set_defaults(func=cmd_oast_token_delete, needs_client=True)
     o_tokens = oast_sub.add_parser("tokens", help="List OAST tokens")
     o_tokens_sub = o_tokens.add_subparsers(dest="oast_tokens_cmd", required=False)
     o_tokens_list = o_tokens_sub.add_parser("list", help="List tokens")

--- a/src/squidc5/mcp/server.py
+++ b/src/squidc5/mcp/server.py
@@ -403,8 +403,10 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
         return s
 
     async def close_session(args: dict[str, Any]) -> Any:
-        await state.sessions.close(args["session_id"])
-        return {"closed": True, "session_id": args["session_id"]}
+        sid = args["session_id"]
+        await state.teams.assert_write_access(sid, auth.name, is_admin=auth.has_scope("admin"))
+        await state.sessions.close(sid)
+        return {"closed": True, "session_id": sid}
 
     async def list_tasks(args: dict[str, Any]) -> Any:
         return await state.tasks.list(session_id=args.get("session_id"))
@@ -413,6 +415,11 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
         t = await state.tasks.get(args["task_id"])
         if not t:
             raise KeyError("task not found")
+        sid = t.get("session_id")
+        if sid:
+            await state.teams.assert_write_access(
+                str(sid), auth.name, is_admin=auth.has_scope("admin"), renew=False
+            )
         return t
 
     async def create_task(args: dict[str, Any]) -> Any:
@@ -515,29 +522,67 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
             raise RuntimeError("OAST not available")
         return state.oast
 
+    async def _oast_owned(token_id: str) -> dict[str, Any]:
+        raw = await state.db.get_oast_client(token_id)
+        if not raw:
+            raise KeyError("oast token not found")
+        if not auth.has_scope("admin") and (raw.get("created_by") or "") != auth.name:
+            raise PermissionError("OAST token not owned by this actor")
+        note = ""
+        meta = raw.get("meta")
+        if isinstance(meta, str):
+            try:
+                import json as _json
+
+                meta = _json.loads(meta)
+            except Exception:
+                meta = {}
+        if isinstance(meta, dict):
+            note = str(meta.get("note") or raw.get("label") or "")
+        return _oast().format_token_response(str(raw["id"]), str(raw["token"]), note=note)
+
     async def oast_mint(args: dict[str, Any]) -> Any:
         return await _oast().create_token(note=str(args.get("note") or ""), created_by=auth.name)
 
     async def oast_list_tokens(args: dict[str, Any]) -> Any:
-        return await _oast().list_tokens(limit=int(args.get("limit") or 100))
+        rows = await _oast().list_tokens(limit=int(args.get("limit") or 100))
+        if auth.has_scope("admin"):
+            return rows
+        owned = []
+        for r in rows:
+            try:
+                owned.append(await _oast_owned(r["id"]))
+            except PermissionError:
+                continue
+        return owned
 
     async def oast_get_token(args: dict[str, Any]) -> Any:
-        row = await _oast().get_token(args["token_id"])
-        if not row:
-            raise KeyError("oast token not found")
-        return row
+        return await _oast_owned(args["token_id"])
 
     async def oast_revoke(args: dict[str, Any]) -> Any:
+        await _oast_owned(args["token_id"])
         ok = await _oast().delete_client(args["token_id"])
         if not ok:
             raise KeyError("oast token not found")
         return {"revoked": True, "token_id": args["token_id"]}
 
     async def oast_hits(args: dict[str, Any]) -> Any:
+        cid = args.get("client_id")
+        tok = args.get("token")
+        if cid:
+            await _oast_owned(str(cid))
+        elif tok:
+            by = await _oast().get_by_token(str(tok))
+            if not by:
+                raise KeyError("oast token not found")
+            await _oast_owned(by["id"])
+            cid = by["id"]
+        elif not auth.has_scope("admin"):
+            raise PermissionError("token or client_id required")
         hits = await _oast().list_hits(
-            token=args.get("token"),
+            token=None if cid else tok,
             protocol=args.get("protocol"),
-            client_id=args.get("client_id"),
+            client_id=cid,
             since=args.get("since"),
             limit=int(args.get("limit") or 100),
         )

--- a/src/squidc5/mcp/server.py
+++ b/src/squidc5/mcp/server.py
@@ -357,16 +357,27 @@ def _tool_catalog() -> list[dict[str, Any]]:
     return [
         {"name": "list_sessions", "description": "List C2 sessions", "inputSchema": {"type": "object", "properties": {"status": {"type": "string"}}}},
         {"name": "get_session", "description": "Get session by id", "inputSchema": {"type": "object", "properties": {"session_id": {"type": "string"}}, "required": ["session_id"]}},
+        {"name": "close_session", "description": "Close a session", "inputSchema": {"type": "object", "properties": {"session_id": {"type": "string"}}, "required": ["session_id"]}},
         {"name": "list_tasks", "description": "List tasks", "inputSchema": {"type": "object", "properties": {"session_id": {"type": "string"}}}},
+        {"name": "get_task", "description": "Get task by id", "inputSchema": {"type": "object", "properties": {"task_id": {"type": "string"}}, "required": ["task_id"]}},
         {"name": "create_task", "description": "Task a session", "inputSchema": {"type": "object", "properties": {"session_id": {"type": "string"}, "command": {"type": "string"}, "args": {"type": "object"}, "hitl_request_id": {"type": "string"}}, "required": ["session_id", "command"]}},
         {"name": "list_listeners", "description": "List listeners", "inputSchema": {"type": "object", "properties": {}}},
-        {"name": "create_listener", "description": "Create listener", "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}, "kind": {"type": "string"}, "port": {"type": "integer"}, "host": {"type": "string"}}, "required": ["name", "kind", "port"]}},
+        {"name": "create_listener", "description": "Create listener", "inputSchema": {"type": "object", "properties": {"name": {"type": "string"}, "kind": {"type": "string"}, "port": {"type": "integer"}, "host": {"type": "string"}, "config": {"type": "object"}}, "required": ["name", "kind", "port"]}},
         {"name": "start_listener", "description": "Start listener", "inputSchema": {"type": "object", "properties": {"listener_id": {"type": "string"}}, "required": ["listener_id"]}},
         {"name": "stop_listener", "description": "Stop listener", "inputSchema": {"type": "object", "properties": {"listener_id": {"type": "string"}}, "required": ["listener_id"]}},
+        {"name": "delete_listener", "description": "Delete listener", "inputSchema": {"type": "object", "properties": {"listener_id": {"type": "string"}}, "required": ["listener_id"]}},
         {"name": "generate_payload", "description": "Generate payload from template", "inputSchema": {"type": "object", "properties": {"template": {"type": "string"}, "host": {"type": "string"}, "port": {"type": "integer"}}, "required": ["template", "host", "port"]}},
+        {"name": "list_payload_templates", "description": "List payload templates", "inputSchema": {"type": "object", "properties": {}}},
         {"name": "get_metrics", "description": "Get metrics snapshot", "inputSchema": {"type": "object", "properties": {}}},
         {"name": "list_audit", "description": "List audit entries", "inputSchema": {"type": "object", "properties": {"limit": {"type": "integer"}}}},
         {"name": "interact_shell", "description": "Send command to reverse shell session", "inputSchema": {"type": "object", "properties": {"session_id": {"type": "string"}, "command": {"type": "string"}, "hitl_request_id": {"type": "string"}}, "required": ["session_id", "command"]}},
+        {"name": "whoami", "description": "Current token name, scopes, MCP tools", "inputSchema": {"type": "object", "properties": {}}},
+        {"name": "get_platform_status", "description": "Public host, OAST flags, listener summary", "inputSchema": {"type": "object", "properties": {}}},
+        {"name": "oast_mint", "description": "Mint OAST token + callback URLs", "inputSchema": {"type": "object", "properties": {"note": {"type": "string"}}}},
+        {"name": "oast_list_tokens", "description": "List minted OAST tokens", "inputSchema": {"type": "object", "properties": {"limit": {"type": "integer"}}}},
+        {"name": "oast_get_token", "description": "Get OAST token + URLs by id", "inputSchema": {"type": "object", "properties": {"token_id": {"type": "string"}}, "required": ["token_id"]}},
+        {"name": "oast_revoke", "description": "Revoke OAST token and its hits", "inputSchema": {"type": "object", "properties": {"token_id": {"type": "string"}}, "required": ["token_id"]}},
+        {"name": "oast_hits", "description": "List OAST hits with count and details", "inputSchema": {"type": "object", "properties": {"token": {"type": "string"}, "protocol": {"type": "string"}, "client_id": {"type": "string"}, "since": {"type": "number"}, "limit": {"type": "integer"}}}},
     ]
 
 
@@ -380,8 +391,18 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
             raise KeyError("session not found")
         return s
 
+    async def close_session(args: dict[str, Any]) -> Any:
+        await state.sessions.close(args["session_id"])
+        return {"closed": True, "session_id": args["session_id"]}
+
     async def list_tasks(args: dict[str, Any]) -> Any:
         return await state.tasks.list(session_id=args.get("session_id"))
+
+    async def get_task(args: dict[str, Any]) -> Any:
+        t = await state.tasks.get(args["task_id"])
+        if not t:
+            raise KeyError("task not found")
+        return t
 
     async def create_task(args: dict[str, Any]) -> Any:
         sid = args["session_id"]
@@ -408,6 +429,7 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
             kind=args["kind"],
             port=int(args["port"]),
             host=args.get("host", "0.0.0.0"),
+            config=args.get("config"),
         )
 
     async def start_listener(args: dict[str, Any]) -> Any:
@@ -415,6 +437,12 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
 
     async def stop_listener(args: dict[str, Any]) -> Any:
         return await state.listeners.stop(args["listener_id"])
+
+    async def delete_listener(args: dict[str, Any]) -> Any:
+        ok = await state.listeners.delete(args["listener_id"])
+        if not ok:
+            raise KeyError("listener not found")
+        return {"deleted": True, "listener_id": args["listener_id"]}
 
     async def generate_payload(args: dict[str, Any]) -> Any:
         if not await state.features.enabled("payloads_generate"):
@@ -424,6 +452,9 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
             host=args["host"],
             port=int(args["port"]),
         )
+
+    async def list_payload_templates(args: dict[str, Any]) -> Any:
+        return state.payloads.list_templates()
 
     async def get_metrics(args: dict[str, Any]) -> Any:
         return await state.metrics.snapshot()
@@ -439,17 +470,90 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
             raise RuntimeError("No live reverse shell for session")
         return {"sent": True, "session_id": sid}
 
+    async def whoami(args: dict[str, Any]) -> Any:
+        return {
+            "name": auth.name,
+            "scopes": sorted(auth.scopes),
+            "mcp_tools": sorted(auth.mcp_tools),
+            "actor_type": auth.actor_type,
+        }
+
+    async def get_platform_status(args: dict[str, Any]) -> Any:
+        flags = await state.features.get_all()
+        listeners = await state.listeners.list()
+        return {
+            "public_host": state.settings.public_host or state.settings.oast_zone,
+            "oast_enabled": bool(state.settings.oast_enabled and flags.get("oast_enabled")),
+            "dns_oast": bool(flags.get("dns_listeners")),
+            "smtp_oast": bool(flags.get("smtp_oast")),
+            "oast_zone": state.settings.oast_zone,
+            "listeners": [
+                {
+                    "id": x.get("id"),
+                    "name": x.get("name"),
+                    "kind": x.get("kind"),
+                    "port": x.get("port"),
+                    "status": x.get("status"),
+                }
+                for x in listeners
+            ],
+        }
+
+    def _oast():
+        if state.oast is None:
+            raise RuntimeError("OAST not available")
+        return state.oast
+
+    async def oast_mint(args: dict[str, Any]) -> Any:
+        return await _oast().create_token(note=str(args.get("note") or ""), created_by=auth.name)
+
+    async def oast_list_tokens(args: dict[str, Any]) -> Any:
+        return await _oast().list_tokens(limit=int(args.get("limit") or 100))
+
+    async def oast_get_token(args: dict[str, Any]) -> Any:
+        row = await _oast().get_token(args["token_id"])
+        if not row:
+            raise KeyError("oast token not found")
+        return row
+
+    async def oast_revoke(args: dict[str, Any]) -> Any:
+        ok = await _oast().delete_client(args["token_id"])
+        if not ok:
+            raise KeyError("oast token not found")
+        return {"revoked": True, "token_id": args["token_id"]}
+
+    async def oast_hits(args: dict[str, Any]) -> Any:
+        hits = await _oast().list_hits(
+            token=args.get("token"),
+            protocol=args.get("protocol"),
+            client_id=args.get("client_id"),
+            since=args.get("since"),
+            limit=int(args.get("limit") or 100),
+        )
+        return {"hits": hits, "count": len(hits)}
+
     return {
         "list_sessions": list_sessions,
         "get_session": get_session,
+        "close_session": close_session,
         "list_tasks": list_tasks,
+        "get_task": get_task,
         "create_task": create_task,
         "list_listeners": list_listeners,
         "create_listener": create_listener,
         "start_listener": start_listener,
         "stop_listener": stop_listener,
+        "delete_listener": delete_listener,
         "generate_payload": generate_payload,
+        "list_payload_templates": list_payload_templates,
         "get_metrics": get_metrics,
         "list_audit": list_audit,
         "interact_shell": interact_shell,
+        "whoami": whoami,
+        "get_platform_status": get_platform_status,
+        "oast_mint": oast_mint,
+        "oast_list_tokens": oast_list_tokens,
+        "oast_get_token": oast_get_token,
+        "oast_revoke": oast_revoke,
+        "oast_hits": oast_hits,
     }

--- a/src/squidc5/mcp/server.py
+++ b/src/squidc5/mcp/server.py
@@ -96,6 +96,17 @@ _TOOL_GATES: dict[str, tuple[list[str], str]] = {
     "get_metrics": (["metrics:read", "admin"], "metrics.read"),
     "list_audit": (["audit:read", "admin"], "audit.read"),
     "interact_shell": (["shell:interact", "admin"], "shell.interact"),
+    "close_session": (["sessions:write", "admin"], "sessions.close"),
+    "get_task": (["tasks:read", "admin"], "tasks.list"),
+    "delete_listener": (["listeners:write", "admin"], "listeners.delete"),
+    "list_payload_templates": (["payloads:generate", "admin"], "payloads.list"),
+    "whoami": (["mcp:connect", "admin"], "mcp.whoami"),
+    "get_platform_status": (["metrics:read", "admin"], "metrics.read"),
+    "oast_mint": (["oast:write", "admin"], "oast.token.create"),
+    "oast_list_tokens": (["oast:read", "admin"], "oast.tokens.list"),
+    "oast_get_token": (["oast:read", "admin"], "oast.tokens.get"),
+    "oast_revoke": (["oast:write", "admin"], "oast.token.delete"),
+    "oast_hits": (["oast:read", "admin"], "oast.hits.list"),
 }
 
 

--- a/tests/test_mcp_and_ai.py
+++ b/tests/test_mcp_and_ai.py
@@ -59,3 +59,102 @@ async def test_admin_ai_bad_capability(client, admin_headers):
         json={"capability": "delete_everything", "user_data": ""},
     )
     assert r.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_mcp_admin_has_oast_tools(client, admin_headers):
+    tools = await client.get("/mcp/tools", headers=admin_headers)
+    assert tools.status_code == 200
+    names = {t["name"] for t in tools.json()["tools"]}
+    for required in (
+        "oast_mint",
+        "oast_list_tokens",
+        "oast_get_token",
+        "oast_revoke",
+        "oast_hits",
+        "get_platform_status",
+        "get_task",
+        "close_session",
+        "delete_listener",
+        "whoami",
+    ):
+        assert required in names
+
+
+@pytest.mark.asyncio
+async def test_mcp_oast_mint_hits_revoke(client, admin_headers):
+    minted = await client.post(
+        "/mcp/call",
+        headers=admin_headers,
+        json={"name": "oast_mint", "arguments": {"note": "inko-canary"}},
+    )
+    assert minted.status_code == 200
+    body = minted.json()
+    assert body["ok"] is True
+    token = body["result"]["token"]
+    assert token
+    assert body["result"]["http_url"]
+    assert body["result"]["http_url_path"]
+    cid = body["result"]["id"]
+
+    listed = await client.post(
+        "/mcp/call",
+        headers=admin_headers,
+        json={"name": "oast_list_tokens", "arguments": {}},
+    )
+    assert listed.json()["ok"] is True
+    ids = {t["id"] for t in listed.json()["result"]}
+    assert cid in ids
+
+    got = await client.post(
+        "/mcp/call",
+        headers=admin_headers,
+        json={"name": "oast_get_token", "arguments": {"token_id": cid}},
+    )
+    assert got.json()["ok"] is True
+    assert got.json()["result"]["token"] == token
+
+    hits = await client.post(
+        "/mcp/call",
+        headers=admin_headers,
+        json={"name": "oast_hits", "arguments": {"token": token}},
+    )
+    assert hits.json()["ok"] is True
+    assert hits.json()["result"]["count"] == 0
+    assert hits.json()["result"]["hits"] == []
+
+    revoked = await client.post(
+        "/mcp/call",
+        headers=admin_headers,
+        json={"name": "oast_revoke", "arguments": {"token_id": cid}},
+    )
+    assert revoked.json()["ok"] is True
+    assert revoked.json()["result"]["revoked"] is True
+
+    missing = await client.post(
+        "/mcp/call",
+        headers=admin_headers,
+        json={"name": "oast_get_token", "arguments": {"token_id": cid}},
+    )
+    assert missing.json()["ok"] is False
+
+
+@pytest.mark.asyncio
+async def test_mcp_oast_tools_not_in_default_allowlist(client, admin_headers):
+    r = await client.post(
+        "/api/v1/tokens",
+        headers=admin_headers,
+        json={
+            "name": "ai-limited",
+            "scopes": ["mcp:connect"],
+            "mcp_tools": ["list_sessions"],
+        },
+    )
+    h = {"Authorization": f"Bearer {r.json()['token']}"}
+    denied = await client.post(
+        "/mcp/call",
+        headers=h,
+        json={"name": "oast_mint", "arguments": {"note": "nope"}},
+    )
+    assert denied.json()["ok"] is False
+    assert "allow-listed" in denied.json()["error"]


### PR DESCRIPTION
## Summary
- Expand MCP catalog so admin/INKO can mint, list, get, revoke OAST tokens and poll hits (count + details).
- Add operator-parity tools: whoami, get_platform_status, get_task, close_session, delete_listener, list_payload_templates.
- Restricted MCP tokens still require an explicit allow-list. CLI: `sc5 oast token delete|revoke`.

## Test plan
- [x] local pytest MCP/OAST
- [ ] CI green
- After merge: INKO `oast_mint` returns token + URLs