### PR TITLE
feat(ops): OAST console plus INKO mint/hits/revoke

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,6 +163,7 @@ sc5 listeners start|stop|delete <id>
 
 sc5 --insecure ... # skip TLS verify (self-signed teamserver)
 sc5 oast token create [--note "..."]
+# Ops UI: OAST page — mint, list (hit counts), poll details, revoke
 sc5 oast token delete|revoke <token_id>
 sc5 oast tokens list
 sc5 oast hits --token T [--protocol dns|http|smtp]

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -767,9 +767,9 @@ Confirm SSRF, blind XSS, and other OOB callbacks during authorized tests without
 ### How
 
 1. Deploy DNS/HTTP/(SMTP) listeners and zone per [Deployment - OAST](deployment.md#oast-collaborator-dns-http-smtp).
-2. Mint a token: `sc5 oast token create --note "..."`.
+2. Ops **OAST** page: Mint tab (or `sc5 oast token create --note "..."` / INKO `oast_mint`).
 3. Use returned `dns_name` / `http_url` / `smtp_to` in the test payload.
-4. Poll hits: `sc5 oast hits --token T [--protocol dns|http|smtp]`.
+4. Tokens tab shows hit counts; Hits tab polls details (or `sc5 oast hits --token T`). Revoke from Hits / `sc5 oast token revoke`.
 
 ### Example
 

--- a/src/squidc5/ai/ops_tools.py
+++ b/src/squidc5/ai/ops_tools.py
@@ -39,6 +39,11 @@ TOOL_GATES: dict[str, tuple[list[str], str]] = {
     "list_audit": (["audit:read", "admin"], "audit.read"),
     "get_platform_status": (["metrics:read", "ai:use", "admin"], "metrics.read"),
     "interact_shell": (["shell:interact", "admin"], "shell.interact"),
+    "oast_mint": (["oast:write", "admin"], "oast.token.create"),
+    "oast_list_tokens": (["oast:read", "admin"], "oast.tokens.list"),
+    "oast_get_token": (["oast:read", "admin"], "oast.tokens.get"),
+    "oast_revoke": (["oast:write", "admin"], "oast.token.delete"),
+    "oast_hits": (["oast:read", "admin"], "oast.hits.list"),
 }
 
 # OpenAI-compatible tool schemas for chat/completions
@@ -369,6 +374,68 @@ OPENAI_TOOLS: list[dict[str, Any]] = [
             },
         },
     },
+    {
+        "type": "function",
+        "function": {
+            "name": "oast_mint",
+            "description": "Mint an OAST correlation token and return token + callback URLs (HTTP/DNS/SMTP).",
+            "parameters": {
+                "type": "object",
+                "properties": {"note": {"type": "string", "description": "Operator label"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "oast_list_tokens",
+            "description": "List minted OAST tokens with hit_count and callback URLs.",
+            "parameters": {
+                "type": "object",
+                "properties": {"limit": {"type": "integer"}},
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "oast_get_token",
+            "description": "Get one OAST token by id (oast_...) including URLs and hit_count.",
+            "parameters": {
+                "type": "object",
+                "properties": {"token_id": {"type": "string"}},
+                "required": ["token_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "oast_revoke",
+            "description": "Revoke/delete an OAST token and its stored hits.",
+            "parameters": {
+                "type": "object",
+                "properties": {"token_id": {"type": "string"}},
+                "required": ["token_id"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "oast_hits",
+            "description": "Poll OAST hits (count + details). Filter by token, client_id, or protocol.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "token": {"type": "string"},
+                    "client_id": {"type": "string"},
+                    "protocol": {"type": "string", "enum": ["http", "dns", "smtp"]},
+                    "limit": {"type": "integer"},
+                },
+            },
+        },
+    },
 ]
 
 CHAT_SYSTEM_PROMPT = """You are INKO (Intelligent Neural Kinetic Operator) - SquidC5's neural operator assistant for this C5 teamserver.
@@ -442,7 +509,7 @@ On reverse_shell capture the server classifies noise, probes OS, injects stage-2
 Mute/echo-only sessions are reaped.
 
 ## Ops UI map (for operator guidance)
-Sessions, Listeners, Payloads, Profiles, Artifacts, Shell/Tasks, Pivot/Files, Collab, Observability,
+Sessions, Listeners, OAST, Payloads, Profiles, Artifacts, Shell/Tasks, Pivot/Files, Collab, Observability,
 Admin (LLM config, tokens, features, TLS cert library), Docs (user guide - not served on C2 /docs).
 
 ## Auth & policy
@@ -465,6 +532,7 @@ If a tool fails on permissions/HITL, say what to approve or which scope is missi
 | Profiles | list_profiles, upsert_profile, activate_profile |
 | Save work | save_asset, list_assets |
 | Health | get_platform_status, get_metrics, list_recent_events, list_audit |
+| OAST | oast_mint, oast_list_tokens, oast_get_token, oast_revoke, oast_hits |
 
 # Formatting for the ops console
 - Prefer short sections with markdown headings
@@ -724,6 +792,39 @@ def _handlers(
             raise RuntimeError("No live reverse shell for session")
         return {"sent": True, "session_id": sid}
 
+    def _oast():
+        if state.oast is None:
+            raise RuntimeError("OAST not available")
+        return state.oast
+
+    async def oast_mint(args: dict[str, Any]) -> Any:
+        return await _oast().create_token(note=str(args.get("note") or ""), created_by=auth.name)
+
+    async def oast_list_tokens(args: dict[str, Any]) -> Any:
+        rows = await _oast().list_tokens(limit=int(args.get("limit") or 100))
+        return {"count": len(rows), "tokens": rows}
+
+    async def oast_get_token(args: dict[str, Any]) -> Any:
+        row = await _oast().get_token(args["token_id"])
+        if not row:
+            raise KeyError("oast token not found")
+        return row
+
+    async def oast_revoke(args: dict[str, Any]) -> Any:
+        ok = await _oast().delete_client(args["token_id"])
+        if not ok:
+            raise KeyError("oast token not found")
+        return {"revoked": True, "token_id": args["token_id"]}
+
+    async def oast_hits(args: dict[str, Any]) -> Any:
+        hits = await _oast().list_hits(
+            token=args.get("token"),
+            protocol=args.get("protocol"),
+            client_id=args.get("client_id"),
+            limit=int(args.get("limit") or 100),
+        )
+        return {"hits": hits, "count": len(hits)}
+
     async def register_payload_template(args: dict[str, Any]) -> Any:
         name = str(args.get("name") or "").strip().replace(" ", "_")
         content = str(args.get("content") or "")
@@ -822,6 +923,11 @@ def _handlers(
         "list_audit": list_audit,
         "get_platform_status": get_platform_status,
         "interact_shell": interact_shell,
+        "oast_mint": oast_mint,
+        "oast_list_tokens": oast_list_tokens,
+        "oast_get_token": oast_get_token,
+        "oast_revoke": oast_revoke,
+        "oast_hits": oast_hits,
     }
 
 
@@ -916,6 +1022,9 @@ _RE_CREATE_LISTENER = re.compile(
 _RE_LIST_SESSIONS = re.compile(r"(?i)\b(list|show|what)\b.*\b(sessions?|shells?|beacons?)\b")
 _RE_LIST_LISTENERS = re.compile(r"(?i)\b(list|show|what)\b.*\blisteners?\b")
 _RE_METRICS = re.compile(r"(?i)\b(metrics|status|health)\b")
+_RE_OAST_MINT = re.compile(r"(?i)\b(mint|create|issue|give)\b.*\b(oast|canary|oob)\b")
+_RE_OAST_HITS = re.compile(r"(?i)\b(oast|oob)\b.*\b(hits?|poll)\b|\b(hits?|poll)\b.*\b(oast|oob)\b")
+_RE_OAST_LIST = re.compile(r"(?i)\b(list|show)\b.*\boast\b")
 _RE_EVENTS = re.compile(r"(?i)\b(events?|event\s*stream)\b")
 
 
@@ -972,6 +1081,27 @@ async def offline_chat_intent(
         return {
             "mode": "offline",
             "reply": _offline_reply_for_tool(r, "Metrics"),
+            "tool_trace": [r],
+        }
+    if _RE_OAST_MINT.search(msg):
+        r = await execute_ops_tool(state, auth, "oast_mint", {"note": "inko"})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "OAST token"),
+            "tool_trace": [r],
+        }
+    if _RE_OAST_HITS.search(msg):
+        r = await execute_ops_tool(state, auth, "oast_hits", {"limit": 50})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "OAST hits"),
+            "tool_trace": [r],
+        }
+    if _RE_OAST_LIST.search(msg):
+        r = await execute_ops_tool(state, auth, "oast_list_tokens", {})
+        return {
+            "mode": "offline",
+            "reply": _offline_reply_for_tool(r, "OAST tokens"),
             "tool_trace": [r],
         }
     return None

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -994,6 +994,18 @@ class Database:
             (limit,),
         )
 
+    async def count_oast_hits_by_client(self) -> dict[str, int]:
+        rows = await self.fetchall(
+            "SELECT client_id, COUNT(*) AS n FROM oast_interactions "
+            "WHERE client_id IS NOT NULL GROUP BY client_id"
+        )
+        out: dict[str, int] = {}
+        for r in rows:
+            cid = r.get("client_id")
+            if cid:
+                out[str(cid)] = int(r.get("n") or 0)
+        return out
+
     async def delete_oast_client(self, client_id: str) -> bool:
         await self.execute("DELETE FROM oast_interactions WHERE client_id = ?", (client_id,))
         cur = await self.execute("DELETE FROM oast_clients WHERE id = ?", (client_id,))

--- a/src/squidc5/oast/store.py
+++ b/src/squidc5/oast/store.py
@@ -161,7 +161,13 @@ class OastService:
         )
 
     def format_token_response(
-        self, client_id: str, token: str, *, note: str = ""
+        self,
+        client_id: str,
+        token: str,
+        *,
+        note: str = "",
+        hit_count: int = 0,
+        created_by: str | None = None,
     ) -> dict[str, Any]:
         zone = self.zone
         host = self.public_host or zone
@@ -187,15 +193,27 @@ class OastService:
             },
             "zone": zone,
             "public_ip": self.public_ip,
+            "hit_count": int(hit_count),
+            "created_by": created_by,
         }
 
     async def list_tokens(self, limit: int = 100) -> list[dict[str, Any]]:
         rows = await self.db.list_oast_clients(limit=limit)
+        counts = await self.db.count_oast_hits_by_client()
         out = []
         for r in rows:
             n = self._norm_client(r)
             note = str((n.get("meta") or {}).get("note") or n.get("label") or "")
-            out.append(self.format_token_response(n["id"], n["token"], note=note))
+            cid = str(n["id"])
+            out.append(
+                self.format_token_response(
+                    cid,
+                    n["token"],
+                    note=note,
+                    hit_count=counts.get(cid, 0),
+                    created_by=n.get("created_by"),
+                )
+            )
         return out
 
     async def get_token(self, token_id: str) -> dict[str, Any] | None:
@@ -204,7 +222,15 @@ class OastService:
             return None
         n = self._norm_client(row)
         note = str((n.get("meta") or {}).get("note") or n.get("label") or "")
-        return self.format_token_response(n["id"], n["token"], note=note)
+        counts = await self.db.count_oast_hits_by_client()
+        cid = str(n["id"])
+        return self.format_token_response(
+            cid,
+            n["token"],
+            note=note,
+            hit_count=counts.get(cid, 0),
+            created_by=n.get("created_by"),
+        )
 
     async def list_clients(self, limit: int = 100) -> list[dict[str, Any]]:
         return await self.list_tokens(limit=limit)

--- a/tests/test_ai_chat.py
+++ b/tests/test_ai_chat.py
@@ -67,6 +67,24 @@ async def test_ai_chat_offline_list_sessions(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_ai_chat_offline_oast_mint(tmp_path):
+    app = create_app(_settings(tmp_path))
+    async with app.router.lifespan_context(app):
+        transport = ASGITransport(app=app)
+        async with AsyncClient(transport=transport, base_url="http://test") as client:
+            h = {"Authorization": f"Bearer {ADMIN}"}
+            r = await client.post(
+                "/api/v1/ai/chat",
+                headers=h,
+                json={"message": "mint an oast token"},
+            )
+            assert r.status_code == 200
+            body = r.json()
+            assert body["mode"] == "offline"
+            assert any(t.get("tool") == "oast_mint" and t.get("ok") for t in body.get("tool_trace") or [])
+
+
+@pytest.mark.asyncio
 async def test_ai_tools_catalog(tmp_path):
     app = create_app(_settings(tmp_path))
     async with app.router.lifespan_context(app):
@@ -78,6 +96,8 @@ async def test_ai_tools_catalog(tmp_path):
             names = {t["name"] for t in r.json()["tools"]}
             assert "create_listener" in names
             assert "list_sessions" in names
+            assert "oast_mint" in names
+            assert "oast_hits" in names
             assert "generate_payload" in names
 
 

--- a/tests/test_oast.py
+++ b/tests/test_oast.py
@@ -47,9 +47,11 @@ async def test_oast_token_api_shape(client, admin_headers):
     assert body["token"] in body["dns_name"]
     assert body["token"] in body["http_url"]
     assert body["smtp_to"].startswith(body["token"] + "@")
+    assert body.get("hit_count") == 0
     lst = await client.get("/api/v1/oast/tokens", headers=admin_headers)
     assert lst.status_code == 200
-    assert any(x["id"] == body["id"] for x in lst.json())
+    row = next(x for x in lst.json() if x["id"] == body["id"])
+    assert row["hit_count"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/test_ops_page_tabs.py
+++ b/tests/test_ops_page_tabs.py
@@ -53,6 +53,7 @@ async def test_all_views_use_page_tabs(tmp_path):
                 "profilesTabs",
                 "artifactsTabs",
                 "assetsTabs",
+                "oastTabs",
             ):
                 assert tid in js, f"missing tabs shell {tid}"
 

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -161,6 +161,10 @@
       { a: "oast-collaborator", t: "OAST" },
       { a: "payloads-and-implants", t: "Payloads" },
     ],
+    oast: [
+      { a: "oast-collaborator", t: "OAST" },
+      { a: "listeners", t: "Listeners" },
+    ],
     payloads: [
       { a: "payloads-and-implants", t: "Payloads & implants" },
       { a: "c2-profiles-profiles", t: "C2 profiles" },
@@ -1234,6 +1238,149 @@
       if (el("lisIdHint")) el("lisIdHint").textContent = "Select a listener to load fields";
       document.querySelectorAll("#lisTbody tr").forEach((x) => x.classList.remove("selected"));
     };
+  }
+
+  let selectedOastId = null;
+
+  function renderOastView(force) {
+    const root = el("view-oast");
+    if (!root) return;
+    if (!force && viewBuilt.oast && root.querySelector(".page-tabs")) {
+      if (el("oastTbody")) loadOastTokens();
+      return;
+    }
+    rememberAllPageTabs(root);
+    root.innerHTML = tabbedHtml([
+      { id: "oasttok", label: "Tokens", html: `
+        <div class="row" style="margin-bottom:8px">
+          <button type="button" class="primary" id="oastRefresh">Refresh</button>
+        </div>
+        <div style="flex:1;min-height:0;overflow:auto">
+          <table class="data"><thead><tr>
+            <th>Note</th><th>Token</th><th>Hits</th><th>HTTP</th>
+          </tr></thead><tbody id="oastTbody"></tbody></table>
+        </div>
+      `},
+      { id: "oastmint", label: "Mint", html: `
+        ${can("oast:write") ? `
+          <div class="form-grid">
+            <div class="full"><label>Note</label><input id="oastNote" placeholder="sqli-oob / xss-canary" /></div>
+          </div>
+          <div class="row">
+            <button type="button" class="primary" id="oastMintBtn">Mint token</button>
+            <button type="button" id="oastCopyUrls">Copy URLs</button>
+          </div>
+        ` : '<p class="muted">Need oast:write to mint</p>'}
+        <div class="outbox empty" id="oastMintOut" style="flex:1;max-height:none">-</div>
+      `},
+      { id: "oasthits", label: "Hits", html: `
+        <div class="form-grid">
+          <div><label>Token</label><input id="oastHitToken" placeholder="hex token" /></div>
+          <div><label>Protocol</label>
+            <select id="oastHitProto">
+              <option value="">all</option>
+              <option value="http">http</option>
+              <option value="dns">dns</option>
+              <option value="smtp">smtp</option>
+            </select>
+          </div>
+        </div>
+        <div class="row">
+          <button type="button" class="primary" id="oastPoll">Poll hits</button>
+          ${can("oast:write") ? '<button type="button" class="danger" id="oastRevoke">Revoke selected</button>' : ""}
+        </div>
+        <p class="muted mono" id="oastHitCount" style="font-size:0.72rem;margin:6px 0 0">count: -</p>
+        <div class="outbox empty" id="oastHitOut" style="flex:1;max-height:none">-</div>
+      `},
+    ], { id: "oastTabs" });
+    viewBuilt.oast = true;
+    bindPageTabs(root);
+    loadOastTokens();
+    if (el("oastRefresh")) el("oastRefresh").onclick = () => loadOastTokens();
+    if (el("oastMintBtn")) el("oastMintBtn").onclick = async () => {
+      try {
+        const note = (el("oastNote") && el("oastNote").value) || "";
+        const r = await api("POST", "/api/v1/oast/tokens", { note });
+        selectedOastId = r.id;
+        if (el("oastMintOut")) {
+          el("oastMintOut").textContent = JSON.stringify(r, null, 2);
+          el("oastMintOut").classList.remove("empty");
+        }
+        if (el("oastHitToken")) el("oastHitToken").value = r.token || "";
+        showOk("OAST token minted");
+        await loadOastTokens();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("oastCopyUrls")) el("oastCopyUrls").onclick = () => {
+      const t = el("oastMintOut") && el("oastMintOut").textContent;
+      if (!t || t === "-") return showError("Mint a token first");
+      try {
+        const o = JSON.parse(t);
+        const blob = [o.token, o.http_url, o.http_url_path, o.dns_name, o.smtp_to].filter(Boolean).join("\n");
+        navigator.clipboard.writeText(blob).then(() => showOk("Copied")).catch(() => showError("Copy failed"));
+      } catch (_) { showError("No mint result"); }
+    };
+    if (el("oastPoll")) el("oastPoll").onclick = () => pollOastHits();
+    if (el("oastRevoke")) el("oastRevoke").onclick = async () => {
+      if (!selectedOastId) return showError("Select a token on Tokens tab");
+      try {
+        await api("DELETE", "/api/v1/oast/tokens/" + encodeURIComponent(selectedOastId));
+        selectedOastId = null;
+        showOk("Revoked");
+        if (el("oastHitOut")) { el("oastHitOut").textContent = "-"; el("oastHitOut").classList.add("empty"); }
+        await loadOastTokens();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+  }
+
+  async function loadOastTokens() {
+    const tb = el("oastTbody");
+    if (!tb) return;
+    try {
+      const rows = await api("GET", "/api/v1/oast/tokens?limit=200");
+      const list = Array.isArray(rows) ? rows : [];
+      if (!list.length) {
+        tb.innerHTML = '<tr><td colspan="4" class="muted">No OAST tokens</td></tr>';
+        return;
+      }
+      tb.innerHTML = list.map((r) => {
+        const sel = r.id === selectedOastId ? " selected" : "";
+        return `<tr data-oid="${esc(r.id)}" data-tok="${esc(r.token)}" class="${sel}">
+          <td>${esc(r.note || "")}</td>
+          <td class="mono">${esc(r.token || "")}</td>
+          <td>${esc(String(r.hit_count != null ? r.hit_count : 0))}</td>
+          <td class="mono" style="font-size:0.68rem">${esc(r.http_url_path || r.http_url || "")}</td>
+        </tr>`;
+      }).join("");
+      tb.querySelectorAll("tr[data-oid]").forEach((tr) => {
+        tr.onclick = () => {
+          selectedOastId = tr.getAttribute("data-oid");
+          const tok = tr.getAttribute("data-tok") || "";
+          tb.querySelectorAll("tr").forEach((x) => x.classList.toggle("selected", x === tr));
+          if (el("oastHitToken")) el("oastHitToken").value = tok;
+          pollOastHits();
+        };
+      });
+    } catch (e) {
+      tb.innerHTML = `<tr><td colspan="4" class="muted">${esc(String(e.message || e))}</td></tr>`;
+    }
+  }
+
+  async function pollOastHits() {
+    const tok = el("oastHitToken") && el("oastHitToken").value.trim();
+    const proto = el("oastHitProto") && el("oastHitProto").value;
+    const q = new URLSearchParams();
+    if (tok) q.set("token", tok);
+    if (proto) q.set("protocol", proto);
+    q.set("limit", "200");
+    try {
+      const r = await api("GET", "/api/v1/oast/hits?" + q.toString());
+      if (el("oastHitCount")) el("oastHitCount").textContent = "count: " + (r.count != null ? r.count : (r.hits || []).length);
+      if (el("oastHitOut")) {
+        el("oastHitOut").textContent = JSON.stringify(r, null, 2);
+        el("oastHitOut").classList.remove("empty");
+      }
+    } catch (e) { showError(String(e.message || e)); }
   }
 
   /* -- Payloads -- */
@@ -3493,6 +3640,7 @@
       case "sessions": renderSessionsView(false); break;
       case "hosts": renderHostsView(false); break;
       case "listeners": renderListenersView(false); break;
+      case "oast": renderOastView(false); break;
       case "payloads": renderPayloadsView(false); break;
       case "profiles": renderProfilesView(false); break;
       case "artifacts": renderArtifactsView(false); break;
@@ -3530,6 +3678,7 @@
     }
     if (currentIs("hosts") && !typing) renderHostsView(false);
     if (currentIs("listeners")) renderListenersView(false);
+    if (currentIs("oast") && !typing) renderOastView(false);
     if (currentIs("payloads") && !typing) renderPayloadsView(false);
     if (currentIs("profiles") && !typing) renderProfilesView(false);
     if (currentIs("artifacts") && !typing) renderArtifactsView(false);

--- a/web/phone-dashboard.html
+++ b/web/phone-dashboard.html
@@ -1428,6 +1428,7 @@
         <button type="button" class="nav-item" data-view="sessions">Sessions <span class="badge-n" id="navNSes">0</span></button>
         <button type="button" class="nav-item" data-view="hosts">Assets</button>
         <button type="button" class="nav-item" data-view="listeners">Listeners <span class="badge-n" id="navNLis">0</span></button>
+        <button type="button" class="nav-item" data-view="oast">OAST</button>
         <button type="button" class="nav-item" data-view="payloads">Payloads</button>
         <button type="button" class="nav-item" data-view="profiles">Profiles</button>
         <button type="button" class="nav-item" data-view="artifacts">Artifacts</button>
@@ -1482,6 +1483,7 @@
         <div class="view" id="view-sessions"></div>
         <div class="view" id="view-hosts"></div>
         <div class="view" id="view-listeners"></div>
+        <div class="view" id="view-oast"></div>
         <div class="view" id="view-payloads"></div>
         <div class="view" id="view-profiles"></div>
         <div class="view" id="view-artifacts"></div>
@@ -1781,6 +1783,7 @@
     sessions: ["sessions:read"],
     hosts: ["sessions:read"],
     listeners: ["listeners:read"],
+    oast: ["oast:read"],
     payloads: ["payloads:generate"],
     profiles: ["profiles:read"],
     artifacts: ["payloads:generate", "profiles:read"],
@@ -1807,7 +1810,7 @@
     const need = NAV_GATES[preferred];
     if (!need || canAny(need)) return preferred;
     const order = [
-      "sessions", "hosts", "listeners", "payloads", "profiles", "artifacts",
+      "sessions", "hosts", "listeners", "oast", "payloads", "profiles", "artifacts",
       "postex", "collab", "ai", "observe", "admin",
     ];
     for (const v of order) {
@@ -1845,6 +1848,7 @@
     sessions: { title: "Sessions", sub: "Beacons and reverse shells", doc: "sessions" },
     hosts: { title: "Assets", sub: "Host graph - implants, access, system info", doc: "sessions" },
     listeners: { title: "Listeners", sub: "Bind ports and manage acceptors", doc: "listeners" },
+    oast: { title: "OAST", sub: "Mint tokens, revoke, poll hits", doc: "oast-collaborator" },
     payloads: { title: "Payloads", sub: "Generate implants and templates", doc: "payloads-and-implants" },
     profiles: { title: "Profiles", sub: "Malleable C2 profiles - activate, edit, push", doc: "c2-profiles" },
     artifacts: { title: "Artifacts", sub: "Saved payloads, templates, profiles, implants", doc: "payloads-and-implants" },


### PR DESCRIPTION
## Summary
- Ops **OAST** page: mint, list tokens with hit counts, poll hit details, revoke.
- INKO tools: `oast_mint`, `oast_list_tokens`, `oast_get_token`, `oast_revoke`, `oast_hits` (offline mint/list/hits).
- Token list/get include `hit_count`.

## Test plan
- [x] pytest oast / ai chat / ops tabs
- [ ] CI + SquidGate green
- After deploy: Ops → OAST mint returns token+URLs; INKO can mint