### PR TITLE
feat(ci): Raspberry Pi linux-arm64 release binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [main, master]
 
-# Public repo CI runs on GitHub-hosted runners (ubuntu-latest / windows-latest).
+# Public repo CI runs on GitHub-hosted runners (ubuntu-latest / ubuntu-24.04-arm / windows-latest).
 # Org self-hosted runners disallow public repos (RCE / LAN risk).
 # SECURITY: same-repo PRs only for jobs that could touch secrets / heavy build.
 
@@ -175,6 +175,9 @@ jobs:
           - runner: ubuntu-latest
             artifact: linux-x64
             is_windows: false
+          - runner: ubuntu-24.04-arm
+            artifact: linux-arm64
+            is_windows: false
           - runner: windows-latest
             artifact: windows-x64
             is_windows: true
@@ -277,7 +280,7 @@ jobs:
   # Publish GitHub Release after tests. Builds Linux here (avoids Actions artifact quota).
   release:
     name: github-release
-    needs: [test]
+    needs: [test, binaries]
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
     permissions:
@@ -321,6 +324,13 @@ jobs:
           name: squidc5-windows-x64
           path: artifacts/windows
 
+      - name: Try Linux ARM64 artifacts (Raspberry Pi)
+        continue-on-error: true
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4
+        with:
+          name: squidc5-linux-arm64
+          path: artifacts/linux-arm64
+
       - name: Stage release assets
         shell: bash
         run: |
@@ -335,6 +345,11 @@ jobs:
             cp artifacts/windows/sc5.exe release/sc5-windows-x64.exe
             cp artifacts/windows/squidc5.exe release/squidc5-windows-x64.exe
           fi
+          if [[ -f artifacts/linux-arm64/sc5 && -f artifacts/linux-arm64/squidc5 ]]; then
+            cp artifacts/linux-arm64/sc5 release/sc5-linux-arm64
+            cp artifacts/linux-arm64/squidc5 release/squidc5-linux-arm64
+            chmod +x release/sc5-linux-arm64 release/squidc5-linux-arm64
+          fi
           python -m pip install --quiet cyclonedx-bom
           pip install -q -r requirements.txt
           cyclonedx-py requirements requirements.txt -o release/sbom.cdx.json || \
@@ -346,8 +361,9 @@ jobs:
           cat > release/README.txt << 'EOF'
           SquidC5 standalone binaries (no Python/venv required)
 
-          sc5-linux-x64 / sc5-windows-x64.exe     Operator CLI
-          squidc5-linux-x64 / squidc5-windows-x64.exe   C2 server
+          sc5-linux-x64 / sc5-linux-arm64 / sc5-windows-x64.exe     Operator CLI
+          squidc5-linux-x64 / squidc5-linux-arm64 / squidc5-windows-x64.exe   C2 server
+          linux-arm64: Raspberry Pi OS 64-bit (Pi 3/4/5) and other aarch64 Linux
 
           Server defaults: 0.0.0.0:8443  data in ./data/
           Ops console: https://HOST:8443/ops (self-signed TLS by default)
@@ -383,6 +399,8 @@ jobs:
             |------|----------|------|
             | `sc5-linux-x64` | Linux x64 | Operator CLI |
             | `squidc5-linux-x64` | Linux x64 | C2 server |
+            | `sc5-linux-arm64` | Linux ARM64 / Raspberry Pi 64-bit | Operator CLI (when available) |
+            | `squidc5-linux-arm64` | Linux ARM64 / Raspberry Pi 64-bit | C2 server (when available) |
             | `sc5-windows-x64.exe` | Windows x64 | Operator CLI (when available) |
             | `squidc5-windows-x64.exe` | Windows x64 | C2 server (when available) |
             | `SHA256SUMS.txt` | - | Checksums |
@@ -399,6 +417,8 @@ jobs:
           files: |
             release/sc5-linux-x64
             release/squidc5-linux-x64
+            release/sc5-linux-arm64
+            release/squidc5-linux-arm64
             release/SHA256SUMS.txt
             release/README.txt
             release/sbom.cdx.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,7 @@ merge main -> CI builds Linux/Windows binaries -> GitHub Release published
 
 Releases: `https://github.com/SquidSec/SquidC5/releases` (created by CI job `github-release` on `master` only).
 
-Public CI runs on **GitHub-hosted** runners (org self-hosted runners disallow public repositories). Prefer PRs into protected `master`.
+Public CI runs on **GitHub-hosted** runners (`ubuntu-latest`, `ubuntu-24.04-arm`, `windows-latest`; org self-hosted runners disallow public repositories). Prefer PRs into protected `master`. Releases include `squidc5-linux-x64` and `squidc5-linux-arm64` (Raspberry Pi 64-bit).
 
 - **Never** commit/push straight to `main`/`master`
 - **Never** rsync WIP source or `docker compose up --build` to prod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Format inspired by [Keep a Changelog](https://keepachangelog.com/).
 ## [Unreleased]
 
 ### Added
+- Release assets `sc5-linux-arm64` / `squidc5-linux-arm64` (Raspberry Pi OS 64-bit)
 - **INKO** (Intelligent Neural Kinetic Operator): rebrand of ops neural operator chat
 - INKO opens from a **top-bar button** as a right flyout panel (full-screen on mobile); floating FAB removed
 - SOCKS5 **duplex**: direct mode + implant reverse-dial bridge (`socks:connect`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,8 +35,8 @@ ruff check src tests
 
 ## CI
 
-- **CI** workflow: pytest (3.11/3.12), ruff, Docker smoke, pip-audit; Linux/Windows binaries + GitHub Release on push to `master`.
-- **Public SquidC5 CI uses GitHub-hosted runners** (`ubuntu-latest` / `windows-latest`). Org self-hosted runners do not accept public repos.
+- **CI** workflow: pytest (3.11/3.12), ruff, Docker smoke, pip-audit; Linux x64/ARM64 + Windows binaries + GitHub Release on push to `master`.
+- **Public SquidC5 CI uses GitHub-hosted runners** (`ubuntu-latest` / `ubuntu-24.04-arm` / `windows-latest`). Org self-hosted runners do not accept public repos.
 - Actions are **SHA-pinned**; fork PR jobs that touch secrets are still gated to same-repo PRs. Fork contributors: run the local checks above and note results in the PR.
 - **`master` is protected**: PR required, status checks (`test (3.12)`, `security`), no force-push.
 - **SquidGate** (when configured): optional PR security gate. Repository secret `LLM_API_KEY` enables full analysis when available.

--- a/README.md
+++ b/README.md
@@ -91,8 +91,10 @@ Every push to `master` builds and releases:
 
 | Asset | Role |
 |-------|------|
-| `squidc5-linux-x64` | Teamserver |
-| `sc5-linux-x64` | Operator CLI |
+| `squidc5-linux-x64` | Teamserver (amd64) |
+| `sc5-linux-x64` | Operator CLI (amd64) |
+| `squidc5-linux-arm64` | Teamserver (Raspberry Pi / aarch64) |
+| `sc5-linux-arm64` | Operator CLI (Raspberry Pi / aarch64) |
 | `sc5beacon-*` (CI artifact) | Native implant |
 | `SHA256SUMS.txt` / `sbom.cdx.json` | Integrity |
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -304,7 +304,7 @@ Pipeline:
 1. Open PR -> CI tests must pass
 2. Merge to `main` / `master`
 3. Main CI builds standalone binaries (`sc5`, `squidc5`) and publishes a GitHub Release
-4. Download **Linux `squidc5-linux-x64`** from that Release
+4. Download **Linux `squidc5-linux-x64`** (or **`squidc5-linux-arm64`** on Raspberry Pi 64-bit) from that Release
 5. Deploy **only that executable**; keep `data/` intact
 
 **Forbidden on prod:** rsync of WIP source, `docker compose up --build` from dirty checkout, feature-branch-only binaries.
@@ -316,6 +316,8 @@ Pipeline:
 - Install dir e.g. `/opt/squidc5/bin/squidc5`
 - Data dir e.g. `/opt/squidc5/data`
 - Unit: [`packaging/squidc5.service`](../packaging/squidc5.service)
+
+Raspberry Pi (64-bit OS, `aarch64`): use `squidc5-linux-arm64` / `sc5-linux-arm64`. 32-bit Raspberry Pi OS is not supported.
 
 ### Commands
 

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -34,7 +34,7 @@ python3 -m venv .venv && source .venv/bin/activate
 pip install -e .
 ```
 
-Or use release binaries: `sc5-linux-x64` from [GitHub Releases](https://github.com/SquidSec/SquidC5/releases/latest).
+Or use release binaries: `sc5-linux-x64` or `sc5-linux-arm64` (Raspberry Pi 64-bit) from [GitHub Releases](https://github.com/SquidSec/SquidC5/releases/latest).
 
 ### Verify
 

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -1464,7 +1464,7 @@ docker exec squidc5 cat /data/admin_token.txt
 **Production (binary only):**
 
 1. PR -> CI green -> merge `master`
-2. CI builds `squidc5-linux-x64` + GitHub Release
+2. CI builds `squidc5-linux-x64` / `squidc5-linux-arm64` + GitHub Release
 3. Deploy **that binary only**; keep `data/` intact
 
 ### Example

--- a/tests/test_ci_release_assets.py
+++ b/tests/test_ci_release_assets.py
@@ -1,0 +1,18 @@
+"""Release CI must publish Raspberry Pi (linux-arm64) binaries."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CI = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+
+
+def test_binaries_matrix_includes_linux_arm64() -> None:
+    assert "ubuntu-24.04-arm" in CI
+    assert "artifact: linux-arm64" in CI
+
+
+def test_github_release_publishes_linux_arm64_assets() -> None:
+    assert "sc5-linux-arm64" in CI
+    assert "squidc5-linux-arm64" in CI
+    assert "release/sc5-linux-arm64" in CI
+    assert "release/squidc5-linux-arm64" in CI


### PR DESCRIPTION
## Summary
- Build `sc5` / `squidc5` on GitHub-hosted `ubuntu-24.04-arm`
- Attach `sc5-linux-arm64` and `squidc5-linux-arm64` to the master GitHub Release (64-bit Raspberry Pi OS)

## Test plan
- [x] `pytest tests/test_ci_release_assets.py`
- [ ] After merge: confirm Release assets include linux-arm64