### PR TITLE
feat(sessions): Kill shell in Ops

### DIFF
--- a/src/squidc5/listeners/manager.py
+++ b/src/squidc5/listeners/manager.py
@@ -825,6 +825,15 @@ class ListenerManager:
     # session ids that passed probe_exec
     # note: initialized in __init__ via attribute set below if missing
 
+    async def kill_channel(self, session_id: str) -> None:
+        """Ask the remote shell to exit, then drop TCP."""
+        try:
+            await self.send_shell(session_id, "exit")
+        except Exception:
+            pass
+        await asyncio.sleep(0.12)
+        await self.drop_channel(session_id)
+
     async def drop_channel(self, session_id: str) -> None:
         """Force-close a live TCP channel (used after failed exec probe)."""
         self._rejected.add(session_id)

--- a/src/squidc5/main.py
+++ b/src/squidc5/main.py
@@ -124,6 +124,7 @@ async def build_state(settings: Settings) -> AppState:
     sessions.verified_check = listeners.is_verified
     sessions.exec_probe = listeners.probe_exec
     sessions.drop_channel = listeners.drop_channel
+    sessions.kill_channel = listeners.kill_channel
     listeners.feature_check = features.enabled
     listeners.profile_engine = profiles
     # After restart, reverse_shell rows can still say active with no socket

--- a/src/squidc5/sessions/manager.py
+++ b/src/squidc5/sessions/manager.py
@@ -25,6 +25,7 @@ class SessionManager:
         self.exec_probe: Callable[[str], Any] | None = None
         # Optional async drop of TCP channel
         self.drop_channel: Callable[[str], Any] | None = None
+        self.kill_channel: Callable[[str], Any] | None = None
 
     async def register(
         self,
@@ -72,11 +73,13 @@ class SessionManager:
         await self.metrics.emit("session.heartbeat", {"id": session_id})
 
     async def close(self, session_id: str, *, drop: bool = True) -> None:
-        if drop and self.drop_channel is not None:
-            try:
-                await self.drop_channel(session_id)
-            except Exception:
-                pass
+        if drop:
+            killer = getattr(self, "kill_channel", None) or self.drop_channel
+            if killer is not None:
+                try:
+                    await killer(session_id)
+                except Exception:
+                    pass
         await self.db.update_session(session_id, status="closed")
         async with self._lock:
             self._live.pop(session_id, None)

--- a/tests/test_ops_page_tabs.py
+++ b/tests/test_ops_page_tabs.py
@@ -61,6 +61,8 @@ async def test_all_views_use_page_tabs(tmp_path):
             assert "oastSaveNote" in js
             assert "oastDeleteBtn" in js
             assert "deleteSelectedOast" in js
+            assert "ctxKill" in js
+            assert "Kill shell" in js
 
             # INKO has Status & tools tab
             assert "aistatus" in js

--- a/web/ops-admin.js
+++ b/web/ops-admin.js
@@ -682,6 +682,17 @@
         renderContext(true);
       } catch (e) { showError(String(e.message || e)); }
     };
+    if (q("#ctxKill")) q("#ctxKill").onclick = async () => {
+      if (!selectedId) return showError("Select a session");
+      if (!(await askConfirm("Kill this shell? Drops TCP and marks the session closed."))) return;
+      const sid = selectedId;
+      try {
+        await api("POST", "/api/v1/sessions/" + encodeURIComponent(sid) + "/close");
+        showOk("Shell killed");
+        selectSession(null);
+        if (window.__SC5_refresh) await window.__SC5_refresh();
+      } catch (e) { showError(String(e.message || e)); }
+    };
     if (q("#ctxRun")) q("#ctxRun").onclick = () => { runShell(); };
     if (q("#ctxCmd")) {
       q("#ctxCmd").onkeydown = (ev) => {
@@ -728,6 +739,7 @@
         <div class="row" style="margin-top:8px">
           <button type="button" class="primary sm" id="ctxRun">Run</button>
           <button type="button" class="primary sm" id="ctxStabilize">Stabilize shell</button>
+          ${can("sessions:write") ? '<button type="button" class="danger sm" id="ctxKill">Kill shell</button>' : ""}
         </div>
         <p class="muted" style="font-size:0.68rem;margin:6px 0 0">Stage-2 inject (Linux/Windows auto-detect). Auto-stabilize is OFF by default.</p>
       </div>` : `
@@ -977,7 +989,7 @@
           <span class="muted" id="sesCount">${rows.length} active</span>
           ${can("sessions:write") ? '<button type="button" class="ghost sm" id="sesReap">Reap dead</button>' : ""}
           <button type="button" class="ghost sm" id="sesRefresh">Refresh</button>
-          ${can("sessions:write") ? '<button type="button" class="danger sm" id="sesClose" style="margin-left:auto">Close</button>' : ""}
+          ${can("sessions:write") ? '<button type="button" class="danger sm" id="sesClose" style="margin-left:auto">Kill shell</button>' : ""}
         </div>
         <div class="ses-list-wrap" style="flex:1;min-height:0;overflow:auto">
           ${rows.length
@@ -1011,16 +1023,17 @@
     };
     if (el("sesClose")) el("sesClose").onclick = async () => {
       if (!selectedId) return showError("Select a session");
+      if (!(await askConfirm("Kill this shell? Drops TCP and marks the session closed."))) return;
       const sid = selectedId;
       try {
         await api("POST", "/api/v1/sessions/" + encodeURIComponent(sid) + "/close");
-        showOk("Closed");
+        showOk("Shell killed");
         selectSession(null);
         if (window.__SC5_refresh) await window.__SC5_refresh();
       } catch (e) {
         try {
           await api("DELETE", "/api/v1/sessions/" + encodeURIComponent(sid));
-          showOk("Closed");
+          showOk("Shell killed");
           selectSession(null);
           if (window.__SC5_refresh) await window.__SC5_refresh();
         } catch (e2) { showError(String(e2.message || e2)); }


### PR DESCRIPTION
## Summary
- **Kill shell** on Sessions list and Session panel (confirm).
- Close sends `exit` then drops TCP so the remote process dies.

## Test plan
- [x] ops tabs + session tests
- [ ] CI