### PR TITLE
feat(ops): edit and delete OAST tokens

### DIFF
--- a/src/squidc5/api/routes.py
+++ b/src/squidc5/api/routes.py
@@ -96,6 +96,11 @@ class OastTokenCreate(BaseModel):
     meta: dict[str, Any] = Field(default_factory=dict)
 
 
+class OastTokenUpdate(BaseModel):
+    note: str | None = None
+    label: str | None = None
+
+
 # backward-compatible alias
 OastClientCreate = OastTokenCreate
 
@@ -3662,6 +3667,20 @@ def build_api_router() -> APIRouter:
             request, auth, token=token, protocol=protocol, client_id=client_id, since=since, limit=limit
         )
         return {"interactions": r["hits"], "count": r["count"]}
+
+    @api.patch("/oast/tokens/{token_id}")
+    async def oast_update_token(
+        token_id: str,
+        body: OastTokenUpdate,
+        request: Request,
+        auth: AuthContext = Depends(require_scope("oast:write", "admin")),
+    ) -> dict[str, Any]:
+        state = await _oast_or_403(request)
+        note = body.note if body.note is not None else body.label
+        row = await state.oast.update_token(token_id, note=note)
+        if not row:
+            raise HTTPException(404, "token not found")
+        return row
 
     @api.delete("/oast/tokens/{token_id}")
     async def oast_delete_token(

--- a/src/squidc5/db/store.py
+++ b/src/squidc5/db/store.py
@@ -1006,6 +1006,35 @@ class Database:
                 out[str(cid)] = int(r.get("n") or 0)
         return out
 
+    async def update_oast_client(
+        self,
+        client_id: str,
+        *,
+        label: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> bool:
+        row = await self.get_oast_client(client_id)
+        if not row:
+            return False
+        new_label = row.get("label") if label is None else label
+        raw_meta = row.get("meta")
+        if isinstance(raw_meta, str):
+            try:
+                cur_meta = json.loads(raw_meta)
+            except Exception:
+                cur_meta = {}
+        elif isinstance(raw_meta, dict):
+            cur_meta = dict(raw_meta)
+        else:
+            cur_meta = {}
+        if meta is not None:
+            cur_meta.update(meta)
+        cur = await self.execute(
+            "UPDATE oast_clients SET label = ?, meta = ? WHERE id = ?",
+            (new_label or "", json.dumps(cur_meta), client_id),
+        )
+        return cur.rowcount > 0
+
     async def delete_oast_client(self, client_id: str) -> bool:
         await self.execute("DELETE FROM oast_interactions WHERE client_id = ?", (client_id,))
         cur = await self.execute("DELETE FROM oast_clients WHERE id = ?", (client_id,))

--- a/src/squidc5/oast/store.py
+++ b/src/squidc5/oast/store.py
@@ -367,6 +367,21 @@ class OastService:
     async def poll(self, **kwargs: Any) -> list[dict[str, Any]]:
         return await self.list_hits(**kwargs)
 
+    async def update_token(self, token_id: str, *, note: str | None = None) -> dict[str, Any] | None:
+        row = await self.db.get_oast_client(token_id)
+        if not row:
+            return None
+        meta: dict[str, Any] | None = None
+        label = None
+        if note is not None:
+            n = str(note)[:200]
+            meta = {"note": n}
+            label = n or str(row.get("token") or "")
+        ok = await self.db.update_oast_client(token_id, label=label, meta=meta)
+        if not ok:
+            return None
+        return await self.get_token(token_id)
+
     async def delete_client(self, client_id: str) -> bool:
         return await self.db.delete_oast_client(client_id)
 

--- a/tests/test_oast.py
+++ b/tests/test_oast.py
@@ -55,6 +55,27 @@ async def test_oast_token_api_shape(client, admin_headers):
 
 
 @pytest.mark.asyncio
+async def test_oast_token_update_and_delete(client, admin_headers):
+    r = await client.post("/api/v1/oast/tokens", headers=admin_headers, json={"note": "old"})
+    assert r.status_code == 200
+    tid = r.json()["id"]
+    secret = r.json()["token"]
+    patched = await client.patch(
+        f"/api/v1/oast/tokens/{tid}",
+        headers=admin_headers,
+        json={"note": "renamed-canary"},
+    )
+    assert patched.status_code == 200
+    assert patched.json()["note"] == "renamed-canary"
+    assert patched.json()["token"] == secret
+    got = await client.get(f"/api/v1/oast/tokens/{tid}", headers=admin_headers)
+    assert got.json()["note"] == "renamed-canary"
+    gone = await client.delete(f"/api/v1/oast/tokens/{tid}", headers=admin_headers)
+    assert gone.status_code == 200
+    assert (await client.get(f"/api/v1/oast/tokens/{tid}", headers=admin_headers)).status_code == 404
+
+
+@pytest.mark.asyncio
 async def test_oast_http_hit(client, admin_headers):
     r = await client.post(
         "/api/v1/oast/tokens",

--- a/tests/test_ops_page_tabs.py
+++ b/tests/test_ops_page_tabs.py
@@ -58,6 +58,9 @@ async def test_all_views_use_page_tabs(tmp_path):
                 assert tid in js, f"missing tabs shell {tid}"
             assert "labeledOastUrls" in js
             assert "oast-copy-one" in js
+            assert "oastSaveNote" in js
+            assert "oastDeleteBtn" in js
+            assert "deleteSelectedOast" in js
 
             # INKO has Status & tools tab
             assert "aistatus" in js

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -1294,8 +1294,15 @@
     rememberAllPageTabs(root);
     root.innerHTML = tabbedHtml([
       { id: "oasttok", label: "Tokens", html: `
+        <div class="form-grid" style="margin-bottom:8px">
+          <div class="full"><label>Selected note</label><input id="oastEditNote" placeholder="Select a token, then edit note" /></div>
+        </div>
         <div class="row" style="margin-bottom:8px">
           <button type="button" class="primary" id="oastRefresh">Refresh</button>
+          ${can("oast:write") ? `
+            <button type="button" id="oastSaveNote">Save note</button>
+            <button type="button" class="danger" id="oastDeleteBtn">Delete</button>
+          ` : ""}
         </div>
         <div style="flex:1;min-height:0;overflow:auto">
           <table class="data"><thead><tr>
@@ -1340,6 +1347,18 @@
     bindPageTabs(root);
     loadOastTokens();
     if (el("oastRefresh")) el("oastRefresh").onclick = () => loadOastTokens();
+    if (el("oastSaveNote")) el("oastSaveNote").onclick = async () => {
+      if (!selectedOastId) return showError("Select a token");
+      try {
+        const note = (el("oastEditNote") && el("oastEditNote").value) || "";
+        const r = await api("PATCH", "/api/v1/oast/tokens/" + encodeURIComponent(selectedOastId), { note });
+        lastOastMint = r;
+        renderOastMintResult(r);
+        showOk("Note saved");
+        await loadOastTokens();
+      } catch (e) { showError(String(e.message || e)); }
+    };
+    if (el("oastDeleteBtn")) el("oastDeleteBtn").onclick = () => deleteSelectedOast();
     if (el("oastMintBtn")) el("oastMintBtn").onclick = async () => {
       try {
         const note = (el("oastNote") && el("oastNote").value) || "";
@@ -1358,16 +1377,7 @@
       navigator.clipboard.writeText(blob).then(() => showOk("Copied labeled URLs")).catch(() => showError("Copy failed"));
     };
     if (el("oastPoll")) el("oastPoll").onclick = () => pollOastHits();
-    if (el("oastRevoke")) el("oastRevoke").onclick = async () => {
-      if (!selectedOastId) return showError("Select a token on Tokens tab");
-      try {
-        await api("DELETE", "/api/v1/oast/tokens/" + encodeURIComponent(selectedOastId));
-        selectedOastId = null;
-        showOk("Revoked");
-        if (el("oastHitOut")) { el("oastHitOut").textContent = "-"; el("oastHitOut").classList.add("empty"); }
-        await loadOastTokens();
-      } catch (e) { showError(String(e.message || e)); }
-    };
+    if (el("oastRevoke")) el("oastRevoke").onclick = () => deleteSelectedOast();
   }
 
   async function loadOastTokens() {
@@ -1382,7 +1392,7 @@
       }
       tb.innerHTML = list.map((r) => {
         const sel = r.id === selectedOastId ? " selected" : "";
-        return `<tr data-oid="${esc(r.id)}" data-tok="${esc(r.token)}" class="${sel}">
+        return `<tr data-oid="${esc(r.id)}" data-tok="${esc(r.token)}" data-note="${esc(r.note || "")}" class="${sel}">
           <td>${esc(r.note || "")}</td>
           <td class="mono">${esc(r.token || "")}</td>
           <td>${esc(String(r.hit_count != null ? r.hit_count : 0))}</td>
@@ -1395,12 +1405,30 @@
           const tok = tr.getAttribute("data-tok") || "";
           tb.querySelectorAll("tr").forEach((x) => x.classList.toggle("selected", x === tr));
           if (el("oastHitToken")) el("oastHitToken").value = tok;
+          if (el("oastEditNote")) el("oastEditNote").value = tr.getAttribute("data-note") || "";
           pollOastHits();
         };
       });
     } catch (e) {
       tb.innerHTML = `<tr><td colspan="4" class="muted">${esc(String(e.message || e))}</td></tr>`;
     }
+  }
+
+  async function deleteSelectedOast() {
+    if (!selectedOastId) return showError("Select a token");
+    const ok = await askConfirm("Delete this OAST token and all its hits?", { danger: true, okLabel: "Delete" });
+    if (!ok) return;
+    try {
+      await api("DELETE", "/api/v1/oast/tokens/" + encodeURIComponent(selectedOastId));
+      selectedOastId = null;
+      lastOastMint = null;
+      if (el("oastEditNote")) el("oastEditNote").value = "";
+      if (el("oastHitToken")) el("oastHitToken").value = "";
+      if (el("oastHitOut")) { el("oastHitOut").textContent = "-"; el("oastHitOut").classList.add("empty"); }
+      if (el("oastMintCards")) { el("oastMintCards").className = "muted"; el("oastMintCards").textContent = "Mint to get callback URLs"; }
+      showOk("Deleted");
+      await loadOastTokens();
+    } catch (e) { showError(String(e.message || e)); }
   }
 
   async function pollOastHits() {


### PR DESCRIPTION
## Summary
- Ops OAST Tokens tab: edit note and delete selected token (confirm).
- `PATCH /api/v1/oast/tokens/{id}` with `{note}`. Correlation hex is immutable.

## Test plan
- [x] pytest update/delete + ops tabs
- [ ] CI green