### PR TITLE
fix(oast): working HTTP callback URLs and Host-token hits

### DIFF
--- a/src/squidc5/listeners/http_listener.py
+++ b/src/squidc5/listeners/http_listener.py
@@ -39,7 +39,26 @@ async def handle_http_client(
         path_only = path.split("?", 1)[0]
 
         if method == "GET" and path_only in ("/", "/health", "/api/v1/health"):
-            # L07: minimal fingerprint
+            host = str(headers.get("host") or "")
+            zone = str(getattr(manager, "oast_zone", "") or "")
+            from squidc5.oast.store import extract_token_from_host
+
+            if extract_token_from_host(host, zone=zone):
+                hit = {
+                    "listener_id": listener_id,
+                    "remote": remote,
+                    "method": method,
+                    "path": path,
+                    "query": query,
+                    "headers": {
+                        k: v
+                        for k, v in headers.items()
+                        if k.lower() not in ("authorization", "cookie")
+                    },
+                    "body_preview": "",
+                    "ts": time.time(),
+                }
+                await manager.record_http_hit(listener_id, hit)
             await _respond(writer, 200, {"status": "ok"})
             return
 

--- a/src/squidc5/mcp/server.py
+++ b/src/squidc5/mcp/server.py
@@ -539,7 +539,7 @@ def _handlers(state: AppState, auth: AuthContext) -> dict[str, Callable[[dict[st
                 meta = {}
         if isinstance(meta, dict):
             note = str(meta.get("note") or raw.get("label") or "")
-        return _oast().format_token_response(str(raw["id"]), str(raw["token"]), note=note)
+        return await _oast().format_token_response(str(raw["id"]), str(raw["token"]), note=note)
 
     async def oast_mint(args: dict[str, Any]) -> Any:
         return await _oast().create_token(note=str(args.get("note") or ""), created_by=auth.name)

--- a/src/squidc5/oast/store.py
+++ b/src/squidc5/oast/store.py
@@ -149,7 +149,7 @@ class OastService:
         )
         if self.metrics:
             await self.metrics.emit("oast.token.created", {"id": cid, "token": token})
-        return self.format_token_response(cid, token, note=note)
+        return await self.format_token_response(cid, token, note=note, created_by=created_by)
 
     # aliases used by older routes
     async def create_client(self, **kwargs: Any) -> dict[str, Any]:
@@ -160,7 +160,29 @@ class OastService:
             meta=kwargs.get("meta"),
         )
 
-    def format_token_response(
+    async def _http_catcher(self) -> tuple[str, int, str]:
+        host = self.public_host or self.zone
+        port = int(self.http_port or 80)
+        scheme = self.scheme or "http"
+        try:
+            rows = await self.db.list_listeners()
+        except Exception:
+            return host, port, scheme
+        running = [
+            r
+            for r in rows
+            if str(r.get("kind") or "") in ("http", "https")
+            and str(r.get("status") or "") == "running"
+        ]
+        if not running:
+            return host, port, scheme
+        pick = next((r for r in running if int(r.get("port") or 0) == port), running[0])
+        port = int(pick.get("port") or port)
+        if str(pick.get("kind")) == "https":
+            scheme = "https"
+        return host, port, scheme
+
+    async def format_token_response(
         self,
         client_id: str,
         token: str,
@@ -170,12 +192,21 @@ class OastService:
         created_by: str | None = None,
     ) -> dict[str, Any]:
         zone = self.zone
-        host = self.public_host or zone
-        port_s = f":{self.http_port}" if self.http_port not in (80, 443) else ""
+        host, port, scheme = await self._http_catcher()
+        port_s = f":{port}" if port not in (80, 443) else ""
         dns_name = f"{token}.{zone}"
-        http_url = f"{self.scheme}://{token}.{zone}{port_s}/"
-        http_path = f"{self.scheme}://{host}{port_s}/{token}/"
+        http_url = f"{scheme}://{token}.{zone}{port_s}/"
+        http_path = f"{scheme}://{host}{port_s}/{token}/"
         smtp_to = f"{token}@{zone}"
+        notes: list[str] = []
+        if port not in (80, 443):
+            notes.append(f"HTTP catcher is {scheme}://{host}:{port}/<token>/ — include the port")
+        try:
+            lis = await self.db.list_listeners()
+            if not any(str(r.get("kind")) == "dns" and str(r.get("status")) == "running" for r in lis):
+                notes.append("DNS name will not resolve until a DNS listener is running for this zone")
+        except Exception:
+            pass
         return {
             "id": client_id,
             "token": token,
@@ -193,8 +224,11 @@ class OastService:
             },
             "zone": zone,
             "public_ip": self.public_ip,
+            "http_port": port,
+            "http_scheme": scheme,
             "hit_count": int(hit_count),
             "created_by": created_by,
+            "notes": notes,
         }
 
     async def list_tokens(self, limit: int = 100) -> list[dict[str, Any]]:
@@ -206,7 +240,7 @@ class OastService:
             note = str((n.get("meta") or {}).get("note") or n.get("label") or "")
             cid = str(n["id"])
             out.append(
-                self.format_token_response(
+                await self.format_token_response(
                     cid,
                     n["token"],
                     note=note,
@@ -224,7 +258,7 @@ class OastService:
         note = str((n.get("meta") or {}).get("note") or n.get("label") or "")
         counts = await self.db.count_oast_hits_by_client()
         cid = str(n["id"])
-        return self.format_token_response(
+        return await self.format_token_response(
             cid,
             n["token"],
             note=note,
@@ -244,7 +278,7 @@ class OastService:
             return None
         n = self._norm_client(row)
         note = str((n.get("meta") or {}).get("note") or n.get("label") or "")
-        return self.format_token_response(n["id"], n["token"], note=note)
+        return await self.format_token_response(n["id"], n["token"], note=note)
 
     async def resolve_token(self, token: str | None) -> str | None:
         if not token:
@@ -337,8 +371,16 @@ class OastService:
         return await self.db.delete_oast_client(client_id)
 
     def payload_urls(self, token: str, **kwargs: Any) -> dict[str, str]:
-        r = self.format_token_response("x", token)
-        return r["payloads"]
+        port = int(self.http_port or 80)
+        port_s = f":{port}" if port not in (80, 443) else ""
+        host = self.public_host or self.zone
+        return {
+            "dns": f"{token}.{self.zone}",
+            "http": f"{self.scheme}://{token}.{self.zone}{port_s}/",
+            "http_path": f"{self.scheme}://{host}{port_s}/{token}/",
+            "smtp": f"{token}@{self.zone}",
+            "token": token,
+        }
 
     def _norm_client(self, row: dict[str, Any]) -> dict[str, Any]:
         out = dict(row)

--- a/tests/test_oast.py
+++ b/tests/test_oast.py
@@ -91,6 +91,50 @@ async def test_oast_http_hit(client, admin_headers):
 
 
 @pytest.mark.asyncio
+async def test_oast_urls_include_running_http_port(client, admin_headers):
+    lr = await client.post(
+        "/api/v1/listeners",
+        headers=admin_headers,
+        json={"name": "oast-http-port", "kind": "http", "port": 19051},
+    )
+    lid = lr.json()["id"]
+    await client.post(f"/api/v1/listeners/{lid}/start", headers=admin_headers)
+    r = await client.post("/api/v1/oast/tokens", headers=admin_headers, json={"note": "port"})
+    body = r.json()
+    assert ":19051" in body["http_url_path"]
+    assert body["http_port"] == 19051
+    await client.post(f"/api/v1/listeners/{lid}/stop", headers=admin_headers)
+
+
+@pytest.mark.asyncio
+async def test_oast_root_host_header_records_hit(client, admin_headers):
+    r = await client.post("/api/v1/oast/tokens", headers=admin_headers, json={"note": "root"})
+    token = r.json()["token"]
+    lr = await client.post(
+        "/api/v1/listeners",
+        headers=admin_headers,
+        json={"name": "oast-root", "kind": "http", "port": 19052},
+    )
+    lid = lr.json()["id"]
+    await client.post(f"/api/v1/listeners/{lid}/start", headers=admin_headers)
+    reader, writer = await asyncio.open_connection("127.0.0.1", 19052)
+    writer.write(
+        f"GET / HTTP/1.1\r\nHost: {token}.oast.lab.invalid\r\nConnection: close\r\n\r\n".encode()
+    )
+    await writer.drain()
+    await reader.read(4096)
+    writer.close()
+    try:
+        await writer.wait_closed()
+    except Exception:
+        pass
+    poll = await client.get(f"/api/v1/oast/hits?token={token}", headers=admin_headers)
+    hits = poll.json()["hits"]
+    assert any(h.get("token") == token for h in hits)
+    await client.post(f"/api/v1/listeners/{lid}/stop", headers=admin_headers)
+
+
+@pytest.mark.asyncio
 async def test_dns_oast_subdomain(client, admin_headers):
     r = await client.post("/api/v1/oast/tokens", headers=admin_headers, json={"note": "dns"})
     token = r.json()["token"]

--- a/tests/test_ops_page_tabs.py
+++ b/tests/test_ops_page_tabs.py
@@ -56,6 +56,8 @@ async def test_all_views_use_page_tabs(tmp_path):
                 "oastTabs",
             ):
                 assert tid in js, f"missing tabs shell {tid}"
+            assert "labeledOastUrls" in js
+            assert "oast-copy-one" in js
 
             # INKO has Status & tools tab
             assert "aistatus" in js

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1241,6 +1241,48 @@
   }
 
   let selectedOastId = null;
+  let lastOastMint = null;
+
+  function labeledOastUrls(o) {
+    return [
+      "token: " + (o.token || ""),
+      "http: " + (o.http_url_path || ""),
+      "http_host: " + (o.http_url || ""),
+      "dns: " + (o.dns_name || ""),
+      "smtp: " + (o.smtp_to || ""),
+    ].join("\n");
+  }
+
+  function renderOastMintResult(o) {
+    const cards = el("oastMintCards");
+    if (cards) {
+      const rows = [
+        ["Use this HTTP URL", o.http_url_path],
+        ["Host-header HTTP", o.http_url],
+        ["DNS", o.dns_name],
+        ["SMTP", o.smtp_to],
+        ["Token", o.token],
+      ];
+      const notes = (o.notes || []).map((n) => `<p class="muted" style="margin:4px 0">${esc(n)}</p>`).join("");
+      cards.className = "";
+      cards.innerHTML = notes + rows.map(([lab, val]) => `
+        <div class="row" style="align-items:center;gap:8px;margin:4px 0">
+          <span class="muted" style="min-width:140px">${esc(lab)}</span>
+          <code class="mono" style="flex:1;font-size:0.75rem">${esc(val || "")}</code>
+          <button type="button" class="ghost oast-copy-one" data-copy="${esc(val || "")}">Copy</button>
+        </div>`).join("");
+      cards.querySelectorAll(".oast-copy-one").forEach((b) => {
+        b.onclick = () => {
+          const v = b.getAttribute("data-copy") || "";
+          navigator.clipboard.writeText(v).then(() => showOk("Copied")).catch(() => showError("Copy failed"));
+        };
+      });
+    }
+    if (el("oastMintOut")) {
+      el("oastMintOut").textContent = JSON.stringify(o, null, 2);
+      el("oastMintOut").classList.remove("empty");
+    }
+  }
 
   function renderOastView(force) {
     const root = el("view-oast");
@@ -1268,9 +1310,10 @@
           </div>
           <div class="row">
             <button type="button" class="primary" id="oastMintBtn">Mint token</button>
-            <button type="button" id="oastCopyUrls">Copy URLs</button>
+            <button type="button" id="oastCopyUrls">Copy labeled URLs</button>
           </div>
         ` : '<p class="muted">Need oast:write to mint</p>'}
+        <div id="oastMintCards" class="muted" style="margin-top:8px">Mint to get callback URLs</div>
         <div class="outbox empty" id="oastMintOut" style="flex:1;max-height:none">-</div>
       `},
       { id: "oasthits", label: "Hits", html: `
@@ -1302,23 +1345,17 @@
         const note = (el("oastNote") && el("oastNote").value) || "";
         const r = await api("POST", "/api/v1/oast/tokens", { note });
         selectedOastId = r.id;
-        if (el("oastMintOut")) {
-          el("oastMintOut").textContent = JSON.stringify(r, null, 2);
-          el("oastMintOut").classList.remove("empty");
-        }
+        lastOastMint = r;
+        renderOastMintResult(r);
         if (el("oastHitToken")) el("oastHitToken").value = r.token || "";
         showOk("OAST token minted");
         await loadOastTokens();
       } catch (e) { showError(String(e.message || e)); }
     };
     if (el("oastCopyUrls")) el("oastCopyUrls").onclick = () => {
-      const t = el("oastMintOut") && el("oastMintOut").textContent;
-      if (!t || t === "-") return showError("Mint a token first");
-      try {
-        const o = JSON.parse(t);
-        const blob = [o.token, o.http_url, o.http_url_path, o.dns_name, o.smtp_to].filter(Boolean).join("\n");
-        navigator.clipboard.writeText(blob).then(() => showOk("Copied")).catch(() => showError("Copy failed"));
-      } catch (_) { showError("No mint result"); }
+      if (!lastOastMint) return showError("Mint a token first");
+      const blob = labeledOastUrls(lastOastMint);
+      navigator.clipboard.writeText(blob).then(() => showOk("Copied labeled URLs")).catch(() => showError("Copy failed"));
     };
     if (el("oastPoll")) el("oastPoll").onclick = () => pollOastHits();
     if (el("oastRevoke")) el("oastRevoke").onclick = async () => {


### PR DESCRIPTION
## Summary
- Minted HTTP URLs now include the **running HTTP listener port** (e.g. `:8080`).
- `GET /` with `Host: <token>.zone` records an OAST hit (subdomain canaries).
- Ops copy is labeled (`http:`, `dns:`, …) with per-row Copy.

## Test plan
- [x] pytest oast URL port + root Host hit
- [ ] CI green
- After deploy: mint, curl `http://oast.squidoffense.com:8080/<token>/`, Hits increment